### PR TITLE
Add additional method signatures for EnvironmentTestUtils.addEnvironment

### DIFF
--- a/src/test/kotlin/org/openrewrite/java/spring/boot2/ReplaceDeprecatedEnvironmentTestUtilsTest.kt
+++ b/src/test/kotlin/org/openrewrite/java/spring/boot2/ReplaceDeprecatedEnvironmentTestUtilsTest.kt
@@ -25,7 +25,7 @@ class ReplaceDeprecatedEnvironmentTestUtilsTest : JavaRecipeTest {
 
     override val parser: JavaParser
         get() = JavaParser.fromJavaVersion()
-            .classpath("spring-beans", "spring-core", "spring-context", "spring-boot-test")
+            .classpath("spring-beans", "spring-core", "spring-context", "spring-boot-test", "spring-web")
             .logCompilationWarningsAndErrors(true)
             .build()
 
@@ -310,5 +310,132 @@ class ReplaceDeprecatedEnvironmentTestUtilsTest : JavaRecipeTest {
                     }
                 }
             """
+    )
+
+    @Test
+    fun givenEnvironmentAddEnvironmentChainsThemCorrectly() = assertChanged(
+        before = """
+                package com.mycompany;
+                import org.springframework.web.context.support.StandardServletEnvironment;
+                import static org.springframework.boot.test.util.EnvironmentTestUtils.addEnvironment;
+                
+                public class MyClass {
+                    public void myMethod() {
+                        StandardServletEnvironment environment1 = new StandardServletEnvironment();
+                        StandardServletEnvironment environment2 = new StandardServletEnvironment();
+                        addEnvironment(environment2, "key1:value1");
+                        addEnvironment(environment1, "key5:value5");
+                        String x = "x";
+                        addEnvironment(environment2, "key6:value6");
+                        addEnvironment(environment2, "key7:value7");
+                        environment1 = new StandardServletEnvironment();
+                        addEnvironment(environment1, "key8:value8");
+                        addEnvironment(environment2, "key9:value9");
+                    }
+                }
+            """,
+        after = """
+                package com.mycompany;
+                import org.springframework.boot.test.util.TestPropertyValues;
+                import org.springframework.web.context.support.StandardServletEnvironment;
+                
+                public class MyClass {
+                    public void myMethod() {
+                        StandardServletEnvironment environment1 = new StandardServletEnvironment();
+                        StandardServletEnvironment environment2 = new StandardServletEnvironment();
+                        TestPropertyValues.of("key1:value1").applyTo(environment2);
+                        TestPropertyValues.of("key5:value5").applyTo(environment1);
+                        String x = "x";
+                        TestPropertyValues.of("key6:value6").and("key7:value7").applyTo(environment2);
+                        environment1 = new StandardServletEnvironment();
+                        TestPropertyValues.of("key8:value8").applyTo(environment1);
+                        TestPropertyValues.of("key9:value9").applyTo(environment2);
+                    }
+                }
+        """
+    )
+
+    @Test
+    fun givenNamedEnvironmentAddEnvironmentChainsThemCorrectly() = assertChanged(
+        before = """
+                package com.mycompany;
+                import org.springframework.web.context.support.StandardServletEnvironment;
+                import static org.springframework.boot.test.util.EnvironmentTestUtils.addEnvironment;
+                
+                public class MyClass {
+                    public void myMethod() {
+                        StandardServletEnvironment environment = new StandardServletEnvironment();
+                        addEnvironment(environment, "key1:value1");
+                        addEnvironment("test", environment, "key5:value5");
+                        String x = "x";
+                        addEnvironment("test", environment, "key6:value6");
+                        addEnvironment("test", environment, "key7:value7");
+                        environment = new StandardServletEnvironment();
+                        addEnvironment(environment, "key8:value8");
+                        addEnvironment(environment, "key9:value9");
+                    }
+                }
+            """,
+        after = """
+                package com.mycompany;
+                import org.springframework.boot.test.util.TestPropertyValues;
+                import org.springframework.web.context.support.StandardServletEnvironment;
+                
+                public class MyClass {
+                    public void myMethod() {
+                        StandardServletEnvironment environment = new StandardServletEnvironment();
+                        TestPropertyValues.of("key1:value1").applyTo(environment);
+                        TestPropertyValues.of("key5:value5").applyTo(environment, TestPropertyValues.Type.MAP, "test");
+                        String x = "x";
+                        TestPropertyValues.of("key6:value6").and("key7:value7").applyTo(environment, TestPropertyValues.Type.MAP, "test");
+                        environment = new StandardServletEnvironment();
+                        TestPropertyValues.of("key8:value8").and("key9:value9").applyTo(environment);
+                    }
+                }
+        """
+    )
+
+    @Test
+    fun givenVarargsAddEnvironmentChainsThemCorrectly() = assertChanged(
+        before = """
+                package com.mycompany;
+                import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+                import static org.springframework.boot.test.util.EnvironmentTestUtils.addEnvironment;
+                
+                public class MyClass {
+                    public void myMethod() {
+                        AnnotationConfigApplicationContext context1 = new AnnotationConfigApplicationContext();
+                        AnnotationConfigApplicationContext context2 = context1;
+                        addEnvironment(context2, "key1:value1", "key2:value2");
+                        addEnvironment(context1, "key3:value3", "key4:value4");
+                        addEnvironment(context1, "key5:value5");
+                        String x = "x";
+                        addEnvironment(context2, "key6:value6");
+                        addEnvironment(context2, "key7:value7");
+                        context1 = new AnnotationConfigApplicationContext();
+                        addEnvironment(context1, "key8:value8");
+                        addEnvironment(context2, "key9:value9");
+                    }
+                }
+            """,
+        after = """
+            package com.mycompany;
+            import org.springframework.boot.test.util.TestPropertyValues;
+            import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+            
+            public class MyClass {
+                public void myMethod() {
+                    AnnotationConfigApplicationContext context1 = new AnnotationConfigApplicationContext();
+                    AnnotationConfigApplicationContext context2 = context1;
+                    TestPropertyValues.of("key1:value1").and("key2:value2").applyTo(context2);
+                    TestPropertyValues.of("key3:value3").and("key4:value4").and("key5:value5").applyTo(context1);
+                    String x = "x";
+                    TestPropertyValues.of("key6:value6").and("key7:value7").applyTo(context2);
+                    context1 = new AnnotationConfigApplicationContext();
+                    TestPropertyValues.of("key8:value8").applyTo(context1);
+                    TestPropertyValues.of("key9:value9").applyTo(context2);
+                }
+            }
+        """
     )
 }


### PR DESCRIPTION
After additional testing of ReplaceDeprecatedEnvironmentTestUtils, I discovered that the
String parameter at the end was varargs and not being handled correctly. I also
discovered that there was another signature of addEnvironment that wasn't being taken
care of appropriately.