### PR TITLE
move kotlin jvm plugin before nebula-release [openrewrite/rewrite#324]

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,12 +15,12 @@ plugins {
     `maven-publish`
     signing
 
+    id("org.jetbrains.kotlin.jvm") version "1.4.21"
     id("nebula.maven-resolved-dependencies") version "17.3.2"
     id("nebula.release") version "15.3.1"
     id("io.github.gradle-nexus.publish-plugin") version "1.0.0"
 
     id("com.github.hierynomus.license") version "0.15.0" apply false
-    id("org.jetbrains.kotlin.jvm") version "1.4.21"
     id("com.github.jk1.dependency-license-report") version "1.16"
 
     id("nebula.maven-publish") version "17.3.2"
@@ -30,6 +30,10 @@ plugins {
     id("nebula.javadoc-jar") version "17.3.2"
     id("nebula.source-jar") version "17.3.2"
     id("nebula.maven-apache-license") version "17.3.2"
+}
+
+configure<nebula.plugin.release.git.base.ReleasePluginExtension> {
+    defaultVersionStrategy = nebula.plugin.release.NetflixOssStrategies.SNAPSHOT(project)
 }
 
 group = "org.openrewrite.recipe"


### PR DESCRIPTION
straightforward fix to no longer need to specify `snapshot`

https://github.com/nebula-plugins/nebula-release-plugin/issues/149
https://youtrack.jetbrains.com/issue/KT-44713

> When you change the order of the plugin so that the Kotlin plugin is applied BEFORE the Nebula plugin, OR you downgrade to Kotlin plugin 1.3.72, then it works as expected.
> 
> This leads me to the conclusion that starting with version 1.4.0 the Kotlin plugin triggers the creation of the version (e.g. by accessing it) when the plugin is applied. This should be reverted to delayed access, e.g. when the plugin's tasks are executed.
> 
> I guess the sequence is like this:
> 
> Gradle applies the plugins
> Nebula release plugin is applied
> Kotlin plugin is applied
> Plugin accesses project.version
> The version is generated by the Nebula plugin, based on defaults
> Gradle processes the build file, including the plugin configurations
> The Nebula plugin extension is configured (without effect)
> The version is accessed in other places, but is not generated again because an version object exists already
> Tested this with Gradle version 6.7. It does not matter if you use Groovy or Kotlin syntax for the build file.