### PR TITLE
Added recipe to mark deprecated APIs to support framework migration.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -170,6 +170,7 @@ dependencies {
     "testWithSpringBoot_2_3RuntimeOnly"("org.springframework.boot:spring-boot-test:1.5.+")
     "testWithSpringBoot_2_3RuntimeOnly"("org.springframework.boot:spring-boot-autoconfigure:2.3.+")
 
+    "testWithSpringBoot_2_4RuntimeOnly"("org.springframework.boot:spring-context:5.2.+")
     "testWithSpringBoot_2_4RuntimeOnly"("org.springframework.boot:spring-boot:2.4.+")
 }
 

--- a/src/main/java/org/openrewrite/java/spring/boot2/MarkDeprecatedAPIs.java
+++ b/src/main/java/org/openrewrite/java/spring/boot2/MarkDeprecatedAPIs.java
@@ -1,0 +1,329 @@
+/*
+ * Copyright 2020 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.spring.boot2;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Value;
+import lombok.experimental.FieldDefaults;
+import org.openrewrite.*;
+import org.openrewrite.internal.StringUtils;
+import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.search.FindMethods;
+import org.openrewrite.java.search.FindTypes;
+import org.openrewrite.java.tree.*;
+import org.openrewrite.marker.SearchResult;
+
+import java.util.*;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Incubating(since = "4.10.0")
+@AllArgsConstructor
+public class MarkDeprecatedAPIs extends Recipe {
+
+    @Override
+    public String getDisplayName() {
+        return "Find and mark java types with a deprecation marker.";
+    }
+
+    @Override
+    public String getDescription() {
+        return "A utility recipe to mark a target class, method, or constant with a deprecation marker.";
+    }
+
+    @Option(displayName = "Source of deprecation",
+            description = "The source of a deprecation.",
+            example = "Spring Boot 2.3.0")
+    String sourceOfDeprecation;
+
+    @Option(displayName = "Type information to find the deprecated target",
+            description = "Type information determines what type of pointcut expression is used. Types include: class, constructor, classMethod, enum, enumConstant, exception, fieldConstant, interface, interfaceMethod.",
+            example = "enum")
+    String deprecatedType;
+
+    @Option(displayName = "A search pattern, expressed as a pointcut expression, that is used to find the deprecated target",
+            description = "The format of the pointcut expression is based on the deprecatedType.",
+            example = "class: com.google.common.collect.ImmutableSet, classMethod: com.google.common.collect.ImmutableSet of(..), or fieldConstant org.openrewrite.Constant.VALUE")
+    String searchPattern;
+
+    @Option(displayName = "Descriptive text about the deprecation",
+            description = "Optionally, communicate information about the deprecation.",
+            required = false,
+            example = "in favor org.example.NewClass")
+    String deprecationComment;
+
+    @Option(displayName = "Link to the documentation.",
+            description = "A link to information about the the documentation.",
+            required = false,
+            example = "https://www.example.link")
+    String deprecatedLink;
+
+    @Override
+    protected TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new MarkDeprecatedAPIs.FindAndMarkDeprecatedAPIs(
+                sourceOfDeprecation,
+                deprecatedType,
+                searchPattern,
+                deprecationComment,
+                deprecatedLink
+        );
+    }
+
+    private static class FindAndMarkDeprecatedAPIs extends JavaIsoVisitor<ExecutionContext> {
+        private final Deprecation deprecation;
+
+        FindAndMarkDeprecatedAPIs(
+                String sourceOfDeprecation,
+                String deprecatedType,
+                String searchPattern,
+                String deprecationComment,
+                String deprecatedLink) {
+
+            Deprecation.Source source = new Deprecation.Source(
+                    StringUtils.isNullOrEmpty(sourceOfDeprecation) ? "" : sourceOfDeprecation,
+                    Deprecation.DeprecatedType.fromValue(deprecatedType),
+                    StringUtils.isNullOrEmpty(deprecationComment) ? "" : deprecationComment,
+                    StringUtils.isNullOrEmpty(deprecatedLink) ? "" : deprecatedLink);
+
+            Deprecation.Info info = new Deprecation.Info(Tree.randomId(), source);
+
+            this.deprecation = new Deprecation(searchPattern, info);
+        }
+
+        @Override
+        public J.CompilationUnit visitCompilationUnit(J.CompilationUnit compilationUnit, ExecutionContext context) {
+            switch (deprecation.info.source.type) {
+                case CLASS:
+                case ENUM:
+                case EXCEPTION:
+                case INTERFACE:
+                    Set<NameTree> references = FindTypes.find(compilationUnit, deprecation.searchPattern);
+                    if (!references.isEmpty()) {
+                        getCursor().putMessage(deprecation.info.source.type.name(), references);
+                    }
+                    break;
+
+                case CLASS_METHOD:
+                    Set<J> methods = FindMethods.find(compilationUnit, deprecation.searchPattern);
+                    if (!methods.isEmpty()) {
+                        getCursor().putMessage(deprecation.info.source.type.name(), methods);
+                    }
+                    break;
+
+                case FIELD_CONSTANT:
+                case ENUM_CONSTANT:
+                    Set<NameTree> enumConstants = findConstants(compilationUnit, TypeUtils.asFullyQualified(JavaType.Class.build(deprecation.searchPattern)));
+                    if (!enumConstants.isEmpty()) {
+                        getCursor().putMessage(deprecation.info.source.type.name(), enumConstants);
+                    }
+                    break;
+
+                case CONSTRUCTOR:
+                case ENUM_METHOD:
+                case INTERFACE_METHOD:
+                    break;
+
+                default:
+                    throw new IllegalStateException("Unexpected value: " + deprecation.info.source.type);
+            }
+
+            return super.visitCompilationUnit(compilationUnit, context);
+        }
+
+        @Override
+        public J.Identifier visitIdentifier(J.Identifier identifier, ExecutionContext context) {
+            J.Identifier id = super.visitIdentifier(identifier, context);
+            Set<NameTree> values = nameTreeFromFindTypes();
+            if (values.contains(id)) {
+                id = (J.Identifier) maybeAddMarker(id);
+            }
+            return id;
+        }
+
+        @Override
+        public J.FieldAccess visitFieldAccess(J.FieldAccess fieldAccess, ExecutionContext context) {
+            J.FieldAccess fa = super.visitFieldAccess(fieldAccess, context);
+            Set<NameTree> values = nameTreeFromFindTypes();
+            if (values.contains(fa)) {
+                fa = (J.FieldAccess) maybeAddMarker(fa);
+            }
+            return fa;
+        }
+
+        @Override
+        public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext context) {
+            J.MethodInvocation m = super.visitMethodInvocation(method, context);
+            Set<J> values = jFromFindMethods();
+            if (values.contains(m)) {
+                m = (J.MethodInvocation) maybeAddMarker(m);
+            }
+            return m;
+        }
+
+        @SuppressWarnings("unchecked")
+        private Set<J> jFromFindMethods() {
+            Object object = getCursor().getNearestMessage(deprecation.info.source.type.name());
+            if (object instanceof Set) {
+                return (Set<J>) object;
+            }
+            return new HashSet<>();
+        }
+
+        @SuppressWarnings("unchecked")
+        private Set<NameTree> nameTreeFromFindTypes() {
+            Object object = getCursor().getNearestMessage(deprecation.info.source.type.name());
+            if (object instanceof Set) {
+                return (Set<NameTree>) object;
+            }
+            return new HashSet<>();
+        }
+
+        private J maybeAddMarker(J j) {
+            if (!j.getMarkers().findFirst(Deprecation.Info.class).isPresent()) {
+                return j.withMarkers(j.getMarkers().addIfAbsent(deprecation.info));
+            }
+            return j;
+        }
+
+    }
+
+    @AllArgsConstructor
+    private static class Deprecation {
+        String searchPattern;
+        Deprecation.Info info;
+
+        @AllArgsConstructor
+        public static class Source {
+            String sourceOfDeprecation;
+            DeprecatedType type;
+            String comment;
+            String link;
+        }
+
+        public enum DeprecatedType {
+            // An abstract class may need different conditions.
+            CLASS("class"),
+            CONSTRUCTOR("constructor"),
+            CLASS_METHOD("classMethod"),
+            ENUM("enum"),
+            ENUM_CONSTANT("enumConstant"),
+            ENUM_METHOD("enumMethod"),
+            EXCEPTION("exception"),
+            FIELD_CONSTANT("fieldConstant"),
+            INTERFACE("interface"),
+            INTERFACE_METHOD("interfaceMethod"),
+            NONE("notProvided");
+
+            public final String value;
+
+            DeprecatedType(String value) {
+                this.value = value;
+            }
+
+            public String getValue() {
+                return value;
+            }
+
+            static final Map<String, DeprecatedType> values = Arrays.stream(DeprecatedType.values())
+                    .collect(Collectors.toMap(DeprecatedType::getValue, Function.identity()));
+
+            public static DeprecatedType fromValue(String value) {
+                return values.getOrDefault(value, DeprecatedType.NONE);
+            }
+        }
+
+        @FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
+        @Value
+        public static class Info implements SearchResult {
+            UUID id;
+            Source source;
+
+            @Override
+            public <P> String print(TreePrinter<P> printer, P p) {
+                String comment = StringUtils.isBlank(source.comment) ? "" : " Reason: " + source.comment + ".";
+                String link = StringUtils.isBlank(source.link) ? "" : " Link: " + source.link + ".";
+                return "/*~~> Source of " + source.type.getValue() + " deprecation: " + source.sourceOfDeprecation + "." + comment + link + " ~~*/";
+            }
+
+            @Override
+            public @Nullable String getDescription() {
+                return null;
+            }
+        }
+    }
+
+    private static Set<NameTree> findConstants(J j, @Nullable JavaType.FullyQualified fullyQualifiedType) {
+        JavaIsoVisitor<Set<NameTree>> findVisitor = new JavaIsoVisitor<Set<NameTree>>() {
+
+            @Override
+            public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration classDecl, Set<NameTree> ns) {
+                return super.visitClassDeclaration(classDecl, ns);
+            }
+
+            @Override
+            public J.Identifier visitIdentifier(J.Identifier identifier, Set<NameTree> ns) {
+                J.Identifier id = super.visitIdentifier(identifier, ns);
+                if (isTargetClass() && isTargetFieldType(id) && fullyQualifiedType != null && id.getSimpleName()
+                        .equals(fullyQualifiedType.getClassName().substring(fullyQualifiedType.getClassName().lastIndexOf(".") + 1))) {
+                    ns.add(id);
+                }
+                return id;
+            }
+
+            @Override
+            public J.FieldAccess visitFieldAccess(J.FieldAccess fieldAccess, Set<NameTree> ns) {
+                J.FieldAccess fa = super.visitFieldAccess(fieldAccess, ns);
+                if (fullyQualifiedType != null) {
+                    JavaType.FullyQualified declaringType = JavaType.Class.build(fullyQualifiedType.getFullyQualifiedName()
+                            .substring(0, fullyQualifiedType.getFullyQualifiedName().lastIndexOf(".")));
+
+                    if (isTargetClass() && TypeUtils.isOfType(declaringType, fa.getTarget().getType()) &&
+                            fa.getName().getSimpleName().equals(fullyQualifiedType.getClassName()
+                                    .substring(fullyQualifiedType.getClassName().lastIndexOf(".") + 1))) {
+                        ns.add(fa);
+                    }
+                }
+                return fa;
+            }
+
+            private boolean isTargetClass() {
+                Cursor parentCursor = getCursor().dropParentUntil(
+                        is -> is instanceof J.CompilationUnit ||
+                              is instanceof J.ClassDeclaration);
+                return (parentCursor.getValue() instanceof J.ClassDeclaration && fullyQualifiedType != null &&
+                        !((J.ClassDeclaration) parentCursor.getValue()).getName().getSimpleName().equals(fullyQualifiedType.getClassName()));
+            }
+
+            private boolean isTargetFieldType(J.Identifier identifier) {
+                if (fullyQualifiedType != null && identifier.getFieldType() != null && identifier.getFieldType() instanceof JavaType.Variable) {
+                    JavaType.Variable fieldType = ((JavaType.Variable)identifier.getFieldType());
+                    JavaType.FullyQualified declaringType = JavaType.Class.build(
+                            fullyQualifiedType.getFullyQualifiedName().substring(0, fullyQualifiedType.getFullyQualifiedName().lastIndexOf(".")));
+                    return TypeUtils.isOfType(declaringType, fieldType.getType());
+                }
+                return false;
+            }
+        };
+
+        Set<NameTree> ts = new HashSet<>();
+        if (fullyQualifiedType != null) {
+            findVisitor.visit(j, ts);
+        }
+        return ts;
+    }
+}

--- a/src/main/resources/META-INF/rewrite/mark-deprecated-2-minor-version-3-apis.yml
+++ b/src/main/resources/META-INF/rewrite/mark-deprecated-2-minor-version-3-apis.yml
@@ -1,0 +1,153 @@
+#
+# Copyright 2020 the original author or authors.
+# <p>
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# <p>
+# https://www.apache.org/licenses/LICENSE-2.0
+# <p>
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.spring.boot2.minorversion3.MarkDeprecatedSpringBoot2MinorVersion3APIs
+displayName: "Mark Spring Boot 2 APIs deprecated in 2.3 for removal in 2.5"
+description: "Mark uses of APIs deprecated in 2.3 to upgrade to the next version of Spring Boot."
+recipeList:
+  # methods
+  - org.openrewrite.java.spring.boot2.LauncherCreateClassLoader
+  - org.openrewrite.java.spring.boot2.ArchiveForEach
+  - org.openrewrite.java.spring.boot2.LauncherGetClassPathArchives
+  - org.openrewrite.java.spring.boot2.AbstractErrorWebExceptionHandlerGetErrorAttributes
+  - org.openrewrite.java.spring.boot2.ArchiveGetNestedArchives
+  - org.openrewrite.java.spring.boot2.ArchiveIterator
+  - org.openrewrite.java.spring.boot2.ArchiveSpliterator
+  # class constructors
+  - org.openrewrite.java.spring.boot2.Packager
+  - org.openrewrite.java.spring.boot2.Repackager
+
+########################################################################################################################
+# Deprecated methods
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.spring.boot2.LauncherCreateClassLoader
+displayName: "Mark `org.springframework.boot.loader.Launcher.createClassLoader(List<Archive>)` as deprecated"
+description: "`Launcher.createClassLoader(List<Archive>)` is deprecated in 2.3.0 for removal in 2.5."
+recipeList:
+  - org.openrewrite.java.spring.boot2.MarkDeprecatedAPIs:
+      sourceOfDeprecation: Spring Boot 2
+      deprecatedType: classMethod
+      searchPattern: org.springframework.boot.builder.Launcher createClassLoader(java.util.List)
+      deprecationComment: Deprecated since 2.3.0 for removal in 2.5.0 in favor of Launcher.createClassLoader(Iterator).
+      deprecatedLink: https://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/loader/Launcher.html#createClassLoader-java.util.List-
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.spring.boot2.ArchiveForEach
+displayName: "Mark `org.springframework.boot.loader.archive.Archive.forEach(Consumer<? super Archive.Entry>)` as deprecated"
+description: "`Archive.forEach(Consumer<? super Archive.Entry>)` is deprecated in 2.3.0 for removal in 2.5."
+recipeList:
+  - org.openrewrite.java.spring.boot2.MarkDeprecatedAPIs:
+      sourceOfDeprecation: Spring Boot 2
+      deprecatedType: interfaceMethod
+      searchPattern: org.springframework.boot.loader.archive.Archive forEach(..)
+      deprecationComment: Deprecated since 2.3.0 for removal in 2.5.0 in favor of using JarFile to access entries and Archive.getNestedArchives(EntryFilter, EntryFilter) for accessing nested archives.
+      deprecatedLink: https://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/loader/archive/Archive.html#forEach-java.util.function.Consumer-
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.spring.boot2.LauncherGetClassPathArchives
+displayName: "Mark `org.springframework.boot.loader.Launcher.getClassPathArchives()` as deprecated"
+description: "`Launcher.getClassPathArchives()` is deprecated in 2.3.0 for removal in 2.5."
+recipeList:
+  - org.openrewrite.java.spring.boot2.MarkDeprecatedAPIs:
+      sourceOfDeprecation: Spring Boot 2
+      deprecatedType: classMethod
+      searchPattern: org.springframework.boot.loader.Launcher getClassPathArchives()
+      deprecationComment: Deprecated since 2.3.0 for removal in 2.5.0 in favor of implementing Launcher.getClassPathArchivesIterator().
+      deprecatedLink: https://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/loader/Launcher.html#getClassPathArchives--
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.spring.boot2.AbstractErrorWebExceptionHandlerGetErrorAttributes
+displayName: "Mark `org.springframework.boot.autoconfigure.web.reactive.error.AbstractErrorWebExceptionHandler.getErrorAttributes(ServerRequest, boolean)` as deprecated"
+description: "`AbstractErrorWebExceptionHandler.getErrorAttributes(ServerRequest, boolean)` is deprecated in 2.3.0 for removal in 2.5."
+recipeList:
+  - org.openrewrite.java.spring.boot2.MarkDeprecatedAPIs:
+      sourceOfDeprecation: Spring Boot 2
+      deprecatedType: classMethod
+      searchPattern: org.springframework.boot.autoconfigure.web.reactive.error.AbstractErrorWebExceptionHandler getErrorAttributes(org.springframework.web.reactive.function.server.ServerRequest, boolean)
+      deprecationComment: Deprecated since 2.3.0 for removal in 2.5.0 in favor of AbstractErrorWebExceptionHandler.getErrorAttributes(ServerRequest, ErrorAttributeOptions).
+      deprecatedLink: https://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/autoconfigure/web/reactive/error/AbstractErrorWebExceptionHandler.html#getErrorAttributes-org.springframework.web.reactive.function.server.ServerRequest-boolean-
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.spring.boot2.ArchiveGetNestedArchives
+displayName: "Mark `org.springframework.boot.loader.archive.Archive.getNestedArchives(Archive.EntryFilter)` as deprecated"
+description: "`Archive.getNestedArchives(Archive.EntryFilter)` is deprecated in 2.3.0 for removal in 2.5."
+recipeList:
+  - org.openrewrite.java.spring.boot2.MarkDeprecatedAPIs:
+      sourceOfDeprecation: Spring Boot 2
+      deprecatedType: interfaceMethod
+      searchPattern: org.springframework.boot.loader.archive.Archive getNestedArchives(Archive.EntryFilter)
+      deprecationComment: Deprecated since 2.3.0 for removal in 2.5.0 in favor of Archive.getNestedArchives(EntryFilter, EntryFilter).
+      deprecatedLink: https://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/loader/archive/Archive.html#getNestedArchives-org.springframework.boot.loader.archive.Archive.EntryFilter-
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.spring.boot2.ArchiveIterator
+displayName: "Mark `org.springframework.boot.loader.archive.Archive.iterator()` as deprecated"
+description: "`Archive.iterator()` is deprecated in 2.3.0 for removal in 2.5."
+recipeList:
+  - org.openrewrite.java.spring.boot2.MarkDeprecatedAPIs:
+      sourceOfDeprecation: Spring Boot 2
+      deprecatedType: interfaceMethod
+      searchPattern: org.springframework.boot.loader.archive.Archive iterator()
+      deprecationComment: Deprecated since 2.3.0 for removal in 2.5.0 in favor of using JarFile to access entries and Archive.getNestedArchives(EntryFilter, EntryFilter) for accessing nested archives.
+      deprecatedLink: https://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/loader/archive/Archive.html#iterator--
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.spring.boot2.ArchiveSpliterator
+displayName: "Mark `org.springframework.boot.loader.archive.Archive.spliterator()` as deprecated"
+description: "`Archive.spliterator()` is deprecated in 2.3.0 for removal in 2.5."
+recipeList:
+  - org.openrewrite.java.spring.boot2.MarkDeprecatedAPIs:
+      sourceOfDeprecation: Spring Boot 2
+      deprecatedType: interfaceMethod
+      searchPattern: org.springframework.boot.loader.archive.Archive spliterator()
+      deprecationComment: Deprecated since 2.3.0 for removal in 2.5.0 in favor of using JarFile to access entries and Archive.getNestedArchives(EntryFilter, EntryFilter) for accessing nested archives.
+      deprecatedLink: https://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/loader/archive/Archive.html#spliterator--
+
+########################################################################################################################
+# Deprecated constructors
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.spring.boot2.Packager
+displayName: "Mark `org.springframework.boot.loader.tools.Packager(File, LayoutFactory)` as deprecated"
+description: "`Packager(File, LayoutFactory)` is deprecated in 2.3.1 for removal in 2.5."
+recipeList:
+  - org.openrewrite.java.spring.boot2.MarkDeprecatedAPIs:
+      sourceOfDeprecation: Spring Boot 2
+      deprecatedType: constructor
+      searchPattern: org.springframework.boot.loader.tools.Packager Packager(java.io.File, org.springframework.boot.loader.tools.LayoutFactory)
+      deprecationComment: Deprecated since 2.3.1 for removal in 2.5 in favor of Packager(File) and Packager.setLayoutFactory(LayoutFactory).
+      deprecatedLink: https://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/loader/tools/Packager.html#Packager-java.io.File-org.springframework.boot.loader.tools.LayoutFactory-
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.spring.boot2.Repackager
+displayName: "Mark `org.springframework.boot.loader.tools.Repackager(File, LayoutFactory)` as deprecated"
+description: "`Repackager(File, LayoutFactory)` is deprecated in 2.3.1 for removal in 2.5."
+recipeList:
+  - org.openrewrite.java.spring.boot2.MarkDeprecatedAPIs:
+      sourceOfDeprecation: Spring Boot 2
+      deprecatedType: constructor
+      searchPattern: org.springframework.boot.loader.tools.Repackager Repackager(java.io.File, org.springframework.boot.loader.tools.LayoutFactory)
+      deprecationComment: Deprecated since 2.3.1 for removal in 2.5 in favor of Repackager(File) and Packager.setLayoutFactory(LayoutFactory).
+      deprecatedLink: https://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/loader/tools/Packager.html#Packager-java.io.File-org.springframework.boot.loader.tools.LayoutFactory-

--- a/src/main/resources/META-INF/rewrite/mark-deprecated-2-minor-version-4-apis.yml
+++ b/src/main/resources/META-INF/rewrite/mark-deprecated-2-minor-version-4-apis.yml
@@ -1,0 +1,732 @@
+#
+# Copyright 2020 the original author or authors.
+# <p>
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# <p>
+# https://www.apache.org/licenses/LICENSE-2.0
+# <p>
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.spring.boot2.minorversion4.MarkDeprecatedSpringBoot2MinorVersion4APIs
+displayName: "Mark Spring Boot 2 APIs deprecated in 2.4 for removal in 2.6"
+description: "Mark uses of APIs deprecated in 2.4 to upgrade to the next version of Spring Boot."
+recipeList:
+  # interfaces
+  - org.openrewrite.java.spring.boot2.minorversion4.Bootstrapper
+  # classes
+  - org.openrewrite.java.spring.boot2.minorversion4.CassandraHealthIndicator
+  - org.openrewrite.java.spring.boot2.minorversion4.CassandraReactiveHealthIndicator
+  - org.openrewrite.java.spring.boot2.minorversion4.ClasspathLoggingApplicationListener
+  - org.openrewrite.java.spring.boot2.minorversion4.ConfigFileApplicationContextInitializer
+  - org.openrewrite.java.spring.boot2.minorversion4.ConfigFileApplicationListener
+  - org.openrewrite.java.spring.boot2.minorversion4.HazelcastClientFactory
+  - org.openrewrite.java.spring.boot2.minorversion4.HazelcastInstanceFactory
+  - org.openrewrite.java.spring.boot2.minorversion4.ResourceProperties
+  # enums
+  - org.openrewrite.java.spring.boot2.minorversion4.WebMvcPropertiesLocaleResolver
+  # fields
+  - org.openrewrite.java.spring.boot2.minorversion4.SpringApplicationDefaultContextClass
+  - org.openrewrite.java.spring.boot2.minorversion4.SpringApplicationDefaultReactiveWebContextClass
+  - org.openrewrite.java.spring.boot2.minorversion4.SpringApplicationDefaultDefaultServletWebContextClass
+  - org.openrewrite.java.spring.boot2.minorversion4.LoggingSystemPropertiesFileCleanHistoryOnStart
+  - org.openrewrite.java.spring.boot2.minorversion4.LoggingSystemPropertiesFileMaxHistory
+  - org.openrewrite.java.spring.boot2.minorversion4.LoggingSystemPropertiesFileMaxSize
+  - org.openrewrite.java.spring.boot2.minorversion4.LoggingSystemPropertiesFileTotalSizeCap
+  - org.openrewrite.java.spring.boot2.minorversion4.LoggingSystemPropertiesRollingFileNamePattern
+  # methods
+  - org.openrewrite.java.spring.boot2.minorversion4.SpringApplicationBuilderAddBootstrapper
+  - org.openrewrite.java.spring.boot2.minorversion4.SpringApplicationAddBootstrapper
+  - org.openrewrite.java.spring.boot2.minorversion4.ApplicationContextAssertProviderAssertThat
+  - org.openrewrite.java.spring.boot2.minorversion4.JsonContentAssertThat
+  - org.openrewrite.java.spring.boot2.minorversion4.SpringApplicationBuilderContextClass
+  - org.openrewrite.java.spring.boot2.minorversion4.SpringApplicationRunListenerEnvironmentPrepared
+  - org.openrewrite.java.spring.boot2.minorversion4.ManagementServerPropertiesServletGetContextPath
+  - org.openrewrite.java.spring.boot2.minorversion4.MongoPropertiesGetGridFsDatabase
+  - org.openrewrite.java.spring.boot2.minorversion4.ConfigDataGetOptions
+  - org.openrewrite.java.spring.boot2.minorversion4.BootstrapperIntitialize
+  - org.openrewrite.java.spring.boot2.minorversion4.UndertowServletWebServerFactoryIsEagerInitFilters
+  - org.openrewrite.java.spring.boot2.minorversion4.EmbeddedDatabaseConnectionIsEmbedded
+  - org.openrewrite.java.spring.boot2.minorversion4.CloudFoundryVcapEnvironmentPostProcessorOnApplicationEvent
+  - org.openrewrite.java.spring.boot2.minorversion4.BuildLogPulledBuilder
+  - org.openrewrite.java.spring.boot2.minorversion4.BuildLogPulledRunImage
+  - org.openrewrite.java.spring.boot2.minorversion4.BuildLogPullingBuilder
+  - org.openrewrite.java.spring.boot2.minorversion4.BuildLogPullingRunImage
+  - org.openrewrite.java.spring.boot2.minorversion4.SpringApplicationSetApplicationContextClass
+  - org.openrewrite.java.spring.boot2.minorversion4.ManagementServerPropertiesServletSetContextPath
+  - org.openrewrite.java.spring.boot2.minorversion4.UndertowServletWebServerFactorySetEagerInitFilters
+  - org.openrewrite.java.spring.boot2.minorversion4.SpringApplicationRunListenerStarting
+  - org.openrewrite.java.spring.boot2.minorversion4.AbstractJarWriterWriteEntries
+  # constructor
+  - org.openrewrite.java.spring.boot2.minorversion4.AbstractErrorWebExceptionHandler
+  - org.openrewrite.java.spring.boot2.minorversion4.ApplicationEnvironmentPreparedEvent
+  - org.openrewrite.java.spring.boot2.minorversion4.ApplicationStartingEvent
+  - org.openrewrite.java.spring.boot2.minorversion4.CloudFoundryVcapEnvironmentPostProcessor
+  - org.openrewrite.java.spring.boot2.minorversion4.DefaultErrorWebExceptionHandler
+  - org.openrewrite.java.spring.boot2.minorversion4.LibraryA
+  - org.openrewrite.java.spring.boot2.minorversion4.LibraryB
+  - org.openrewrite.java.spring.boot2.minorversion4.LibraryC
+  - org.openrewrite.java.spring.boot2.minorversion4.LibraryD
+  - org.openrewrite.java.spring.boot2.minorversion4.LibraryE
+  # enum constant
+  - org.openrewrite.java.spring.boot2.minorversion4.EmbeddedDatabaseConnectionHSQL
+
+########################################################################################################################
+# Deprecated interfaces
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.spring.boot2.minorversion4.Bootstrapper
+displayName: "Mark `org.springframework.boot.Bootstrapper` as deprecated"
+description: "`Bootstrapper` is deprecated in 2.4.5 for removal in 2.6."
+recipeList:
+  - org.openrewrite.java.spring.boot2.MarkDeprecatedAPIs:
+      sourceOfDeprecation: Spring Boot 2
+      deprecatedType: interface
+      searchPattern: org.springframework.boot.Bootstrapper
+      deprecationComment: Deprecated since 2.4.5 for removal in 2.6 in favor of BootstrapRegistryInitializer.
+      deprecatedLink: https://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/Bootstrapper.html
+
+########################################################################################################################
+# Deprecated classes
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.spring.boot2.minorversion4.CassandraHealthIndicator
+displayName: "Mark `org.springframework.boot.actuate.cassandra.CassandraHealthIndicator` as deprecated"
+description: "`CassandraHealthIndicator` is deprecated in 2.4.0 for removal in 2.6."
+recipeList:
+  - org.openrewrite.java.spring.boot2.MarkDeprecatedAPIs:
+      sourceOfDeprecation: Spring Boot 2
+      deprecatedType: class
+      searchPattern: org.springframework.boot.actuate.cassandra.CassandraHealthIndicator
+      deprecationComment: Deprecated since 2.4.0 for removal in 2.6.0 in favor of CassandraDriverHealthIndicator.
+      deprecatedLink: https://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/actuate/cassandra/CassandraHealthIndicator.html
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.spring.boot2.minorversion4.CassandraReactiveHealthIndicator
+displayName: "Mark `org.springframework.boot.actuate.cassandra.CassandraReactiveHealthIndicator` as deprecated"
+description: "`CassandraReactiveHealthIndicator` is deprecated in 2.4.0 for removal in 2.6."
+recipeList:
+  - org.openrewrite.java.spring.boot2.MarkDeprecatedAPIs:
+      sourceOfDeprecation: Spring Boot 2
+      deprecatedType: class
+      searchPattern: org.springframework.boot.actuate.cassandra.CassandraReactiveHealthIndicator
+      deprecationComment: Deprecated since 2.4.0 for removal in 2.6.0 in favor of CassandraDriverHealthIndicator.
+      deprecatedLink: https://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/actuate/cassandra/CassandraReactiveHealthIndicator.html
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.spring.boot2.minorversion4.ClasspathLoggingApplicationListener
+displayName: "Mark `org.springframework.boot.context.logging.ClasspathLoggingApplicationListener` as deprecated"
+description: "`ClasspathLoggingApplicationListener` is deprecated in 2.4.0 for removal in 2.6."
+recipeList:
+  - org.openrewrite.java.spring.boot2.MarkDeprecatedAPIs:
+      sourceOfDeprecation: Spring Boot 2
+      deprecatedType: class
+      searchPattern: org.springframework.boot.context.logging.ClasspathLoggingApplicationListener
+      deprecationComment: Deprecated since 2.4.0 for removal in 2.6.0 with no direct replacement. FailureAnalysis is now the preferred approach for diagnosing and reporting startup failures.
+      deprecatedLink: https://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/context/logging/ClasspathLoggingApplicationListener.html
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.spring.boot2.minorversion4.ConfigFileApplicationContextInitializer
+displayName: "Mark `org.springframework.boot.test.context.ConfigFileApplicationContextInitializer` as deprecated"
+description: "`ConfigFileApplicationContextInitializer` is deprecated in 2.4.0 for removal in 2.6."
+recipeList:
+  - org.openrewrite.java.spring.boot2.MarkDeprecatedAPIs:
+      sourceOfDeprecation: Spring Boot 2
+      deprecatedType: class
+      searchPattern: org.springframework.boot.test.context.ConfigFileApplicationContextInitializer
+      deprecationComment: Deprecated since 2.4.0 for removal in 2.6.0 in favor of ConfigDataApplicationContextInitializer.
+      deprecatedLink: https://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/test/context/ConfigFileApplicationContextInitializer.html
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.spring.boot2.minorversion4.ConfigFileApplicationListener
+displayName: "Mark `org.springframework.boot.context.config.ConfigFileApplicationListener` as deprecated"
+description: "`ConfigFileApplicationListener` is deprecated in 2.4.0 for removal in 2.6."
+recipeList:
+  - org.openrewrite.java.spring.boot2.MarkDeprecatedAPIs:
+      sourceOfDeprecation: Spring Boot 2
+      deprecatedType: class
+      searchPattern: org.springframework.boot.context.config.ConfigFileApplicationListener
+      deprecationComment: Deprecated since 2.4.0 for removal in 2.6.0 in favor of ConfigDataEnvironmentPostProcessor.
+      deprecatedLink: https://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/context/config/ConfigFileApplicationListener.html
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.spring.boot2.minorversion4.HazelcastClientFactory
+displayName: "Mark `org.springframework.boot.autoconfigure.hazelcast.HazelcastClientFactory` as deprecated"
+description: "`HazelcastClientFactory` is deprecated in 2.4.3 for removal in 2.6."
+recipeList:
+  - org.openrewrite.java.spring.boot2.MarkDeprecatedAPIs:
+      sourceOfDeprecation: Spring Boot 2
+      deprecatedType: class
+      searchPattern: org.springframework.boot.autoconfigure.hazelcast.HazelcastClientFactory
+      deprecationComment: Deprecated since 2.4.3 for removal in 2.6 in favor of using the Hazelcast API directly.
+      deprecatedLink: https://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/autoconfigure/hazelcast/HazelcastClientFactory.html
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.spring.boot2.minorversion4.HazelcastInstanceFactory
+displayName: "Mark `org.springframework.boot.autoconfigure.hazelcast.HazelcastClientFactory` as deprecated"
+description: "`HazelcastClientFactory` is deprecated in 2.4.3 for removal in 2.6."
+recipeList:
+  - org.openrewrite.java.spring.boot2.MarkDeprecatedAPIs:
+      sourceOfDeprecation: Spring Boot 2
+      deprecatedType: class
+      searchPattern: org.springframework.boot.autoconfigure.hazelcast.HazelcastInstanceFactory
+      deprecationComment: Deprecated since 2.4.3 for removal in 2.6 in favor of using the Hazelcast API directly.
+      deprecatedLink: https://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/autoconfigure/hazelcast/HazelcastInstanceFactory.html
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.spring.boot2.minorversion4.ResourceProperties
+displayName: "Mark `org.springframework.boot.autoconfigure.web.ResourceProperties` as deprecated"
+description: "`ResourceProperties` is deprecated in 2.4.0 for removal in 2.6."
+recipeList:
+  - org.openrewrite.java.spring.boot2.MarkDeprecatedAPIs:
+      sourceOfDeprecation: Spring Boot 2
+      deprecatedType: class
+      searchPattern: org.springframework.boot.autoconfigure.web.ResourceProperties
+      deprecationComment: Deprecated since 2.4.0 for removal in 2.6.0 in favor of WebProperties.Resources.
+      deprecatedLink: https://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/autoconfigure/web/ResourceProperties.html
+
+########################################################################################################################
+# Deprecated enums
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.spring.boot2.minorversion4.WebMvcPropertiesLocaleResolver
+displayName: "Mark `org.springframework.boot.autoconfigure.web.servlet.WebMvcProperties.LocaleResolver` as deprecated"
+description: "`WebMvcProperties.LocaleResolver` is deprecated in 2.4.0 for removal in 2.6."
+recipeList:
+  - org.openrewrite.java.spring.boot2.MarkDeprecatedAPIs:
+      sourceOfDeprecation: Spring Boot 2
+      deprecatedType: enum
+      searchPattern: org.springframework.boot.autoconfigure.web.servlet.WebMvcProperties.LocaleResolver
+      deprecationComment: Deprecated since 2.4.0 for removal in 2.6.0 in favor of WebProperties.LocaleResolver.
+      deprecatedLink: https://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/autoconfigure/web/servlet/WebMvcProperties.LocaleResolver.html
+
+########################################################################################################################
+# Deprecated fields
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.spring.boot2.minorversion4.SpringApplicationDefaultContextClass
+displayName: "Mark `org.springframework.boot.SpringApplication.DEFAULT_CONTEXT_CLASS` as deprecated"
+description: "`SpringApplication.DEFAULT_CONTEXT_CLASS` is deprecated in 2.4.0 for removal in 2.6."
+recipeList:
+  - org.openrewrite.java.spring.boot2.MarkDeprecatedAPIs:
+      sourceOfDeprecation: Spring Boot 2
+      deprecatedType: fieldConstant
+      searchPattern: org.springframework.boot.SpringApplication.DEFAULT_CONTEXT_CLASS
+      deprecationComment: Deprecated since 2.4.0 for removal in 2.6.0 in favor of using a ApplicationContextFactory.
+      deprecatedLink: https://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/SpringApplication.html#DEFAULT_CONTEXT_CLASS
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.spring.boot2.minorversion4.SpringApplicationDefaultReactiveWebContextClass
+displayName: "Mark `org.springframework.boot.SpringApplication.DEFAULT_REACTIVE_WEB_CONTEXT_CLASS` as deprecated"
+description: "`SpringApplication.DEFAULT_REACTIVE_WEB_CONTEXT_CLASS` is deprecated in 2.4.0 for removal in 2.6."
+recipeList:
+  - org.openrewrite.java.spring.boot2.MarkDeprecatedAPIs:
+      sourceOfDeprecation: Spring Boot 2
+      deprecatedType: fieldConstant
+      searchPattern: org.springframework.boot.SpringApplication.DEFAULT_REACTIVE_WEB_CONTEXT_CLASS
+      deprecationComment: Deprecated since 2.4.0 for removal in 2.6.0 in favor of using an ApplicationContextFactory.
+      deprecatedLink: https://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/SpringApplication.html#DEFAULT_REACTIVE_WEB_CONTEXT_CLASS
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.spring.boot2.minorversion4.SpringApplicationDefaultDefaultServletWebContextClass
+displayName: "Mark `org.springframework.boot.SpringApplication.DEFAULT_SERVLET_WEB_CONTEXT_CLASS` as deprecated"
+description: "`SpringApplication.DEFAULT_SERVLET_WEB_CONTEXT_CLASS` is deprecated in 2.4.0 for removal in 2.6."
+recipeList:
+  - org.openrewrite.java.spring.boot2.MarkDeprecatedAPIs:
+      sourceOfDeprecation: Spring Boot 2
+      deprecatedType: fieldConstant
+      searchPattern: org.springframework.boot.SpringApplication.DEFAULT_SERVLET_WEB_CONTEXT_CLASS
+      deprecationComment: Deprecated since 2.4.0 for removal in 2.6.0 in favor of using an ApplicationContextFactory.
+      deprecatedLink: https://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/SpringApplication.html#DEFAULT_SERVLET_WEB_CONTEXT_CLASS
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.spring.boot2.minorversion4.LoggingSystemPropertiesFileCleanHistoryOnStart
+displayName: "Mark `org.springframework.boot.logging.LoggingSystemProperties.FILE_CLEAN_HISTORY_ON_START` as deprecated"
+description: "`LoggingSystemProperties.FILE_CLEAN_HISTORY_ON_START` is deprecated in 2.4.0 for removal in 2.6."
+recipeList:
+  - org.openrewrite.java.spring.boot2.MarkDeprecatedAPIs:
+      sourceOfDeprecation: Spring Boot 2
+      deprecatedType: fieldConstant
+      searchPattern: org.springframework.boot.logging.LoggingSystemProperties.FILE_CLEAN_HISTORY_ON_START
+      deprecationComment: Deprecated since 2.4.0 for removal in 2.6.0 in favor of LogbackLoggingSystemProperties.ROLLINGPOLICY_CLEAN_HISTORY_ON_START.
+      deprecatedLink: https://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/logging/LoggingSystemProperties.html#FILE_CLEAN_HISTORY_ON_START
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.spring.boot2.minorversion4.LoggingSystemPropertiesFileMaxHistory
+displayName: "Mark `org.springframework.boot.logging.LoggingSystemProperties.FILE_MAX_HISTORY` as deprecated"
+description: "`LoggingSystemProperties.FILE_MAX_HISTORY` is deprecated in 2.4.0 for removal in 2.6."
+recipeList:
+  - org.openrewrite.java.spring.boot2.MarkDeprecatedAPIs:
+      sourceOfDeprecation: Spring Boot 2
+      deprecatedType: fieldConstant
+      searchPattern: org.springframework.boot.logging.LoggingSystemProperties.FILE_MAX_HISTORY
+      deprecationComment: Deprecated since 2.4.0 for removal in 2.6.0 in favor of LogbackLoggingSystemProperties.ROLLINGPOLICY_MAX_HISTORY.
+      deprecatedLink: https://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/logging/LoggingSystemProperties.html#FILE_MAX_HISTORY
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.spring.boot2.minorversion4.LoggingSystemPropertiesFileMaxSize
+displayName: "Mark `org.springframework.boot.logging.LoggingSystemProperties.FILE_MAX_SIZE` as deprecated"
+description: "`LoggingSystemProperties.FILE_MAX_SIZE` is deprecated in 2.4.0 for removal in 2.6."
+recipeList:
+  - org.openrewrite.java.spring.boot2.MarkDeprecatedAPIs:
+      sourceOfDeprecation: Spring Boot 2
+      deprecatedType: fieldConstant
+      searchPattern: org.springframework.boot.logging.LoggingSystemProperties.FILE_MAX_SIZE
+      deprecationComment: Deprecated since 2.4.0 for removal in 2.6.0 in favor of LogbackLoggingSystemProperties.ROLLINGPOLICY_MAX_FILE_SIZE.
+      deprecatedLink: https://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/logging/LoggingSystemProperties.html#FILE_MAX_SIZE
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.spring.boot2.minorversion4.LoggingSystemPropertiesFileTotalSizeCap
+displayName: "Mark `org.springframework.boot.logging.LoggingSystemProperties.FILE_TOTAL_SIZE_CAP` as deprecated"
+description: "`LoggingSystemProperties.FILE_TOTAL_SIZE_CAP` is deprecated in 2.4.0 for removal in 2.6."
+recipeList:
+  - org.openrewrite.java.spring.boot2.MarkDeprecatedAPIs:
+      sourceOfDeprecation: Spring Boot 2
+      deprecatedType: fieldConstant
+      searchPattern: org.springframework.boot.logging.LoggingSystemProperties.FILE_TOTAL_SIZE_CAP
+      deprecationComment: Deprecated since 2.4.0 for removal in 2.6.0 in favor of LogbackLoggingSystemProperties.ROLLINGPOLICY_TOTAL_SIZE_CAP.
+      deprecatedLink: https://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/logging/LoggingSystemProperties.html#FILE_TOTAL_SIZE_CAP
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.spring.boot2.minorversion4.LoggingSystemPropertiesRollingFileNamePattern
+displayName: "Mark `org.springframework.boot.logging.LoggingSystemProperties.ROLLING_FILE_NAME_PATTERN` as deprecated"
+description: "`LoggingSystemProperties.ROLLING_FILE_NAME_PATTERN` is deprecated in 2.4.0 for removal in 2.6."
+recipeList:
+  - org.openrewrite.java.spring.boot2.MarkDeprecatedAPIs:
+      sourceOfDeprecation: Spring Boot 2
+      deprecatedType: fieldConstant
+      searchPattern: org.springframework.boot.logging.LoggingSystemProperties.ROLLING_FILE_NAME_PATTERN
+      deprecationComment: Deprecated since 2.4.0 for removal in 2.6.0 in favor of LogbackLoggingSystemProperties.ROLLINGPOLICY_FILE_NAME_PATTERN.
+      deprecatedLink: https://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/logging/LoggingSystemProperties.html#FILE_TOTAL_SIZE_CAP
+
+########################################################################################################################
+# Deprecated methods
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.spring.boot2.minorversion4.SpringApplicationBuilderAddBootstrapper
+displayName: "Mark `org.springframework.boot.builder.SpringApplicationBuilder.addBootstrapper(Bootstrapper)` as deprecated"
+description: "`SpringApplicationBuilder.addBootstrapper(Bootstrapper)` is deprecated in 2.4.5 for removal in 2.6."
+recipeList:
+  - org.openrewrite.java.spring.boot2.MarkDeprecatedAPIs:
+      sourceOfDeprecation: Spring Boot 2
+      deprecatedType: classMethod
+      searchPattern: org.springframework.boot.builder.SpringApplicationBuilder addBootstrapper(..)
+      deprecationComment: Deprecated since 2.4.5 for removal in 2.6 in favor of SpringApplicationBuilder.addBootstrapRegistryInitializer(BootstrapRegistryInitializer).
+      deprecatedLink: https://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/builder/SpringApplicationBuilder.html#addBootstrapper-org.springframework.boot.Bootstrapper-
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.spring.boot2.minorversion4.SpringApplicationAddBootstrapper
+displayName: "Mark `org.springframework.boot.SpringApplication.addBootstrapper(Bootstrapper)` as deprecated"
+description: "`SpringApplication.addBootstrapper(Bootstrapper)` is deprecated in 2.4.5 for removal in 2.6."
+recipeList:
+  - org.openrewrite.java.spring.boot2.MarkDeprecatedAPIs:
+      sourceOfDeprecation: Spring Boot 2
+      deprecatedType: classMethod
+      searchPattern: org.springframework.boot.SpringApplication addBootstrapper(..)
+      deprecationComment: Deprecated since 2.4.5 for removal in 2.6 in favor of SpringApplication.addBootstrapRegistryInitializer(BootstrapRegistryInitializer).
+      deprecatedLink: https://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/SpringApplication.html#addBootstrapper-org.springframework.boot.Bootstrapper-
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.spring.boot2.minorversion4.SpringApplicationBuilderContextClass
+displayName: "Mark `org.springframework.boot.builder.SpringApplicationBuilder.contextClass(Class<? extends ConfigurableApplicationContext>)` as deprecated"
+description: "`SpringApplicationBuilder.contextClass(Class<? extends ConfigurableApplicationContext>)` is deprecated in 2.4.0 for removal in 2.6."
+recipeList:
+  - org.openrewrite.java.spring.boot2.MarkDeprecatedAPIs:
+      sourceOfDeprecation: Spring Boot 2
+      deprecatedType: classMethod
+      searchPattern: org.springframework.boot.builder.SpringApplicationBuilder contextClass(..)
+      deprecationComment: Deprecated since 2.4.0 for removal in 2.6.0 in favor of SpringApplicationBuilder.contextFactory(ApplicationContextFactory).
+      deprecatedLink: https://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/builder/SpringApplicationBuilder.html#contextClass-java.lang.Class-
+
+---
+# FixMe: interface method, add ... visit class dec find interface, visit method, check for override in classDecl.
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.spring.boot2.minorversion4.SpringApplicationRunListenerEnvironmentPrepared
+displayName: "Mark `org.springframework.boot.SpringApplicationRunListener.environmentPrepared(ConfigurableEnvironment)` as deprecated"
+description: "`SpringApplicationRunListener.environmentPrepared(ConfigurableEnvironment)` is deprecated in 2.4.0 for removal in 2.6."
+recipeList:
+  - org.openrewrite.java.spring.boot2.MarkDeprecatedAPIs:
+      sourceOfDeprecation: Spring Boot 2
+      deprecatedType: interfaceMethod
+      searchPattern: org.springframework.boot.SpringApplicationRunListener environmentPrepared(org.springframework.core.env.ConfigurableEnvironment)
+      deprecationComment: since 2.4.0 for removal in 2.6.0 in favor of SpringApplicationRunListener.environmentPrepared(ConfigurableBootstrapContext, ConfigurableEnvironment).
+      deprecatedLink: https://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/SpringApplicationRunListener.html#environmentPrepared-org.springframework.core.env.ConfigurableEnvironment-
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.spring.boot2.minorversion4.ManagementServerPropertiesServletGetContextPath
+displayName: "Mark `org.springframework.boot.actuate.autoconfigure.web.server.ManagementServerProperties.Servlet.getContextPath()` as deprecated"
+description: "`ManagementServerProperties.Servlet.getContextPath()` is deprecated in 2.4.0 for removal in 2.6."
+recipeList:
+  - org.openrewrite.java.spring.boot2.MarkDeprecatedAPIs:
+      sourceOfDeprecation: Spring Boot 2
+      deprecatedType: classMethod
+      searchPattern: org.springframework.boot.actuate.autoconfigure.web.server.ManagementServerProperties.Servlet getContextPath()
+      deprecationComment: Deprecated since 2.4.0 for removal in 2.6.0 in favor of ManagementServerProperties.getBasePath().
+      deprecatedLink: https://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/actuate/autoconfigure/web/server/ManagementServerProperties.Servlet.html#getContextPath--
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.spring.boot2.minorversion4.MongoPropertiesGetGridFsDatabase
+displayName: "Mark `org.springframework.boot.autoconfigure.mongo.MongoProperties.getGridFsDatabase()` as deprecated"
+description: "`MongoProperties getGridFsDatabase()` is deprecated in 2.4.0 for removal in 2.6."
+recipeList:
+  - org.openrewrite.java.spring.boot2.MarkDeprecatedAPIs:
+      sourceOfDeprecation: Spring Boot 2
+      deprecatedType: classMethod
+      searchPattern: org.springframework.boot.autoconfigure.mongo.MongoProperties getGridFsDatabase()
+      deprecationComment: Deprecated since 2.4.0 for removal in 2.6.0 in favor of MongoProperties.Gridfs.getDatabase().
+      deprecatedLink: https://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/autoconfigure/mongo/MongoProperties.html#getGridFsDatabase--
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.spring.boot2.minorversion4.ConfigDataGetOptions
+displayName: "Mark `org.springframework.boot.autoconfigure.mongo.MongoProperties.getGridFsDatabase()` as deprecated"
+description: "`MongoProperties getGridFsDatabase()` is deprecated in 2.4.5 for removal in 2.6."
+recipeList:
+  - org.openrewrite.java.spring.boot2.MarkDeprecatedAPIs:
+      sourceOfDeprecation: Spring Boot 2
+      deprecatedType: classMethod
+      searchPattern: org.springframework.boot.context.config.ConfigData getOptions()
+      deprecationComment: Deprecated since 2.4.5 in favor of ConfigData.getOptions(PropertySource).
+      deprecatedLink: https://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/context/config/ConfigData.html#getOptions--
+
+---
+# check how the matcher distinguishes default void vs void.
+#type: specs.openrewrite.org/v1beta/recipe
+#name: org.openrewrite.java.spring.boot2.minorversion4.BootstrapperIntitialize
+#displayName: ""
+#description: ""
+#recipeList:
+#  - org.openrewrite.java.spring.boot2.MarkDeprecatedAPIs:
+#      sourceOfDeprecation: Spring Boot 2
+#      deprecatedType: interfaceMethod
+#      searchPattern: org.springframework.boot.Bootstrapper intitialize(..)
+#      deprecationComment: Deprecated since 2.4.4 for removal in 2.6 in favor of Bootstrapper.initialize(BootstrapRegistry).
+#      deprecatedLink: https://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/Bootstrapper.html#intitialize-org.springframework.boot.BootstrapRegistry-
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.spring.boot2.minorversion4.UndertowServletWebServerFactoryIsEagerInitFilters
+displayName: "Mark `org.springframework.boot.web.embedded.undertow.UndertowServletWebServerFactory.isEagerInitFilters()` as deprecated"
+description: "`UndertowServletWebServerFactory.isEagerInitFilters()` is deprecated in 2.4.0 for removal in 2.6."
+recipeList:
+  - org.openrewrite.java.spring.boot2.MarkDeprecatedAPIs:
+      sourceOfDeprecation: Spring Boot 2
+      deprecatedType: classMethod
+      searchPattern: org.springframework.boot.web.embedded.undertow.UndertowServletWebServerFactory isEagerInitFilters()
+      deprecationComment: Deprecated since 2.4.0 for removal in 2.6.0 in favor of UndertowServletWebServerFactory.isEagerFilterInit().
+      deprecatedLink: https://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/web/embedded/undertow/UndertowServletWebServerFactory.html#isEagerInitFilters--
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.spring.boot2.minorversion4.EmbeddedDatabaseConnectionIsEmbedded
+displayName: "Mark `org.springframework.boot.jdbc.EmbeddedDatabaseConnection.isEmbedded(String)` as deprecated"
+description: "`EmbeddedDatabaseConnection.isEmbedded(String)` is deprecated in 2.4.0 for removal in 2.6."
+recipeList:
+  - org.openrewrite.java.spring.boot2.MarkDeprecatedAPIs:
+      sourceOfDeprecation: Spring Boot 2
+      deprecatedType: enumMethod
+      searchPattern: org.springframework.boot.jdbc.EmbeddedDatabaseConnection isEmbedded(java.lang.String)
+      deprecationComment: Deprecated since 2.4.0 for removal in 2.6.0 in favor of EmbeddedDatabaseConnection.isEmbedded(String, String).
+      deprecatedLink: https://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/jdbc/EmbeddedDatabaseConnection.html#isEmbedded-java.lang.String-
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.spring.boot2.minorversion4.CloudFoundryVcapEnvironmentPostProcessorOnApplicationEvent
+displayName: "Mark `org.springframework.boot.cloud.CloudFoundryVcapEnvironmentPostProcessor.onApplicationEvent(ApplicationPreparedEvent)` as deprecated"
+description: "`CloudFoundryVcapEnvironmentPostProcessor.onApplicationEvent(ApplicationPreparedEvent)` is deprecated in 2.4.0 for removal in 2.6."
+recipeList:
+  - org.openrewrite.java.spring.boot2.MarkDeprecatedAPIs:
+      sourceOfDeprecation: Spring Boot 2
+      deprecatedType: classMethod
+      searchPattern: org.springframework.boot.cloud.CloudFoundryVcapEnvironmentPostProcessor onApplicationEvent(org.springframework.boot.context.event.ApplicationPreparedEvent)
+      deprecationComment: Deprecated since 2.4.0 for removal in 2.6.0 in favor of only using EnvironmentPostProcessor callbacks.
+      deprecatedLink: https://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/cloud/CloudFoundryVcapEnvironmentPostProcessor.html#onApplicationEvent-org.springframework.boot.context.event.ApplicationPreparedEvent-
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.spring.boot2.minorversion4.BuildLogPulledBuilder
+displayName: "Mark `org.springframework.boot.buildpack.platform.build.BuildLog.pulledBuilder(BuildRequest, Image)` as deprecated"
+description: "`BuildLog.pulledBuilder(BuildRequest, Image)` is deprecated in 2.4.0 for removal in 2.6."
+recipeList:
+  - org.openrewrite.java.spring.boot2.MarkDeprecatedAPIs:
+      sourceOfDeprecation: Spring Boot 2
+      deprecatedType: interfaceMethod
+      searchPattern: org.springframework.boot.buildpack.platform.build.BuildLog pulledBuilder(org.springframework.boot.buildpack.platform.build.BuildRequest.BuildRequest, org.springframework.boot.buildpack.platform.docker.type.Image)
+      deprecationComment: Deprecated since 2.4.0 for removal in 2.6.0 in favor of BuildLog.pulledImage(Image, ImageType).
+      deprecatedLink: https://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/buildpack/platform/build/BuildLog.html#pulledBuilder-org.springframework.boot.buildpack.platform.build.BuildRequest-org.springframework.boot.buildpack.platform.docker.type.Image-
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.spring.boot2.minorversion4.BuildLogPulledRunImage
+displayName: "Mark `org.springframework.boot.buildpack.platform.build.BuildLog.pulledRunImage(BuildRequest, Image)` as deprecated"
+description: "`BuildLog.pulledRunImage(BuildRequest, Image)` is deprecated in 2.4.0 for removal in 2.6."
+recipeList:
+  - org.openrewrite.java.spring.boot2.MarkDeprecatedAPIs:
+      sourceOfDeprecation: Spring Boot 2
+      deprecatedType: interfaceMethod
+      searchPattern: org.springframework.boot.buildpack.platform.build.BuildLog pulledRunImage(org.springframework.boot.buildpack.platform.build.BuildRequest.BuildRequest, org.springframework.boot.buildpack.platform.docker.type.Image)
+      deprecationComment: Deprecated since 2.4.0 for removal in 2.6.0 in favor of BuildLog.pulledImage(Image, ImageType).
+      deprecatedLink: https://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/buildpack/platform/build/BuildLog.html#pulledRunImage-org.springframework.boot.buildpack.platform.build.BuildRequest-org.springframework.boot.buildpack.platform.docker.type.Image-
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.spring.boot2.minorversion4.BuildLogPullingBuilder
+displayName: "Mark `org.springframework.boot.buildpack.platform.build.BuildLog.pullingBuilder(BuildRequest, ImageReference)` as deprecated"
+description: "`BuildLog.pullingBuilder(BuildRequest, ImageReference)` is deprecated in 2.4.0 for removal in 2.6."
+recipeList:
+  - org.openrewrite.java.spring.boot2.MarkDeprecatedAPIs:
+      sourceOfDeprecation: Spring Boot 2
+      deprecatedType: interfaceMethod
+      searchPattern: org.springframework.boot.buildpack.platform.build.BuildLog.pullingBuilder(org.springframework.boot.buildpack.platform.build.BuildRequest.BuildRequest, org.springframework.boot.buildpack.platform.docker.type.ImageReference)
+      deprecationComment: Deprecated since 2.4.0 for removal in 2.6.0 in favor of BuildLog.pullingImage(ImageReference, ImageType).
+      deprecatedLink: https://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/buildpack/platform/build/BuildLog.html#pullingBuilder-org.springframework.boot.buildpack.platform.build.BuildRequest-org.springframework.boot.buildpack.platform.docker.type.ImageReference-
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.spring.boot2.minorversion4.BuildLogPullingRunImage
+displayName: "Mark `org.springframework.boot.buildpack.platform.build.BuildLog.pullingRunImage(BuildRequest, ImageReference)` as deprecated"
+description: "`BuildLog.pullingRunImage(BuildRequest, ImageReference)` is deprecated in 2.4.0 for removal in 2.6."
+recipeList:
+  - org.openrewrite.java.spring.boot2.MarkDeprecatedAPIs:
+      sourceOfDeprecation: Spring Boot 2
+      deprecatedType: interfaceMethod
+      searchPattern: org.springframework.boot.buildpack.platform.build.BuildLog.pullingRunImage(org.springframework.boot.buildpack.platform.build.BuildRequest.BuildRequest, org.springframework.boot.buildpack.platform.docker.type.ImageReference)
+      deprecationComment: Deprecated since 2.4.0 for removal in 2.6.0 in favor of BuildLog.pullingImage(ImageReference, ImageType).
+      deprecatedLink: https://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/buildpack/platform/build/BuildLog.html#pullingRunImage-org.springframework.boot.buildpack.platform.build.BuildRequest-org.springframework.boot.buildpack.platform.docker.type.ImageReference-
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.spring.boot2.minorversion4.SpringApplicationSetApplicationContextClass
+displayName: "Mark `org.springframework.boot.SpringApplication.setApplicationContextClass(Class<? extends ConfigurableApplicationContext>)` as deprecated"
+description: "`SpringApplication.setApplicationContextClass(Class<? extends ConfigurableApplicationContext>)` is deprecated in 2.4.0 for removal in 2.6."
+recipeList:
+  - org.openrewrite.java.spring.boot2.MarkDeprecatedAPIs:
+      sourceOfDeprecation: Spring Boot 2
+      deprecatedType: classMethod
+      searchPattern: org.springframework.boot.SpringApplication setApplicationContextClass(..)
+      deprecationComment: Deprecated since 2.4.0 for removal in 2.6.0 in favor of SpringApplication.setApplicationContextFactory(ApplicationContextFactory).
+      deprecatedLink: https://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/SpringApplication.html#setApplicationContextClass-java.lang.Class-
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.spring.boot2.minorversion4.ManagementServerPropertiesServletSetContextPath
+displayName: "Mark `org.springframework.boot.actuate.autoconfigure.web.server.ManagementServerProperties.Servlet.setContextPath(String)` as deprecated"
+description: "`ManagementServerProperties.Servlet.setContextPath(String)` is deprecated in 2.4.0 for removal in 2.6."
+recipeList:
+  - org.openrewrite.java.spring.boot2.MarkDeprecatedAPIs:
+      sourceOfDeprecation: Spring Boot 2
+      deprecatedType: classMethod
+      searchPattern: org.springframework.boot.actuate.autoconfigure.web.server.ManagementServerProperties.Servlet setContextPath(java.lang.String)
+      deprecationComment: Deprecated since 2.4.0 for removal in 2.6.0 in favor of ManagementServerProperties.setBasePath(String).
+      deprecatedLink: https://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/actuate/autoconfigure/web/server/ManagementServerProperties.Servlet.html#setContextPath-java.lang.String-
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.spring.boot2.minorversion4.UndertowServletWebServerFactorySetEagerInitFilters
+displayName: "Mark `org.springframework.boot.web.embedded.undertow.UndertowServletWebServerFactory.setEagerInitFilters(boolean)` as deprecated"
+description: "`UndertowServletWebServerFactory.setEagerInitFilters(boolean)` is deprecated in 2.4.0 for removal in 2.6."
+recipeList:
+  - org.openrewrite.java.spring.boot2.MarkDeprecatedAPIs:
+      sourceOfDeprecation: Spring Boot 2
+      deprecatedType: classMethod
+      searchPattern: org.springframework.boot.web.embedded.undertow.UndertowServletWebServerFactory setEagerInitFilters(boolean)
+      deprecationComment: Deprecated since 2.4.0 for removal in 2.6.0 in favor of UndertowServletWebServerFactory.isEagerFilterInit().
+      deprecatedLink: https://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/web/embedded/undertow/UndertowServletWebServerFactory.html#setEagerInitFilters-boolean-
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.spring.boot2.minorversion4.SpringApplicationRunListenerStarting
+displayName: "Mark `org.springframework.boot.SpringApplicationRunListener.starting()` as deprecated"
+description: "`SpringApplicationRunListener.starting()` is deprecated in 2.4.0 for removal in 2.6."
+recipeList:
+  - org.openrewrite.java.spring.boot2.MarkDeprecatedAPIs:
+      sourceOfDeprecation: Spring Boot 2
+      deprecatedType: interfaceMethod
+      searchPattern: org.springframework.boot.SpringApplicationRunListener starting()
+      deprecationComment: Deprecated since 2.4.0 for removal in 2.6.0 in favor of SpringApplicationRunListener.starting(ConfigurableBootstrapContext).
+      deprecatedLink: https://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/SpringApplicationRunListener.html#starting--
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.spring.boot2.minorversion4.AbstractJarWriterWriteEntries
+displayName: "Mark `org.springframework.boot.loader.tools.AbstractJarWriter.writeEntries(JarFile)` as deprecated"
+description: "`AbstractJarWriter.writeEntries(JarFile)` is deprecated in 2.4.8 for removal in 2.6."
+recipeList:
+  - org.openrewrite.java.spring.boot2.MarkDeprecatedAPIs:
+      sourceOfDeprecation: Spring Boot 2
+      deprecatedType: classMethod
+      searchPattern: org.springframework.boot.loader.tools.AbstractJarWriter writeEntries(..)
+      deprecationComment: Deprecated since 2.4.8 for removal in 2.6.0.
+      deprecatedLink: https://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/loader/tools/AbstractJarWriter.html#writeEntries-java.util.jar.JarFile-
+
+########################################################################################################################
+# Deprecated constructors
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.spring.boot2.minorversion4.AbstractErrorWebExceptionHandler
+displayName: "Mark `org.springframework.boot.autoconfigure.web.reactive.error.AbstractErrorWebExceptionHandler(ErrorAttributes, ResourceProperties, ApplicationContext)` as deprecated"
+description: "`AbstractErrorWebExceptionHandler(ErrorAttributes, ResourceProperties, ApplicationContext)` is deprecated in 2.4.0 for removal in 2.6."
+recipeList:
+  - org.openrewrite.java.spring.boot2.MarkDeprecatedAPIs:
+      sourceOfDeprecation: Spring Boot 2
+      deprecatedType: constructor
+      searchPattern: org.springframework.boot.autoconfigure.web.reactive.error.AbstractErrorWebExceptionHandler AbstractErrorWebExceptionHandler(org.springframework.boot.web.reactive.error.ErrorAttributes, org.springframework.boot.autoconfigure.web.ResourceProperties, org.springframework.context.ApplicationContext)
+      deprecationComment: Deprecated since 2.4.0 for removal in 2.6.0 in favor of \#AbstractErrorWebExceptionHandler(ErrorAttributes, Resources, ApplicationContext).
+      deprecatedLink: https://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/autoconfigure/web/reactive/error/AbstractErrorWebExceptionHandler.html#AbstractErrorWebExceptionHandler-org.springframework.boot.web.reactive.error.ErrorAttributes-org.springframework.boot.autoconfigure.web.ResourceProperties-org.springframework.context.ApplicationContext-
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.spring.boot2.minorversion4.ApplicationEnvironmentPreparedEvent
+displayName: "Mark `org.springframework.boot.context.event.ApplicationEnvironmentPreparedEvent(SpringApplication, String[], ConfigurableEnvironment)` as deprecated"
+description: "`ApplicationEnvironmentPreparedEvent(SpringApplication, String[], ConfigurableEnvironment)` is deprecated in 2.4.0 for removal in 2.6."
+recipeList:
+  - org.openrewrite.java.spring.boot2.MarkDeprecatedAPIs:
+      sourceOfDeprecation: Spring Boot 2
+      deprecatedType: constructor
+      searchPattern: org.springframework.boot.context.event.ApplicationEnvironmentPreparedEvent ApplicationEnvironmentPreparedEvent(org.springframework.boot.SpringApplication, java.lang.String[], org.springframework.core.env.ConfigurableEnvironment)
+      deprecationComment: Deprecated since 2.4.0 for removal in 2.6.0 in favor of ApplicationEnvironmentPreparedEvent(ConfigurableBootstrapContext, SpringApplication, String[], ConfigurableEnvironment).
+      deprecatedLink: https://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/context/event/ApplicationEnvironmentPreparedEvent.html#ApplicationEnvironmentPreparedEvent-org.springframework.boot.SpringApplication-java.lang.String:A-org.springframework.core.env.ConfigurableEnvironment-
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.spring.boot2.minorversion4.ApplicationStartingEvent
+displayName: "Mark `org.springframework.boot.context.event.ApplicationStartingEvent(SpringApplication, String[])` as deprecated"
+description: "`ApplicationStartingEvent(SpringApplication, String[])` is deprecated in 2.4.0 for removal in 2.6."
+recipeList:
+  - org.openrewrite.java.spring.boot2.MarkDeprecatedAPIs:
+      sourceOfDeprecation: Spring Boot 2
+      deprecatedType: constructor
+      searchPattern: org.springframework.boot.context.event.ApplicationStartingEvent ApplicationStartingEvent(org.springframework.boot.SpringApplication, java.lang.String[])
+      deprecationComment: Deprecated since 2.4.0 for removal in 2.6.0 in favor of ApplicationStartingEvent(ConfigurableBootstrapContext, SpringApplication, String[]).
+      deprecatedLink: https://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/context/event/ApplicationStartingEvent.html#ApplicationStartingEvent-org.springframework.boot.SpringApplication-java.lang.String:A-
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.spring.boot2.minorversion4.CloudFoundryVcapEnvironmentPostProcessor
+displayName: "Mark `org.springframework.boot.cloud.CloudFoundryVcapEnvironmentPostProcessor()` as deprecated"
+description: "`CloudFoundryVcapEnvironmentPostProcessor()` is deprecated in 2.4.0 for removal in 2.6."
+recipeList:
+  - org.openrewrite.java.spring.boot2.MarkDeprecatedAPIs:
+      sourceOfDeprecation: Spring Boot 2
+      deprecatedType: constructor
+      searchPattern: org.springframework.boot.cloud.CloudFoundryVcapEnvironmentPostProcessor CloudFoundryVcapEnvironmentPostProcessor()
+      deprecationComment: Deprecated since 2.4.0 for removal in 2.6.0 in favor of CloudFoundryVcapEnvironmentPostProcessor(Log).
+      deprecatedLink: https://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/cloud/CloudFoundryVcapEnvironmentPostProcessor.html#CloudFoundryVcapEnvironmentPostProcessor--
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.spring.boot2.minorversion4.DefaultErrorWebExceptionHandler
+displayName: "Mark `org.springframework.boot.autoconfigure.web.reactive.error.DefaultErrorWebExceptionHandler(ErrorAttributes, ResourceProperties, ErrorProperties, ApplicationContext)` as deprecated"
+description: "`DefaultErrorWebExceptionHandler(ErrorAttributes, ResourceProperties, ErrorProperties, ApplicationContext)` is deprecated in 2.4.0 for removal in 2.6."
+recipeList:
+  - org.openrewrite.java.spring.boot2.MarkDeprecatedAPIs:
+      sourceOfDeprecation: Spring Boot 2
+      deprecatedType: constructor
+      searchPattern: org.springframework.boot.autoconfigure.web.reactive.error.DefaultErrorWebExceptionHandler DefaultErrorWebExceptionHandler(org.springframework.boot.web.reactive.error.ErrorAttributes, org.springframework.boot.autoconfigure.web.ResourceProperties, org.springframework.boot.autoconfigure.web.ErrorProperties, org.springframework.context.ApplicationContext)
+      deprecationComment: Deprecated since 2.4.0 for removal in 2.6.0 in favor of \#DefaultErrorWebExceptionHandler(ErrorAttributes, Resources, ErrorProperties, ApplicationContext).
+      deprecatedLink: https://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/autoconfigure/web/reactive/error/DefaultErrorWebExceptionHandler.html#DefaultErrorWebExceptionHandler-org.springframework.boot.web.reactive.error.ErrorAttributes-org.springframework.boot.autoconfigure.web.ResourceProperties-org.springframework.boot.autoconfigure.web.ErrorProperties-org.springframework.context.ApplicationContext-
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.spring.boot2.minorversion4.LibraryA
+displayName: "Mark `org.springframework.boot.loader.tools.Library(File, LibraryScope, boolean)` as deprecated"
+description: "`Library(File, LibraryScope, boolean)` is deprecated in 2.4.8 for removal in 2.6."
+recipeList:
+  - org.openrewrite.java.spring.boot2.MarkDeprecatedAPIs:
+      sourceOfDeprecation: Spring Boot 2
+      deprecatedType: constructor
+      searchPattern: org.springframework.boot.loader.tools.Library Library(java.io.File, org.springframework.boot.loader.tools.LibraryScope, boolean)
+      deprecationComment: Deprecated since 2.4.8 for removal in 2.6.0 in favor of Library(String, File, LibraryScope, LibraryCoordinates, boolean, boolean, boolean).
+      deprecatedLink: https://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/loader/tools/Library.html#Library-java.io.File-org.springframework.boot.loader.tools.LibraryScope-boolean-
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.spring.boot2.minorversion4.LibraryB
+displayName: "Mark `org.springframework.boot.loader.tools.Library(String, File, LibraryScope, boolean)` as deprecated"
+description: "`Library(String, File, LibraryScope, boolean)` is deprecated in 2.4.8 for removal in 2.6."
+recipeList:
+  - org.openrewrite.java.spring.boot2.MarkDeprecatedAPIs:
+      sourceOfDeprecation: Spring Boot 2
+      deprecatedType: constructor
+      searchPattern: org.springframework.boot.loader.tools.Library Library(java.lang.String, java.io.File, org.springframework.boot.loader.tools.LibraryScope, boolean)
+      deprecationComment: Deprecated since 2.4.8 for removal in 2.6.0 in favor of Library(String, File, LibraryScope, LibraryCoordinates, boolean, boolean, boolean).
+      deprecatedLink: https://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/loader/tools/Library.html#Library-java.lang.String-java.io.File-org.springframework.boot.loader.tools.LibraryScope-boolean-
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.spring.boot2.minorversion4.LibraryC
+displayName: "Mark `org.springframework.boot.loader.tools.Library(String, File, LibraryScope, LibraryCoordinates, boolean)` as deprecated"
+description: "`Library(String, File, LibraryScope, LibraryCoordinates, boolean)` is deprecated in 2.4.8 for removal in 2.6."
+recipeList:
+  - org.openrewrite.java.spring.boot2.MarkDeprecatedAPIs:
+      sourceOfDeprecation: Spring Boot 2
+      deprecatedType: constructor
+      searchPattern: org.springframework.boot.loader.tools.Library Library(java.lang.String, java.io.File, org.springframework.boot.loader.tools.LibraryScope, org.springframework.boot.loader.tools.LibraryCoordinates, boolean)
+      deprecationComment: Deprecated since 2.4.8 for removal in 2.6.0 in favor of Library(String, File, LibraryScope, LibraryCoordinates, boolean, boolean, boolean).
+      deprecatedLink: https://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/loader/tools/Library.html#Library-java.lang.String-java.io.File-org.springframework.boot.loader.tools.LibraryScope-org.springframework.boot.loader.tools.LibraryCoordinates-boolean-
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.spring.boot2.minorversion4.LibraryD
+displayName: "Mark `org.springframework.boot.loader.tools.Library(String, File, LibraryScope, LibraryCoordinates, boolean, boolean)` as deprecated"
+description: "`Library(String, File, LibraryScope, LibraryCoordinates, boolean, boolean)` is deprecated in 2.4.8 for removal in 2.6."
+recipeList:
+  - org.openrewrite.java.spring.boot2.MarkDeprecatedAPIs:
+      sourceOfDeprecation: Spring Boot 2
+      deprecatedType: constructor
+      searchPattern: org.springframework.boot.loader.tools.Library Library(java.lang.String, java.io.File, org.springframework.boot.loader.tools.LibraryScope, org.springframework.boot.loader.tools.LibraryCoordinates, boolean, boolean)
+      deprecationComment: Deprecated since 2.4.8 for removal in 2.6.0 in favor of Library(String, File, LibraryScope, LibraryCoordinates, boolean, boolean, boolean).
+      deprecatedLink: https://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/loader/tools/Library.html#Library-java.lang.String-java.io.File-org.springframework.boot.loader.tools.LibraryScope-org.springframework.boot.loader.tools.LibraryCoordinates-boolean-boolean-
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.spring.boot2.minorversion4.LibraryE
+displayName: "Mark `org.springframework.boot.test.util.TestPropertyValues.Pair(String, String)` as deprecated"
+description: "`TestPropertyValues.Pair(String, String)` is deprecated in 2.4.0 for removal in 2.6."
+recipeList:
+  - org.openrewrite.java.spring.boot2.MarkDeprecatedAPIs:
+      sourceOfDeprecation: Spring Boot 2
+      deprecatedType: constructor
+      searchPattern: org.springframework.boot.test.util.TestPropertyValues.Pair Pair(java.lang.String, java.lang.String)
+      deprecationComment: Deprecated since 2.4.0 for removal in 2.6.0 in favor of TestPropertyValues.Pair.of(String, String).
+      deprecatedLink: https://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/test/util/TestPropertyValues.Pair.html#Pair-java.lang.String-java.lang.String-
+
+########################################################################################################################
+# Deprecated enum constant
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.spring.boot2.minorversion4.EmbeddedDatabaseConnectionHSQL
+displayName: "Mark `org.springframework.boot.jdbc.EmbeddedDatabaseConnection.HSQL` as deprecated"
+description: "`EmbeddedDatabaseConnection.HSQL` is deprecated in 2.4.0 for removal in 2.6."
+recipeList:
+  - org.openrewrite.java.spring.boot2.MarkDeprecatedAPIs:
+      sourceOfDeprecation: Spring Boot 2
+      deprecatedType: enumConstant
+      searchPattern: org.springframework.boot.jdbc.EmbeddedDatabaseConnection.HSQL
+      deprecationComment: Deprecated since 2.4.0 for removal in 2.6.0 in favor of EmbeddedDatabaseConnection.HSQLDB.
+      deprecatedLink: https://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/jdbc/EmbeddedDatabaseConnection.html#HSQL

--- a/src/main/resources/META-INF/rewrite/mark-deprecated-2-minor-version-5-apis.yml
+++ b/src/main/resources/META-INF/rewrite/mark-deprecated-2-minor-version-5-apis.yml
@@ -1,0 +1,355 @@
+#
+# Copyright 2020 the original author or authors.
+# <p>
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# <p>
+# https://www.apache.org/licenses/LICENSE-2.0
+# <p>
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.spring.boot2.minorversion5.MarkDeprecatedSpringBoot2MinorVersion4APIs
+displayName: "Mark Spring Boot 2 APIs deprecated in 2.5 for removal in 2.7"
+description: "Mark uses of APIs deprecated in 2.5 to upgrade to the next version of Spring Boot."
+recipeList:
+  # classes
+  - org.openrewrite.java.spring.boot2.minorversion5.ActuatorMediaType
+  - org.openrewrite.java.spring.boot2.minorversion5.ConnectionFactoryBuilder
+  - org.openrewrite.java.spring.boot2.minorversion5.DataSourceSchemaCreatedEvent
+  - org.openrewrite.java.spring.boot2.minorversion5.DslContextDependsOnPostProcessor
+  - org.openrewrite.java.spring.boot2.minorversion5.EntityManagerFactoryDependsOnPostProcessor
+  - org.openrewrite.java.spring.boot2.minorversion5.HypermediaHttpMessageConverterConfiguration
+  - org.openrewrite.java.spring.boot2.minorversion5.JdbcOperationsDependsOnPostProcessor
+  - org.openrewrite.java.spring.boot2.minorversion5.MustacheEnvironmentCollector
+  - org.openrewrite.java.spring.boot2.minorversion5.NamedParameterJdbcOperationsDependsOnPostProcessor
+  # enums
+  - org.openrewrite.java.spring.boot2.minorversion5.ApiVersion
+  - org.openrewrite.java.spring.boot2.minorversion5.EmbeddedDatabaseConnection
+  # exceptions
+  - org.openrewrite.java.spring.boot2.minorversion5.FlywayMigrationScriptMissingException
+  # methods
+  - org.openrewrite.java.spring.boot2.minorversion5.ConnectionFactoryBuilderDerivefrom
+  - org.openrewrite.java.spring.boot2.minorversion5.ApiVersionFromHttpHeaders
+  - org.openrewrite.java.spring.boot2.minorversion5.InvocationContextGetApiVersion
+  - org.openrewrite.java.spring.boot2.minorversion5.ArtemisPropertiesGetHost
+  - org.openrewrite.java.spring.boot2.minorversion5.BatchPropertiesGetInitializeSchema
+  - org.openrewrite.java.spring.boot2.minorversion5.ArtemisPropertiesGetPort
+  - org.openrewrite.java.spring.boot2.minorversion5.BatchPropertiesGetSchema
+  - org.openrewrite.java.spring.boot2.minorversion5.InvocationContextGetSecurityContext
+  - org.openrewrite.java.spring.boot2.minorversion5.BatchPropertiesGetTablePrefix
+  - org.openrewrite.java.spring.boot2.minorversion5.FlywayPropertiesIsCreateDataSource
+  - org.openrewrite.java.spring.boot2.minorversion5.WebFluxTagsOutcome
+
+########################################################################################################################
+# Deprecated classes
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.spring.boot2.minorversion5.ActuatorMediaType
+displayName: "Mark `org.springframework.boot.actuate.endpoint.http.ActuatorMediaType` as deprecated"
+description: "`ActuatorMediaType` is deprecated in 2.5.0 for removal in 2.7."
+recipeList:
+  - org.openrewrite.java.spring.boot2.MarkDeprecatedAPIs:
+      sourceOfDeprecation: Spring Boot 2
+      deprecatedType: class
+      searchPattern: org.springframework.boot.actuate.endpoint.http.ActuatorMediaType
+      deprecationComment: Deprecated since 2.5.0 for removal in 2.7.0 in favor of ApiVersion.getProducedMimeType().
+      deprecatedLink: https://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/actuate/endpoint/http/ActuatorMediaType.html
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.spring.boot2.minorversion5.ConnectionFactoryBuilder
+displayName: "Mark `org.springframework.boot.autoconfigure.r2dbc.ConnectionFactoryBuilder` as deprecated"
+description: "`ConnectionFactoryBuilder` is deprecated in 2.5.0 for removal in 2.7."
+recipeList:
+  - org.openrewrite.java.spring.boot2.MarkDeprecatedAPIs:
+      sourceOfDeprecation: Spring Boot 2
+      deprecatedType: class
+      searchPattern: org.springframework.boot.autoconfigure.r2dbc.ConnectionFactoryBuilder
+      deprecationComment: Deprecated since 2.5.0 for removal in 2.7.0 in favor of ConnectionFactoryBuilder.
+      deprecatedLink: https://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/autoconfigure/r2dbc/ConnectionFactoryBuilder.html
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.spring.boot2.minorversion5.DataSourceSchemaCreatedEvent
+displayName: "Mark `org.springframework.boot.autoconfigure.jdbc.DataSourceSchemaCreatedEvent` as deprecated"
+description: "`DataSourceSchemaCreatedEvent` is deprecated in 2.5.0 for removal in 2.7."
+recipeList:
+  - org.openrewrite.java.spring.boot2.MarkDeprecatedAPIs:
+      sourceOfDeprecation: Spring Boot 2
+      deprecatedType: class
+      searchPattern: org.springframework.boot.autoconfigure.jdbc.DataSourceSchemaCreatedEvent
+      deprecationComment: Deprecated since 2.5.0 for removal in 2.7.0 with no replacement as the event is no longer published.
+      deprecatedLink: https://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/autoconfigure/jdbc/DataSourceSchemaCreatedEvent.html
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.spring.boot2.minorversion5.DslContextDependsOnPostProcessor
+displayName: "Mark `org.springframework.boot.autoconfigure.jooq.DslContextDependsOnPostProcessor` as deprecated"
+description: "`DslContextDependsOnPostProcessor` is deprecated in 2.5.0 for removal in 2.7."
+recipeList:
+  - org.openrewrite.java.spring.boot2.MarkDeprecatedAPIs:
+      sourceOfDeprecation: Spring Boot 2
+      deprecatedType: class
+      searchPattern: org.springframework.boot.autoconfigure.jooq.DslContextDependsOnPostProcessor
+      deprecationComment: Deprecated since 2.5.0 for removal in 2.7.0 in favor of DependsOnDatabaseInitializationDetector.
+      deprecatedLink: https://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/autoconfigure/jooq/DslContextDependsOnPostProcessor.html
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.spring.boot2.minorversion5.EntityManagerFactoryDependsOnPostProcessor
+displayName: "Mark `org.springframework.boot.autoconfigure.data.jpa.EntityManagerFactoryDependsOnPostProcessor` as deprecated"
+description: "`EntityManagerFactoryDependsOnPostProcessor` is deprecated in 2.5.0 for removal in 2.7."
+recipeList:
+  - org.openrewrite.java.spring.boot2.MarkDeprecatedAPIs:
+      sourceOfDeprecation: Spring Boot 2
+      deprecatedType: class
+      searchPattern: org.springframework.boot.autoconfigure.data.jpa.EntityManagerFactoryDependsOnPostProcessor
+      deprecationComment: Deprecated since 2.5.0 for removal in 2.7.0 in favor of EntityManagerFactoryDependsOnPostProcessor.
+      deprecatedLink: https://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/autoconfigure/data/jpa/EntityManagerFactoryDependsOnPostProcessor.html
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.spring.boot2.minorversion5.HypermediaHttpMessageConverterConfiguration
+displayName: "Mark `org.springframework.boot.autoconfigure.hateoas.HypermediaHttpMessageConverterConfiguration` as deprecated"
+description: "`HypermediaHttpMessageConverterConfiguration` is deprecated in 2.5.0 for removal in 2.7."
+recipeList:
+  - org.openrewrite.java.spring.boot2.MarkDeprecatedAPIs:
+      sourceOfDeprecation: Spring Boot 2
+      deprecatedType: class
+      searchPattern: org.springframework.boot.autoconfigure.hateoas.HypermediaHttpMessageConverterConfiguration
+      deprecationComment: Deprecated since 2.5.0 for removal in 2.7.0 in favor of a HalConfiguration bean.
+      deprecatedLink: https://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/autoconfigure/hateoas/HypermediaHttpMessageConverterConfiguration.html
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.spring.boot2.minorversion5.JdbcOperationsDependsOnPostProcessor
+displayName: "Mark `org.springframework.boot.autoconfigure.jdbc.JdbcOperationsDependsOnPostProcessor` as deprecated"
+description: "`JdbcOperationsDependsOnPostProcessor` is deprecated in 2.5.0 for removal in 2.7."
+recipeList:
+  - org.openrewrite.java.spring.boot2.MarkDeprecatedAPIs:
+      sourceOfDeprecation: Spring Boot 2
+      deprecatedType: class
+      searchPattern: org.springframework.boot.autoconfigure.jdbc.JdbcOperationsDependsOnPostProcessor
+      deprecationComment: Deprecated since 2.5.0 for removal in 2.7.0 in favor of DependsOnDatabaseInitializationDetector.
+      deprecatedLink: https://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/autoconfigure/jdbc/JdbcOperationsDependsOnPostProcessor.html
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.spring.boot2.minorversion5.MustacheEnvironmentCollector
+displayName: "Mark `org.springframework.boot.autoconfigure.mustache.MustacheEnvironmentCollector` as deprecated"
+description: "`MustacheEnvironmentCollector` is deprecated in 2.5.0 for removal in 2.7."
+recipeList:
+  - org.openrewrite.java.spring.boot2.MarkDeprecatedAPIs:
+      sourceOfDeprecation: Spring Boot 2
+      deprecatedType: class
+      searchPattern: org.springframework.boot.autoconfigure.mustache.MustacheEnvironmentCollector
+      deprecationComment: Deprecated since 2.5.0 for removal in 2.7.0 in favor of direct addition of values from the Environment to the model.
+      deprecatedLink: https://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/autoconfigure/jdbc/JdbcOperationsDependsOnPostProcessor.html
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.spring.boot2.minorversion5.NamedParameterJdbcOperationsDependsOnPostProcessor
+displayName: "Mark `org.springframework.boot.autoconfigure.jdbc.NamedParameterJdbcOperationsDependsOnPostProcessor` as deprecated"
+description: "`NamedParameterJdbcOperationsDependsOnPostProcessor` is deprecated in 2.5.0 for removal in 2.7."
+recipeList:
+  - org.openrewrite.java.spring.boot2.MarkDeprecatedAPIs:
+      sourceOfDeprecation: Spring Boot 2
+      deprecatedType: class
+      searchPattern: org.springframework.boot.autoconfigure.jdbc.NamedParameterJdbcOperationsDependsOnPostProcessor
+      deprecationComment: Deprecated since 2.5.0 for removal in 2.7.0 in favor of DependsOnDatabaseInitializationDetector.
+      deprecatedLink: https://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/autoconfigure/jdbc/NamedParameterJdbcOperationsDependsOnPostProcessor.html
+
+########################################################################################################################
+# Deprecated enums
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.spring.boot2.minorversion5.ApiVersion
+displayName: "Mark `org.springframework.boot.actuate.endpoint.http.ApiVersion` as deprecated"
+description: "`ApiVersion` is deprecated in 2.5.0 for removal in 2.7."
+recipeList:
+  - org.openrewrite.java.spring.boot2.MarkDeprecatedAPIs:
+      sourceOfDeprecation: Spring Boot 2
+      deprecatedType: enum
+      searchPattern: org.springframework.boot.actuate.endpoint.http.ApiVersion
+      deprecationComment: Deprecated since 2.5.0 for removal in 2.7.0 in favor of ApiVersion.
+      deprecatedLink: https://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/actuate/endpoint/http/ApiVersion.html
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.spring.boot2.minorversion5.EmbeddedDatabaseConnection
+displayName: "Mark `org.springframework.boot.autoconfigure.r2dbc.EmbeddedDatabaseConnection` as deprecated"
+description: "`EmbeddedDatabaseConnection` is deprecated in 2.5.0 for removal in 2.7."
+recipeList:
+  - org.openrewrite.java.spring.boot2.MarkDeprecatedAPIs:
+      sourceOfDeprecation: Spring Boot 2
+      deprecatedType: enum
+      searchPattern: org.springframework.boot.autoconfigure.r2dbc.EmbeddedDatabaseConnection
+      deprecationComment: Deprecated since 2.5.0 for removal in 2.7.0 in favor of EmbeddedDatabaseConnection.
+      deprecatedLink: https://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/autoconfigure/r2dbc/EmbeddedDatabaseConnection.html
+
+########################################################################################################################
+# Deprecated exceptions
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.spring.boot2.minorversion5.FlywayMigrationScriptMissingException
+displayName: "Mark `org.springframework.boot.autoconfigure.flyway.FlywayMigrationScriptMissingException` as deprecated"
+description: "`FlywayMigrationScriptMissingException` is deprecated in 2.5.0 for removal in 2.7."
+recipeList:
+  - org.openrewrite.java.spring.boot2.MarkDeprecatedAPIs:
+      sourceOfDeprecation: Spring Boot 2
+      deprecatedType: exception
+      searchPattern: org.springframework.boot.autoconfigure.flyway.FlywayMigrationScriptMissingException
+      deprecationComment: Deprecated since 2.5.0 for removal in 2.7.0 as location checking is deprecated.
+      deprecatedLink: https://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/autoconfigure/flyway/FlywayMigrationScriptMissingException.html
+
+########################################################################################################################
+# Deprecated methods
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.spring.boot2.minorversion5.ConnectionFactoryBuilderDerivefrom
+displayName: "Mark `org.springframework.boot.r2dbc.ConnectionFactoryBuilder.derivefrom(ConnectionFactory)` as deprecated"
+description: "`ConnectionFactoryBuilder.derivefrom(ConnectionFactory)` is deprecated in 2.5.1 for removal in 2.7."
+recipeList:
+  - org.openrewrite.java.spring.boot2.MarkDeprecatedAPIs:
+      sourceOfDeprecation: Spring Boot 2
+      deprecatedType: classMethod
+      searchPattern: org.springframework.boot.r2dbc.ConnectionFactoryBuilder derivefrom(io.r2dbc.spi.ConnectionFactory connectionFactory)
+      deprecationComment: Deprecated since 2.5.1 for removal in 2.7.0 in favor of ConnectionFactoryBuilder.derivedFrom(ConnectionFactory).
+      deprecatedLink: https://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/r2dbc/ConnectionFactoryBuilder.html#derivefrom-io.r2dbc.spi.ConnectionFactory-
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.spring.boot2.minorversion5.ApiVersionFromHttpHeaders
+displayName: "Mark `org.springframework.boot.actuate.endpoint.http.ApiVersion.fromHttpHeaders(Map<String, List<String>>)` as deprecated"
+description: "`ApiVersion.fromHttpHeaders(Map<String, List<String>>)` is deprecated in 2.5.0 for removal in 2.7."
+recipeList:
+  - org.openrewrite.java.spring.boot2.MarkDeprecatedAPIs:
+      sourceOfDeprecation: Spring Boot 2
+      deprecatedType: enumMethod
+      searchPattern: org.springframework.boot.actuate.endpoint.http.ApiVersion fromHttpHeaders(..)
+      deprecationComment: Deprecated since 2.5.0 for removal in 2.7.0 in favor of direct injection with resolution via the ProducibleOperationArgumentResolver.
+      deprecatedLink: https://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/actuate/endpoint/http/ApiVersion.html#fromHttpHeaders-java.util.Map-
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.spring.boot2.minorversion5.InvocationContextGetApiVersion
+displayName: "Mark `org.springframework.boot.actuate.endpoint.InvocationContext.getApiVersion()` as deprecated"
+description: "`InvocationContext.getApiVersion()` is deprecated in 2.5.0 for removal in 2.7."
+recipeList:
+  - org.openrewrite.java.spring.boot2.MarkDeprecatedAPIs:
+      sourceOfDeprecation: Spring Boot 2
+      deprecatedType: classMethod
+      searchPattern: org.springframework.boot.actuate.endpoint.InvocationContext getApiVersion()
+      deprecationComment: Deprecated since 2.5.0 for removal in 2.7.0 in favor of InvocationContext.resolveArgument(Class) using ApiVersion.
+      deprecatedLink: https://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/actuate/endpoint/InvocationContext.html#getApiVersion--
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.spring.boot2.minorversion5.ArtemisPropertiesGetHost
+displayName: "Mark `org.springframework.boot.autoconfigure.jms.artemis.ArtemisProperties.getHost()` as deprecated"
+description: "`ArtemisProperties.getHost()` is deprecated in 2.5.0 for removal in 2.7."
+recipeList:
+  - org.openrewrite.java.spring.boot2.MarkDeprecatedAPIs:
+      sourceOfDeprecation: Spring Boot 2
+      deprecatedType: classMethod
+      searchPattern: org.springframework.boot.autoconfigure.jms.artemis.ArtemisProperties getHost()
+      deprecationComment: Deprecated since 2.5.0 for removal in 2.7.0 in favor of broker url.
+      deprecatedLink: https://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/autoconfigure/jms/artemis/ArtemisProperties.html#getHost--
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.spring.boot2.minorversion5.BatchPropertiesGetInitializeSchema
+displayName: "Mark `org.springframework.boot.autoconfigure.batch.BatchProperties.getInitializeSchema()` as deprecated"
+description: "`BatchProperties.getInitializeSchema()` is deprecated in 2.5.0 for removal in 2.7."
+recipeList:
+  - org.openrewrite.java.spring.boot2.MarkDeprecatedAPIs:
+      sourceOfDeprecation: Spring Boot 2
+      deprecatedType: classMethod
+      searchPattern: org.springframework.boot.autoconfigure.batch.BatchProperties getInitializeSchema()
+      deprecationComment: Deprecated since 2.5.0 for removal in 2.7.0 in favor of BatchProperties.Jdbc.getInitializeSchema().
+      deprecatedLink: https://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/autoconfigure/batch/BatchProperties.html#getInitializeSchema--
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.spring.boot2.minorversion5.ArtemisPropertiesGetPort
+displayName: "Mark `org.springframework.boot.autoconfigure.jms.artemis.ArtemisProperties.getPort()` as deprecated"
+description: "`ArtemisProperties.getPort()` is deprecated in 2.5.0 for removal in 2.7."
+recipeList:
+  - org.openrewrite.java.spring.boot2.MarkDeprecatedAPIs:
+      sourceOfDeprecation: Spring Boot 2
+      deprecatedType: classMethod
+      searchPattern: org.springframework.boot.autoconfigure.jms.artemis.ArtemisProperties getPort()
+      deprecationComment: Deprecated since 2.5.0 for removal in 2.7.0 in favor of broker url.
+      deprecatedLink: https://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/autoconfigure/jms/artemis/ArtemisProperties.html#getPort--
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.spring.boot2.minorversion5.BatchPropertiesGetSchema
+displayName: "Mark `org.springframework.boot.autoconfigure.batch.BatchProperties.getSchema()` as deprecated"
+description: "`BatchProperties.getSchema()` is deprecated in 2.5.0 for removal in 2.7."
+recipeList:
+  - org.openrewrite.java.spring.boot2.MarkDeprecatedAPIs:
+      sourceOfDeprecation: Spring Boot 2
+      deprecatedType: classMethod
+      searchPattern: org.springframework.boot.autoconfigure.batch.BatchProperties getSchema()
+      deprecationComment: Deprecate since 2.5.0 for removal in 2.7.0 in favor of BatchProperties.Jdbc.getSchema().
+      deprecatedLink: https://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/autoconfigure/batch/BatchProperties.html#getSchema--
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.spring.boot2.minorversion5.InvocationContextGetSecurityContext
+displayName: "Mark `org.springframework.boot.actuate.endpoint.InvocationContext.getSecurityContext()` as deprecated"
+description: "`InvocationContext.getSecurityContext()` is deprecated in 2.5.0 for removal in 2.7."
+recipeList:
+  - org.openrewrite.java.spring.boot2.MarkDeprecatedAPIs:
+      sourceOfDeprecation: Spring Boot 2
+      deprecatedType: classMethod
+      searchPattern: org.springframework.boot.actuate.endpoint.InvocationContext getSecurityContext()
+      deprecationComment: Deprecate since 2.5.0 for removal in 2.7.0 in favor of InvocationContext.resolveArgument(Class).
+      deprecatedLink: https://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/actuate/endpoint/InvocationContext.html#getSecurityContext--
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.spring.boot2.minorversion5.BatchPropertiesGetTablePrefix
+displayName: "Mark `org.springframework.boot.autoconfigure.batch.BatchProperties.getTablePrefix()` as deprecated"
+description: "`BatchProperties.getTablePrefix()` is deprecated in 2.5.0 for removal in 2.7."
+recipeList:
+  - org.openrewrite.java.spring.boot2.MarkDeprecatedAPIs:
+      sourceOfDeprecation: Spring Boot 2
+      deprecatedType: classMethod
+      searchPattern: org.springframework.boot.autoconfigure.batch.BatchProperties getTablePrefix()
+      deprecationComment: Deprecate since 2.5.0 for removal in 2.7.0 in favor of BatchProperties.Jdbc.getTablePrefix().
+      deprecatedLink: https://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/autoconfigure/batch/BatchProperties.html#getTablePrefix--
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.spring.boot2.minorversion5.FlywayPropertiesIsCreateDataSource
+displayName: "Mark `org.springframework.boot.autoconfigure.flyway.FlywayProperties isCreateDataSource()` as deprecated"
+description: "`FlywayProperties isCreateDataSource()` is deprecated in 2.5.0 for removal in 2.7."
+recipeList:
+  - org.openrewrite.java.spring.boot2.MarkDeprecatedAPIs:
+      sourceOfDeprecation: Spring Boot 2
+      deprecatedType: classMethod
+      searchPattern: org.springframework.boot.autoconfigure.flyway.FlywayProperties isCreateDataSource()
+      deprecationComment: Deprecate since 2.5.0 for removal in 2.7.0 in favor of directly checking user and url.
+      deprecatedLink: https://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/autoconfigure/flyway/FlywayProperties.html#isCreateDataSource--
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.spring.boot2.minorversion5.WebFluxTagsOutcome
+displayName: "Mark `org.springframework.boot.actuate.metrics.web.reactive.server.WebFluxTags.outcome(ServerWebExchange)` as deprecated"
+description: "`WebFluxTags.outcome(ServerWebExchange)` is deprecated in 2.5.0 for removal in 2.7."
+recipeList:
+  - org.openrewrite.java.spring.boot2.MarkDeprecatedAPIs:
+      sourceOfDeprecation: Spring Boot 2
+      deprecatedType: classMethod
+      searchPattern: org.springframework.boot.actuate.metrics.web.reactive.server.WebFluxTags outcome(org.springframework.web.server.ServerWebExchange)
+      deprecationComment: Deprecate since 2.5.0 for removal in 2.7.0 in favor of WebFluxTags.outcome(ServerWebExchange, Throwable).
+      deprecatedLink: https://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/actuate/metrics/web/reactive/server/WebFluxTags.html#outcome-org.springframework.web.server.ServerWebExchange-

--- a/src/test/kotlin/org/openrewrite/java/spring/MarkDeprecatedAPIsTest.kt
+++ b/src/test/kotlin/org/openrewrite/java/spring/MarkDeprecatedAPIsTest.kt
@@ -1,0 +1,477 @@
+/*
+ * Copyright 2020 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.spring.org.openrewrite.java.spring
+
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Test
+import org.openrewrite.java.JavaRecipeTest
+import org.openrewrite.java.spring.boot2.MarkDeprecatedAPIs
+
+class MarkDeprecatedAPIsTest : JavaRecipeTest {
+
+    @Test
+    fun markClassMethod() = assertChanged(
+        recipe = MarkDeprecatedAPIs(
+            "org.example in 4.10.0",
+            "classMethod",
+            "java.util.List add(..)",
+            "use version x",
+            "https://link.here"
+        ),
+        before = """
+            package org.test;
+
+            import java.util.ArrayList;
+            import java.util.List;
+            
+            public class Test {
+                public void method() {
+                    List<Integer> example = new ArrayList<>();
+                    example.add(1000);
+                }
+            }
+        """,
+        after = """
+            package org.test;
+
+            import java.util.ArrayList;
+            import java.util.List;
+            
+            public class Test {
+                public void method() {
+                    List<Integer> example = new ArrayList<>();
+                    /*~~> Source of classMethod deprecation: org.example in 4.10.0. Reason: use version x. Link: https://link.here. ~~*/example.add(1000);
+                }
+            }
+        """
+    )
+
+    @Test
+    fun markFieldConstant() = assertChanged(
+        recipe = MarkDeprecatedAPIs(
+            "org.example in 4.10.0",
+            "fieldConstant",
+            "org.a.Constants.VALUE",
+            "use version x",
+            "https://link.here"
+        ),
+        dependsOn = arrayOf("""
+            package org.a;
+            public class Constants {
+                public static final int VALUE = 1000;
+            }
+        """),
+        before = """
+            package org.test;
+
+            import org.a.Constants;
+
+            public class Test {
+                public void method() {
+                    int i = Constants.VALUE;
+                }
+            }
+        """,
+        after = """
+            package org.test;
+
+            import org.a.Constants;
+            
+            public class Test {
+                public void method() {
+                    int i = /*~~> Source of fieldConstant deprecation: org.example in 4.10.0. Reason: use version x. Link: https://link.here. ~~*/Constants.VALUE;
+                }
+            }
+        """
+    )
+
+    @Test
+    fun markStaticFieldConstant() = assertChanged(
+        recipe = MarkDeprecatedAPIs(
+            "org.example in 4.10.0",
+            "fieldConstant",
+            "org.a.Constants.VALUE",
+            "use version x",
+            "https://link.here"
+        ),
+        dependsOn = arrayOf("""
+            package org.a;
+            public class Constants {
+                public static final int VALUE = 1000;
+            }
+        """),
+        before = """
+            package org.test;
+
+            import static org.a.Constants.VALUE;
+
+            public class Test {
+                public void method() {
+                    int i = VALUE;
+                }
+            }
+        """,
+        after = """
+            package org.test;
+
+            import static org.a.Constants.VALUE;
+            
+            public class Test {
+                public void method() {
+                    int i = /*~~> Source of fieldConstant deprecation: org.example in 4.10.0. Reason: use version x. Link: https://link.here. ~~*/VALUE;
+                }
+            }
+        """
+    )
+
+    @Test
+    fun markInterface() = assertChanged(
+        recipe = MarkDeprecatedAPIs(
+            "org.example in 4.10.0",
+            "interface",
+            "org.test.AnInterface",
+            "use version x",
+            "https://link.here"
+        ),
+        dependsOn = arrayOf("""
+            package org.test;
+            
+            public interface AnInterface {
+                void method();
+            }
+        """),
+        before = """
+            package org.test;
+
+            import java.util.ArrayList;
+            import java.util.List;
+            
+            public class Test implements AnInterface{
+                @Override
+                public void method() {
+                    List<Integer> example = new ArrayList<>();
+                    example.add(1000);
+                }
+            }
+        """,
+        after = """
+            package org.test;
+
+            import java.util.ArrayList;
+            import java.util.List;
+            
+            public class Test implements /*~~> Source of interface deprecation: org.example in 4.10.0. Reason: use version x. Link: https://link.here. ~~*/AnInterface{
+                @Override
+                public void method() {
+                    List<Integer> example = new ArrayList<>();
+                    example.add(1000);
+                }
+            }
+        """
+    )
+
+    @Disabled
+    @Test
+    fun markMethodInterface() = assertChanged(
+        recipe = MarkDeprecatedAPIs(
+            "org.example in 4.10.0",
+            "interfaceMethod",
+            "* method()",
+            "use version x",
+            "https://link.here"
+        ),
+        dependsOn = arrayOf("""
+            package org.test;
+            
+            public interface AnInterface {
+                void method();
+            }
+        """),
+        before = """
+            package org.test;
+
+            import java.util.ArrayList;
+            import java.util.List;
+            
+            public class Test implements AnInterface{
+                @Override
+                public void method() {
+                    List<Integer> example = new ArrayList<>();
+                    example.add(1000);
+                }
+            }
+        """,
+        after = """
+            package org.test;
+
+            import java.util.ArrayList;
+            import java.util.List;
+            
+            public class Test implements AnInterface{
+                @Override
+                public void /*~~> placeholder ~~*/method() {
+                    List<Integer> example = new ArrayList<>();
+                    example.add(1000);
+                }
+            }
+        """
+    )
+
+    @Test
+    fun markClass() = assertChanged(
+        recipe = MarkDeprecatedAPIs(
+            "org.example in 4.10.0",
+            "class",
+            "org.test.DeprecatedClass",
+            "use version x",
+            "https://link.here"
+        ),
+        dependsOn = arrayOf("""
+            package org.test;
+            
+            public class DeprecatedClass {}
+        """),
+        before = """
+            package org.test;
+            
+            public class Test {
+            
+                public void method() {
+                    DeprecatedClass deprecated = new DeprecatedClass();
+                }
+            }
+        """,
+        after = """
+            package org.test;
+            
+            public class Test {
+            
+                public void method() {
+                    /*~~> Source of class deprecation: org.example in 4.10.0. Reason: use version x. Link: https://link.here. ~~*/DeprecatedClass deprecated = new /*~~> Source of class deprecation: org.example in 4.10.0. Reason: use version x. Link: https://link.here. ~~*/DeprecatedClass();
+                }
+            }
+        """
+    )
+
+    @Disabled
+    @Test
+    fun markConstructor() = assertChanged(
+        recipe = MarkDeprecatedAPIs(
+            "org.example in 4.10.0",
+            "constructor",
+            "org.test.DeprecatedClass DeprecatedClass(java.lang.int, java.lang.boolean)",
+            "use version x",
+            "https://link.here"
+        ),
+        dependsOn = arrayOf("""
+            package org.test;
+            
+            public class DeprecatedClass {
+                public DeprecatedClass() {}
+                public DeprecatedClass(int valA, boolean valB) {}
+            }
+        """),
+        before = """
+            package org.test;
+            
+            public class Test {
+            
+                public void method() {
+                    int valA = 1;
+                    boolean valB = true;
+                    DeprecatedClass deprecated = new DeprecatedClass(valA, valB);
+                    deprecated = new DeprecatedClass();
+                }
+            }
+        """,
+        after = """
+            package org.test;
+            
+            public class Test {
+            
+                public void method() {
+                    int valA = 1, valB = 2;
+                    DeprecatedClass deprecated = new DeprecatedClass(valA, valB);
+                    deprecated = new DeprecatedClass();
+                }
+            }
+        """
+    )
+
+    @Test
+    fun markEnum() = assertChanged(
+        recipe = MarkDeprecatedAPIs(
+            "org.example in 4.10.0",
+            "enum",
+            "org.test.DeprecatedEnum",
+            "use version x",
+            "https://link.here"
+        ),
+        dependsOn = arrayOf("""
+            package org.test;
+            
+            public enum DeprecatedEnum { V_1, V_2, V_3 }
+        """),
+        before = """
+            package org.test;
+            
+            public class Test {
+            
+                public void method() {
+                    DeprecatedEnum value = DeprecatedEnum.V_1;
+                }
+            }
+        """,
+        after = """
+            package org.test;
+
+            public class Test {
+
+                public void method() {
+                    /*~~> Source of enum deprecation: org.example in 4.10.0. Reason: use version x. Link: https://link.here. ~~*/DeprecatedEnum value = /*~~> Source of enum deprecation: org.example in 4.10.0. Reason: use version x. Link: https://link.here. ~~*//*~~> Source of enum deprecation: org.example in 4.10.0. Reason: use version x. Link: https://link.here. ~~*/DeprecatedEnum.V_1;
+                }
+            }
+        """
+    )
+
+    @Test
+    fun enumValueReference() = assertChanged(
+        recipe = MarkDeprecatedAPIs(
+            "org.example in 4.10.0",
+            "enumConstant",
+            "org.a.DeprecatedEnum.V_1",
+            "use version x",
+            "https://link.here"
+        ),
+        dependsOn = arrayOf("""
+            package org.a;
+            
+            public enum DeprecatedEnum { V_1, V_2, V_3 }
+        """),
+        before = """
+            package org.test;
+            
+            import org.a.DeprecatedEnum;
+
+            public class Test {
+            
+                public void method() {
+                    DeprecatedEnum v1 = DeprecatedEnum.V_1;
+                }
+            }
+        """,
+        after = """
+            package org.test;
+            
+            import org.a.DeprecatedEnum;
+
+            public class Test {
+            
+                public void method() {
+                    DeprecatedEnum v1 = /*~~> Source of enumConstant deprecation: org.example in 4.10.0. Reason: use version x. Link: https://link.here. ~~*/DeprecatedEnum.V_1;
+                }
+            }
+        """
+    )
+
+    @Test
+    fun enumStaticValueReference() = assertChanged(
+        recipe = MarkDeprecatedAPIs(
+            "org.example in 4.10.0",
+            "enumConstant",
+            "org.a.DeprecatedEnum.V_2",
+            "use version x",
+            "https://link.here"
+        ),
+        dependsOn = arrayOf("""
+            package org.a;
+            
+            public enum DeprecatedEnum { V_1, V_2, V_3 }
+        """),
+        before = """
+            package org.test;
+            
+            import org.a.DeprecatedEnum;
+
+            import static org.a.DeprecatedEnum.V_2;
+
+            public class Test {
+            
+                public void method() {
+                    DeprecatedEnum v2 = V_2;
+                }
+            }
+        """,
+        after = """
+            package org.test;
+            
+            import org.a.DeprecatedEnum;
+
+            import static org.a.DeprecatedEnum.V_2;
+
+            public class Test {
+            
+                public void method() {
+                    DeprecatedEnum v2 = /*~~> Source of enumConstant deprecation: org.example in 4.10.0. Reason: use version x. Link: https://link.here. ~~*/V_2;
+                }
+            }
+        """
+    )
+
+    @Test
+    fun markException() = assertChanged(
+        recipe = MarkDeprecatedAPIs(
+            "org.example in 4.10.0",
+            "exception",
+            "org.test.DeprecatedException",
+            "use version x",
+            "https://link.here"
+        ),
+        dependsOn = arrayOf("""
+            package org.test;
+            
+            public class DeprecatedException extends Exception {}
+        """),
+        before = """
+            package org.test;
+            
+            public class Test {
+            
+                public void method() {
+                    try {
+                        int i = 1 + 2;
+                    } catch (DeprecatedException ex) {
+                        throw new RuntimeException("message", ex);
+                    }
+                }
+            }
+        """,
+        after = """
+            package org.test;
+            
+            public class Test {
+            
+                public void method() {
+                    try {
+                        int i = 1 + 2;
+                    } catch (/*~~> Source of exception deprecation: org.example in 4.10.0. Reason: use version x. Link: https://link.here. ~~*/DeprecatedException ex) {
+                        throw new RuntimeException("message", ex);
+                    }
+                }
+            }
+        """
+    )
+}

--- a/src/testWithSpringBoot_2_4/kotlin/org/openrewrite/java/spring/boot2/MarkDeprecated2MinorVersion4APIsTest.kt
+++ b/src/testWithSpringBoot_2_4/kotlin/org/openrewrite/java/spring/boot2/MarkDeprecated2MinorVersion4APIsTest.kt
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2020 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.spring.boot2
+
+import org.junit.jupiter.api.Test
+import org.openrewrite.Recipe
+import org.openrewrite.config.Environment
+import org.openrewrite.java.JavaParser
+import org.openrewrite.java.JavaRecipeTest
+
+class MarkDeprecatedSpringBoot2MinorVersion4APIsTest : JavaRecipeTest {
+    override val parser: JavaParser
+        get() = JavaParser.fromJavaVersion()
+            .classpath("spring-boot", "spring-context", "spring-core")
+            .logCompilationWarningsAndErrors(true)
+            .build()
+
+    override val recipe: Recipe
+        get() = Environment.builder()
+            .scanRuntimeClasspath()
+            .build()
+            .activateRecipes("org.openrewrite.java.spring.boot2.minorversion4.SpringApplicationBuilderContextClass")
+
+    @Test
+    fun markDeprecatedMethodTest() = assertChanged(
+        before = """
+            package org.test;
+
+            import org.springframework.boot.builder.SpringApplicationBuilder;
+            import org.springframework.context.support.GenericApplicationContext;
+
+            public class Test {
+                public void method() {
+                    SpringApplicationBuilder builder = new SpringApplicationBuilder(String.class);
+                    builder = builder.contextClass(GenericApplicationContext.class);
+                }
+            }
+        """,
+        after = """
+            package org.test;
+
+            import org.springframework.boot.builder.SpringApplicationBuilder;
+            import org.springframework.context.support.GenericApplicationContext;
+            
+            public class Test {
+                public void method() {
+                    SpringApplicationBuilder builder = new SpringApplicationBuilder(String.class);
+                    builder = /*~~> Source of classMethod deprecation: Spring Boot 2. Reason: Deprecated since 2.4.0 for removal in 2.6.0 in favor of SpringApplicationBuilder.contextFactory(ApplicationContextFactory).. Link: https://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/builder/SpringApplicationBuilder.html#contextClass-java.lang.Class-. ~~*/builder.contextClass(GenericApplicationContext.class);
+                }
+            }
+        """
+    )
+
+}


### PR DESCRIPTION
Added recipe to mark deprecated APIs in Spring Boot 2.3.
Added recipe to mark deprecated APIs in Spring Boot 2.4.
Added recipe to mark deprecated APIs in Spring Boot 2.5.