### PR TITLE
Replace deprecated EnvironmentTestUtils for Spring Boot 2.x

### DIFF
--- a/src/main/java/org/openrewrite/java/spring/boot2/ReplaceDeprecatedEnvironmentTestUtils.java
+++ b/src/main/java/org/openrewrite/java/spring/boot2/ReplaceDeprecatedEnvironmentTestUtils.java
@@ -1,0 +1,216 @@
+/*
+ * Copyright 2020 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.spring.boot2;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Parser;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.java.MethodMatcher;
+import org.openrewrite.java.search.SemanticallyEqual;
+import org.openrewrite.java.tree.Expression;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.Statement;
+import org.openrewrite.marker.SearchResult;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+public class ReplaceDeprecatedEnvironmentTestUtils extends Recipe {
+
+    public static final String ENV_UTILS_ADD_ENV_FQN = "org.springframework.boot.test.util.EnvironmentTestUtils.addEnvironment";
+    public static final String TEST_PROPERTY_VALUES_FQN = "org.springframework.boot.test.util.TestPropertyValues";
+    public static final MethodMatcher METHOD_MATCHER = new MethodMatcher("org.springframework.boot.test.util.EnvironmentTestUtils addEnvironment(..)");
+
+    @Override
+    public String getDisplayName() {
+        return "Replace EnvironmentUtils with TestPropertyValues";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Replaces any references to the deprecated org.springframework.boot.test.util.EnvironmentTestUtils" +
+                " with org.springframework.boot.test.util.TestPropertyValues and the appropriate functionality";
+    }
+
+    @Override
+    protected TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new FindEnvironmentTestUtilsVisitor();
+    }
+
+    private static class ReplaceEnvironmentUtilsMarker implements SearchResult {
+        private final String templateString;
+        private final List<Expression> parameters;
+
+        private ReplaceEnvironmentUtilsMarker(String templateString, List<Expression> parameters) {
+            this.templateString = templateString;
+            this.parameters = parameters;
+        }
+
+
+        @Override
+        public @Nullable String getDescription() {
+            return templateString;
+        }
+    }
+
+    private static class FindEnvironmentTestUtilsVisitor extends JavaIsoVisitor<ExecutionContext> {
+
+        @Override
+        public J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration method, ExecutionContext executionContext) {
+            J.MethodDeclaration m = super.visitMethodDeclaration(method, executionContext);
+
+            if (m.getBody() == null || m.getBody().getStatements().size() == 0) {
+                return m;
+            }
+
+            List<Statement> statements = m.getBody().getStatements();
+            List<Statement> newStatements = new ArrayList<>();
+            List<J.MethodInvocation> collectedEnvironmentMethods = new ArrayList<>();
+            boolean requiresRemoval = false;
+
+            for (Statement statement : statements) {
+                if (statement instanceof J.MethodInvocation && isAddEnvironmentMethod((J.MethodInvocation) statement)) {
+                    J.MethodInvocation methodInvocation = (J.MethodInvocation) statement;
+                    if (collectedEnvironmentMethods.isEmpty() || isCollectedContextOrEnvironment(collectedEnvironmentMethods, methodInvocation)) {
+                        collectedEnvironmentMethods.add(methodInvocation);
+                        requiresRemoval = true;
+                    } else {
+                        newStatements.add(coalesceToFluentMethod(collectedEnvironmentMethods));
+                        collectedEnvironmentMethods = new ArrayList<>();
+                        collectedEnvironmentMethods.add(methodInvocation);
+                    }
+                } else {
+                    if (!collectedEnvironmentMethods.isEmpty()) {
+                        newStatements.add(coalesceToFluentMethod(collectedEnvironmentMethods));
+                        collectedEnvironmentMethods = new ArrayList<>();
+                    }
+                    newStatements.add(statement);
+                }
+            }
+
+            if (!collectedEnvironmentMethods.isEmpty()) {
+                newStatements.add(coalesceToFluentMethod(collectedEnvironmentMethods));
+            }
+
+            if (requiresRemoval) {
+                doAfterVisit(new ReplaceDeprecatedEnvironmentTestUtils.RemoveEnvironmentTestUtilsVisitor());
+            }
+
+            return m.withBody(m.getBody().withStatements(newStatements));
+        }
+
+        private boolean isCollectedContextOrEnvironment(List<J.MethodInvocation> collectedMethods, J.MethodInvocation methodInvocation) {
+            if (methodInvocation.getArguments().size() == 0
+                    || collectedMethods.size() == 0
+                    || collectedMethods.get(0).getArguments().size() == 0) {
+                return false;
+            }
+            J.MethodInvocation collectedMethod = collectedMethods.get(0);
+            Expression contextOrEnvironmentToCheck = getContextOrEnvironmentArgument(methodInvocation);
+            Expression collectedContextOrEnvironment = getContextOrEnvironmentArgument(collectedMethod);
+
+            return SemanticallyEqual.areEqual(contextOrEnvironmentToCheck, collectedContextOrEnvironment);
+        }
+
+        private Expression getPairArgument(J.MethodInvocation methodInvocation) {
+            if (methodInvocation.getArguments().size() < 2) {
+                throw new IllegalArgumentException("getPairArgument requires a method with at least 2 arguments");
+            }
+            // for one variant of addEnvironment there are 3 arguments, the others have 2
+            return methodInvocation.getArguments().get(methodInvocation.getArguments().size() == 3 ? 2 : 1);
+        }
+
+        private Expression getContextOrEnvironmentArgument(J.MethodInvocation methodInvocation) {
+            if (methodInvocation.getArguments().size() < 2) {
+                throw new IllegalArgumentException("getContextOrEnvironmentArgument requires a method with at least 2 arguments");
+            }
+            // for one variant of addEnvironment there are 3 arguments, the others have 2
+            return methodInvocation.getArguments().get(methodInvocation.getArguments().size() == 3 ? 1 : 0);
+        }
+
+        private J.MethodInvocation coalesceToFluentMethod(List<J.MethodInvocation> collectedMethods) {
+            if (collectedMethods.size() == 0) {
+                throw new IllegalArgumentException("collectedMethods must have at least one element");
+            }
+            J.MethodInvocation toReplace = collectedMethods.get(0);
+
+            String currentTemplateString = generateTemplateString(collectedMethods);
+            List<Expression> parameters = generateParameters(collectedMethods);
+
+            return toReplace.withMarker(new ReplaceEnvironmentUtilsMarker(currentTemplateString, parameters));
+        }
+
+        private List<Expression> generateParameters(List<J.MethodInvocation> collectedMethods) {
+            if (collectedMethods.size() == 0) {
+                throw new IllegalArgumentException("collectedMethods must have at least one element");
+            }
+            List<Expression> parameters = new ArrayList<>();
+            for (J.MethodInvocation collectedMethod : collectedMethods) {
+                parameters.add(getPairArgument(collectedMethod));
+            }
+            parameters.add(getContextOrEnvironmentArgument(collectedMethods.get(0)));
+
+            return parameters;
+        }
+
+        private String generateTemplateString(List<J.MethodInvocation> collectedMethods) {
+            StringBuilder template = new StringBuilder("TestPropertyValues.of(#{})");
+            for (int i = 1; i < collectedMethods.size(); i++) {
+                template.append(".and(#{})");
+            }
+            template.append(".applyTo(#{})");
+            return template.toString();
+        }
+
+        private boolean isAddEnvironmentMethod(J.MethodInvocation method) {
+            return METHOD_MATCHER.matches(method);
+        }
+    }
+
+    private static class RemoveEnvironmentTestUtilsVisitor extends JavaIsoVisitor<ExecutionContext> {
+        @Override
+        public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext executionContext) {
+            J.MethodInvocation m = super.visitMethodInvocation(method, executionContext);
+            Optional<ReplaceEnvironmentUtilsMarker> maybeMarker = m.getMarkers().findFirst(ReplaceEnvironmentUtilsMarker.class);
+            if (maybeMarker.isPresent()) {
+                ReplaceEnvironmentUtilsMarker marker = maybeMarker.get();
+                m = m.withTemplate(
+                    template(marker.templateString)
+                        .javaParser(
+                            JavaParser.fromJavaVersion()
+                                .logCompilationWarningsAndErrors(true)
+                                .dependsOn(Collections.singletonList(Parser.Input.fromResource("/TestPropertyValues.java")))
+                                .build()
+                        )
+                        .imports(TEST_PROPERTY_VALUES_FQN)
+                        .build(),
+                    m.getCoordinates().replace(),
+                    marker.parameters.toArray()
+                );
+
+                maybeRemoveImport(ENV_UTILS_ADD_ENV_FQN);
+                maybeAddImport(TEST_PROPERTY_VALUES_FQN);
+            }
+            return m;
+        }
+    }
+}

--- a/src/main/resources/META-INF/rewrite/spring-boot2.yml
+++ b/src/main/resources/META-INF/rewrite/spring-boot2.yml
@@ -92,6 +92,7 @@ recipeList:
   - org.openrewrite.java.spring.boot2.SpringRunnerToSpringExtension
   - org.openrewrite.java.spring.boot2.ConditionalOnBeanAnyNestedCondition
   - org.openrewrite.java.spring.boot2.RestTemplateBuilderRequestFactory
+  - org.openrewrite.java.spring.boot2.ReplaceDeprecatedEnvironmentTestUtils
   - org.openrewrite.java.spring.boot2.config.SpringBootConfigurationYaml.2_0
   - org.openrewrite.java.spring.boot2.config.SpringBootConfigurationProperties.2_0
   - org.openrewrite.java.spring.boot2.config.SpringBootConfigurationYaml.2_1

--- a/src/main/resources/TestPropertyValues.java
+++ b/src/main/resources/TestPropertyValues.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2020 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.test.util;
+
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.MutablePropertySources;
+
+import java.util.concurrent.Callable;
+import java.util.stream.Stream;
+
+public final class TestPropertyValues {
+    public TestPropertyValues and(String... pairs) { return this; }
+
+    private TestPropertyValues and(Stream<Pair> pairs) { return this; }
+
+    public void applyTo(ConfigurableApplicationContext context) {}
+
+    public void applyTo(ConfigurableEnvironment environment) {}
+
+    public void applyTo(ConfigurableEnvironment environment, TestPropertyValues.Type type) {}
+
+    public void applyTo(ConfigurableEnvironment environment, TestPropertyValues.Type type, String name) {}
+
+    public <T> T applyToSystemProperties(Callable<T> call) { return null; }
+
+    private <E extends Throwable> void rethrow(Throwable e) throws E {}
+
+    private void addToSources(MutablePropertySources sources, TestPropertyValues.Type type, String name) {}
+
+    public static TestPropertyValues of(String... pairs) { return null; }
+
+    public static TestPropertyValues of(Iterable<String> pairs) { return null; }
+
+    public static TestPropertyValues of(Stream<String> pairs) { return null; }
+
+    public static TestPropertyValues empty() { return null; }
+
+    public static class Pair {}
+
+    public static enum Type {SYSTEM_ENVIRONMENT, MAP}
+}

--- a/src/test/kotlin/org/openrewrite/java/spring/boot2/ReplaceDeprecatedEnvironmentTestUtilsTest.kt
+++ b/src/test/kotlin/org/openrewrite/java/spring/boot2/ReplaceDeprecatedEnvironmentTestUtilsTest.kt
@@ -1,0 +1,314 @@
+/*
+ * Copyright 2020 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.spring.org.openrewrite.java.spring.boot2
+
+import org.junit.jupiter.api.Test
+import org.openrewrite.Recipe
+import org.openrewrite.java.JavaParser
+import org.openrewrite.java.JavaRecipeTest
+import org.openrewrite.java.spring.boot2.ReplaceDeprecatedEnvironmentTestUtils
+
+class ReplaceDeprecatedEnvironmentTestUtilsTest : JavaRecipeTest {
+
+    override val parser: JavaParser
+        get() = JavaParser.fromJavaVersion()
+            .classpath("spring-beans", "spring-core", "spring-context", "spring-boot-test")
+            .logCompilationWarningsAndErrors(true)
+            .build()
+
+    override val recipe: Recipe
+        get() = ReplaceDeprecatedEnvironmentTestUtils()
+
+    @Test
+    fun givenHasStringVariableWhenRemovingDeprecatedThenReplacesAddEnvironmentWithSetProperties() =
+        assertChanged(
+            before = """
+                package com.mycompany;
+                import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+                import static org.springframework.boot.test.util.EnvironmentTestUtils.addEnvironment;
+                
+                public class MyClass {
+                    public void myMethod() {
+                        AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
+                        String pair = "pair";
+                        addEnvironment(context, pair);
+                    }
+                }
+            """,
+            after = """
+                package com.mycompany;
+                import org.springframework.boot.test.util.TestPropertyValues;
+                import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+                
+                public class MyClass {
+                    public void myMethod() {
+                        AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
+                        String pair = "pair";
+                        TestPropertyValues.of(pair).applyTo(context);
+                    }
+                }
+            """
+        )
+
+    @Test
+    fun givenHasSingleStringWhenRemovingDeprecatedThenReplacesAddEnvironmentWithSetProperties() =
+        assertChanged(
+            before = """
+                package com.mycompany;
+                import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+                import static org.springframework.boot.test.util.EnvironmentTestUtils.addEnvironment;
+                
+                public class MyClass {
+                    public void myMethod() {
+                        AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
+                        addEnvironment(context, "pair:pair");
+                    }
+                }
+            """,
+            after = """
+                package com.mycompany;
+                import org.springframework.boot.test.util.TestPropertyValues;
+                import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+                
+                public class MyClass {
+                    public void myMethod() {
+                        AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
+                        TestPropertyValues.of("pair:pair").applyTo(context);
+                    }
+                }
+            """
+        )
+
+    @Test
+    fun givenConstructsStringAndContextWhenRemovingDeprecatedThenReplacesAddEnvironmentWithSetProperties() =
+        assertChanged(
+            before = """
+                package com.mycompany;
+                import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+                import static org.springframework.boot.test.util.EnvironmentTestUtils.addEnvironment;
+                
+                public class MyClass {
+                    public void myMethod() {
+                        addEnvironment(new AnnotationConfigApplicationContext(), "pair" + "pair");
+                    }
+                }
+            """,
+            after = """
+                package com.mycompany;
+                import org.springframework.boot.test.util.TestPropertyValues;
+                import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+                
+                public class MyClass {
+                    public void myMethod() {
+                        TestPropertyValues.of("pair" + "pair").applyTo(new AnnotationConfigApplicationContext());
+                    }
+                }
+            """
+        )
+
+    @Test
+    fun givenChainedCallsReplacesThemWithAFluentSetOfCalls() = assertChanged(
+        before = """
+                package com.mycompany;
+                import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+                import static org.springframework.boot.test.util.EnvironmentTestUtils.addEnvironment;
+                
+                public class MyClass {
+                    public void myMethod() {
+                        AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
+                        addEnvironment(context, "key1:value1");
+                        addEnvironment(context, "key2:value2");
+                        addEnvironment(context, "key3:value3");
+                        String x = "x";
+                        addEnvironment(context, "key4:value4");
+                    }
+                }
+            """,
+        after = """
+                package com.mycompany;
+                import org.springframework.boot.test.util.TestPropertyValues;
+                import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+                
+                public class MyClass {
+                    public void myMethod() {
+                        AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
+                        TestPropertyValues.of("key1:value1").and("key2:value2").and("key3:value3").applyTo(context);
+                        String x = "x";
+                        TestPropertyValues.of("key4:value4").applyTo(context);
+                    }
+                }
+            """
+    )
+
+    @Test
+    fun givenChainedCallsWithDifferentContextsCoalescesThemCorrectly() {
+        assertChanged(
+            before = """
+                package com.mycompany;
+                import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+                import static org.springframework.boot.test.util.EnvironmentTestUtils.addEnvironment;
+                
+                public class MyClass {
+                    public void myMethod() {
+                        AnnotationConfigApplicationContext context1 = new AnnotationConfigApplicationContext();
+                        AnnotationConfigApplicationContext context2 = new AnnotationConfigApplicationContext();
+                        addEnvironment(context2, "key1:value1");
+                        addEnvironment(context1, "key2:value2");
+                        addEnvironment(context1, "key3:value3");
+                        String x = "x";
+                        addEnvironment(context2, "key4:value4");
+                        addEnvironment(context2, "key5:value5");
+                        addEnvironment(context1, "key6:value6");
+                        addEnvironment(context2, "key7:value7");
+                    }
+                }
+            """,
+            after = """
+                package com.mycompany;
+                import org.springframework.boot.test.util.TestPropertyValues;
+                import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+                
+                public class MyClass {
+                    public void myMethod() {
+                        AnnotationConfigApplicationContext context1 = new AnnotationConfigApplicationContext();
+                        AnnotationConfigApplicationContext context2 = new AnnotationConfigApplicationContext();
+                        TestPropertyValues.of("key1:value1").applyTo(context2);
+                        TestPropertyValues.of("key2:value2").and("key3:value3").applyTo(context1);
+                        String x = "x";
+                        TestPropertyValues.of("key4:value4").and("key5:value5").applyTo(context2);
+                        TestPropertyValues.of("key6:value6").applyTo(context1);
+                        TestPropertyValues.of("key7:value7").applyTo(context2);
+                    }
+                }
+            """
+        )
+    }
+
+    @Test
+    fun givenChainedCallsWithGeneratedContextsCoalescesThemCorrectly() {
+        assertChanged(
+            before = """
+                package com.mycompany;
+                import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+                import static org.springframework.boot.test.util.EnvironmentTestUtils.addEnvironment;
+                
+                public class MyClass {
+                    public void myMethod() {
+                        addEnvironment(new AnnotationConfigApplicationContext(), "key1:value1");
+                        addEnvironment(new AnnotationConfigApplicationContext(), "key2:value2");
+                        addEnvironment(new AnnotationConfigApplicationContext(), "key3:value3");
+                    }
+                }
+            """,
+            after = """
+                package com.mycompany;
+                import org.springframework.boot.test.util.TestPropertyValues;
+                import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+                
+                public class MyClass {
+                    public void myMethod() {
+                        TestPropertyValues.of("key1:value1").applyTo(new AnnotationConfigApplicationContext());
+                        TestPropertyValues.of("key2:value2").applyTo(new AnnotationConfigApplicationContext());
+                        TestPropertyValues.of("key3:value3").applyTo(new AnnotationConfigApplicationContext());
+                    }
+                }
+            """
+        )
+    }
+
+    @Test
+    fun givenChainedCallsWithMixOfContextsCoalescesThemCorrectly() {
+        assertChanged(
+            before = """
+                package com.mycompany;
+                import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+                import static org.springframework.boot.test.util.EnvironmentTestUtils.addEnvironment;
+                
+                public class MyClass {
+                    public void myMethod() {
+                        addEnvironment(new AnnotationConfigApplicationContext(), "key1:value1");
+                        addEnvironment(new AnnotationConfigApplicationContext(), "key2:value2");
+                        AnnotationConfigApplicationContext context1 = new AnnotationConfigApplicationContext();
+                        addEnvironment(context1, "key3:value3");
+                        addEnvironment(context1, "key4:value4");
+                        addEnvironment(new AnnotationConfigApplicationContext(), "key5:value5");
+                        addEnvironment(context1, "key5:value5");
+                    }
+                }
+            """,
+            after = """
+                package com.mycompany;
+                import org.springframework.boot.test.util.TestPropertyValues;
+                import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+                
+                public class MyClass {
+                    public void myMethod() {
+                        TestPropertyValues.of("key1:value1").applyTo(new AnnotationConfigApplicationContext());
+                        TestPropertyValues.of("key2:value2").applyTo(new AnnotationConfigApplicationContext());
+                        AnnotationConfigApplicationContext context1 = new AnnotationConfigApplicationContext();
+                        TestPropertyValues.of("key3:value3").and("key4:value4").applyTo(context1);
+                        TestPropertyValues.of("key5:value5").applyTo(new AnnotationConfigApplicationContext());
+                        TestPropertyValues.of("key5:value5").applyTo(context1);
+                    }
+                }
+            """
+        )
+    }
+
+    @Test
+    fun givenChainedCallsThatReferToTheSameObjectUnfortunatelyDoesntChainThem() = assertChanged(
+        before = """
+                package com.mycompany;
+                import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+                import static org.springframework.boot.test.util.EnvironmentTestUtils.addEnvironment;
+                
+                public class MyClass {
+                    public void myMethod() {
+                        AnnotationConfigApplicationContext context1 = new AnnotationConfigApplicationContext();
+                        AnnotationConfigApplicationContext context2 = context1;
+                        addEnvironment(context2, "key1:value1");
+                        addEnvironment(context1, "key2:value2");
+                        addEnvironment(context1, "key3:value3");
+                        String x = "x";
+                        addEnvironment(context2, "key4:value4");
+                        addEnvironment(context2, "key5:value5");
+                        context1 = new AnnotationConfigApplicationContext();
+                        addEnvironment(context1, "key6:value6");
+                        addEnvironment(context2, "key7:value7");
+                    }
+                }
+            """,
+        after = """
+                package com.mycompany;
+                import org.springframework.boot.test.util.TestPropertyValues;
+                import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+                
+                public class MyClass {
+                    public void myMethod() {
+                        AnnotationConfigApplicationContext context1 = new AnnotationConfigApplicationContext();
+                        AnnotationConfigApplicationContext context2 = context1;
+                        TestPropertyValues.of("key1:value1").applyTo(context2);
+                        TestPropertyValues.of("key2:value2").and("key3:value3").applyTo(context1);
+                        String x = "x";
+                        TestPropertyValues.of("key4:value4").and("key5:value5").applyTo(context2);
+                        context1 = new AnnotationConfigApplicationContext();
+                        TestPropertyValues.of("key6:value6").applyTo(context1);
+                        TestPropertyValues.of("key7:value7").applyTo(context2);
+                    }
+                }
+            """
+    )
+}


### PR DESCRIPTION
The class `org.springframework.boot.test.util.EnvironmentTestUtils` is deprecated in Spring Boot 2.x in favor of `TestPropertyValues`. This PR includes a recipe that replaces this. Automatically.

Replace the following:

```
EnvironmentTestUtils.addEnvironment(contextOrEnvironment, keyValuePair1)
EnvironmentTestUtils.addEnvironment(contextOrEnvironment, keyValuePair2)
```

with the following:

```
TestPropertyValues.of(keyValuePair1).and(keyValuePair2).applyTo(contextOrEnvironment);
```

The way it works is as follows:

1. Visit a method declaration
2. If an `addEnvironment` method call is found, start collecting them
3. Coalesce collected `addEnvironment` calls into a single `TestPropertyValues.of/and/applyTo` chain
4. Add a marker to the first collected `addEnvironment` call that includes instructions for replacing it
5. Remove the rest of the collected `addEnvironment` calls
6. Pass through all other statements unmodified
7. In another visitor, visit method invocation
8. If the method invocation is marked for replacement, replace it with the `TestPropertyValues.of/and/applyTo` chain