### PR TITLE
Spring Integration Scheduler Pool Size. Boot -> 2.5

### DIFF
--- a/src/main/java/org/openrewrite/java/spring/boot2/search/IntegrationSchedulerPoolRecipe.java
+++ b/src/main/java/org/openrewrite/java/spring/boot2/search/IntegrationSchedulerPoolRecipe.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright 2022 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.spring.boot2.search;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.SourceFile;
+import org.openrewrite.Tree;
+import org.openrewrite.internal.ListUtils;
+import org.openrewrite.java.AnnotationMatcher;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.marker.JavaProject;
+import org.openrewrite.java.tree.Comment;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.TextComment;
+import org.openrewrite.marker.Markers;
+import org.openrewrite.maven.MavenVisitor;
+import org.openrewrite.maven.tree.Maven;
+import org.openrewrite.maven.tree.Pom;
+import org.openrewrite.maven.tree.Scope;
+import org.openrewrite.properties.PropertiesVisitor;
+import org.openrewrite.properties.search.FindProperties;
+import org.openrewrite.properties.tree.Properties;
+import org.openrewrite.semver.DependencyMatcher;
+import org.openrewrite.yaml.YamlIsoVisitor;
+import org.openrewrite.yaml.search.FindProperty;
+import org.openrewrite.yaml.tree.Yaml;
+
+import java.util.*;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+/**
+ * @author Alex Boyko
+ */
+public class IntegrationSchedulerPoolRecipe extends Recipe {
+
+    private static Pattern APP_PROPS_FILE_REGEX = Pattern.compile("^application.*\\.properties$");
+    private static Pattern APP_YAML_FILE_REGEX = Pattern.compile("^application.*\\.ya?ml$");
+
+    private static final String PROPERTY_KEY = "spring.task.scheduling.pool.size";
+
+    private static final String PROPS_MIGRATION_MESSAGE = " TODO: Consider Scheduler thread pool size for Spring Integration";
+    private static final String GENERAL_MIGRATION_MESSAGE = " TODO: Scheduler thread pool size for Spring Integration either in properties or config server\n";
+
+    @Override
+    public String getDisplayName() {
+        return "Integration Sceduler Pool Size";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Spring Integration now reuses an available TaskScheduler rather than configuring its own. In a" +
+                " typical application setup relying on the auto-configuration, this means that Spring Integration" +
+                " uses the auto-configured task scheduler that has a pool size of 1. To restore Spring Integration’s" +
+                " default of 10 threads, use the spring.task.scheduling.pool.size property.";
+    }
+
+    private boolean isApplicableMavenProject(Maven maven) {
+        DependencyMatcher boot25Matcher = DependencyMatcher.build("org.springframework.boot:spring-boot:2.5.X").getValue();
+        DependencyMatcher integrationMatcher = DependencyMatcher.build("org.springframework.integration:spring-integration-core").getValue();
+        Collection<Pom.Dependency> deps = maven.getModel().getDependencies(Scope.Compile);
+        boolean boot25 = false;
+        boolean si = false;
+        for (Pom.Dependency d : deps) {
+            if (!boot25) {
+                boot25 = boot25Matcher.matches(d.getGroupId(), d.getArtifactId(), d.getVersion());
+            }
+            if (!si) {
+                si = integrationMatcher.matches(d.getGroupId(), d.getArtifactId());
+            }
+            if (boot25 && si) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    protected MavenVisitor getApplicableTest() {
+        return new MavenVisitor() {
+            @Override
+            public Maven visitMaven(Maven maven, ExecutionContext ctx) {
+                if (isApplicableMavenProject(maven)) {
+                  return maven.withMarkers(maven.getMarkers().searchResult());
+                }
+                return maven;
+            }
+        };
+    }
+
+    @Override
+    protected List<SourceFile> visit(List<SourceFile> before, ExecutionContext ctx) {
+        Set<JavaProject> javaProjects = before.stream()
+                .filter(Maven.class::isInstance)
+                .map(Maven.class::cast)
+                .filter(this::isApplicableMavenProject)
+                .map(m -> m.getMarkers().findFirst(JavaProject.class))
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .collect(Collectors.toSet());
+
+        Set<JavaProject> projectsWithCommentOverProperty = new HashSet<>();
+
+        // Leave the comment about scheduler pool size next to 'spring.task.scheduling.pool.size' property in the external properties file (props or yaml)
+        List<SourceFile> modified = ListUtils.map(before, source -> {
+            String fileName = source.getSourcePath().getFileName().toString();
+            JavaProject javaProject = source.getMarkers().findFirst(JavaProject.class).orElse(null);
+            if (javaProjects.contains(javaProject)) {
+                if (APP_PROPS_FILE_REGEX.matcher(fileName).matches() && source instanceof Properties) {
+                    Set<Properties.Entry> foundEntries = FindProperties.find((Properties) source, PROPERTY_KEY, false);
+                    if (!foundEntries.isEmpty()) {
+                        projectsWithCommentOverProperty.add(javaProject);
+                        // There should only be one exact match!
+                        Properties.Entry entry = foundEntries.iterator().next();
+                        return (SourceFile) new PropertiesVisitor<ExecutionContext>() {
+                            @Override
+                            public Properties visitFile(Properties.File file, ExecutionContext context) {
+                                int idx = file.getContent().indexOf(entry);
+                                if (idx >= 0) {
+                                    Properties.Comment comment = new Properties.Comment(Tree.randomId(), "\n", Markers.EMPTY, PROPS_MIGRATION_MESSAGE);
+                                    List<Properties.Content> contents = new ArrayList<>(file.getContent());
+                                    contents.add(idx, comment);
+                                    return file.withContent(contents);
+                                } else {
+                                    throw new RuntimeException("Entry must be present in the properties file!");
+                                }
+                            }
+                        }.visitNonNull(source, ctx);
+                    }
+                } else if (APP_YAML_FILE_REGEX.matcher(fileName).matches() && source instanceof Yaml) {
+                    Set<Yaml.Block> foundEntriesValues = FindProperty.find((Yaml) source, PROPERTY_KEY, false);
+                    if (!foundEntriesValues.isEmpty()) {
+                        projectsWithCommentOverProperty.add(javaProject);
+                        return (SourceFile) new YamlIsoVisitor<ExecutionContext>(){
+                            @Override
+                            public Yaml.Mapping.Entry visitMappingEntry(Yaml.Mapping.Entry entry, ExecutionContext context) {
+                                if (foundEntriesValues.contains(entry.getValue())) {
+                                    return entry.withPrefix("\n#" + PROPS_MIGRATION_MESSAGE + entry.getPrefix());
+                                }
+                                return super.visitMappingEntry(entry, context);
+                            }
+                        }.visitNonNull(source, ctx);
+                    }
+                }
+            }
+            return source;
+        });
+
+        javaProjects.removeAll(projectsWithCommentOverProperty);
+
+        // Leave generic comment next Boot Application main class declaration since no property value specified for thread pool size
+        modified = ListUtils.map(modified, source -> {
+            if (javaProjects.contains(source.getMarkers().findFirst(JavaProject.class).orElse(null))) {
+                AnnotationMatcher annotationMatcher = new AnnotationMatcher("@org.springframework.boot.autoconfigure.SpringBootApplication");
+                return (SourceFile) new JavaIsoVisitor<ExecutionContext>() {
+                    @Override
+                    public J.Annotation visitAnnotation(J.Annotation annotation, ExecutionContext context) {
+                        List<Comment> comments = new ArrayList<>(annotation.getComments());
+                        comments.add(new TextComment(false, GENERAL_MIGRATION_MESSAGE, "", Markers.EMPTY));
+                        return annotation.withComments(comments);
+                    }
+                }.visitNonNull(source, ctx);
+            }
+            return source;
+        });
+
+        return modified;
+    }
+
+}

--- a/src/test/kotlin/org/openrewrite/java/spring/boot2/search/IntegrationSchedulerPoolRecipeTest.kt
+++ b/src/test/kotlin/org/openrewrite/java/spring/boot2/search/IntegrationSchedulerPoolRecipeTest.kt
@@ -1,0 +1,536 @@
+/*
+ * Copyright 2022 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.spring.org.openrewrite.java.spring.boot2.search
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import org.openrewrite.InMemoryExecutionContext
+import org.openrewrite.java.JavaParser
+import org.openrewrite.java.spring.boot2.search.IntegrationSchedulerPoolRecipe
+import org.openrewrite.maven.MavenParser
+import org.openrewrite.maven.cache.InMemoryMavenPomCache
+import org.openrewrite.maven.cache.LocalMavenArtifactCache
+import org.openrewrite.maven.cache.ReadOnlyLocalMavenArtifactCache
+import org.openrewrite.maven.internal.MavenParsingException
+import org.openrewrite.maven.utilities.MavenArtifactDownloader
+import org.openrewrite.maven.utilities.MavenProjectParser
+import org.openrewrite.properties.PropertiesParser
+import java.io.File
+import java.nio.file.Paths
+import java.util.function.Consumer
+
+/**
+ * @author Alex Boyko
+ */
+class IntegrationSchedulerPoolRecipeTest {
+
+    @TempDir
+    var testFolder: File? = null
+
+    companion object {
+
+        var mavenProjectParser: MavenProjectParser? = null;
+
+        @BeforeAll
+        @JvmStatic
+        internal fun beforeAll() {
+            val errorConsumer = Consumer<Throwable> { t ->
+                if (t is MavenParsingException) {
+                    println("  ${t.message}")
+                } else {
+                    t.printStackTrace()
+                }
+            }
+
+            val downloader = MavenArtifactDownloader(
+                ReadOnlyLocalMavenArtifactCache.mavenLocal().orElse(
+                    LocalMavenArtifactCache(Paths.get(System.getProperty("user.home"), ".rewrite", "cache", "artifacts"))
+                ),
+                null,
+                errorConsumer
+            )
+
+            val pomCache = InMemoryMavenPomCache();
+
+            val mavenParserBuilder = MavenParser.builder()
+                .cache(pomCache);
+
+            mavenProjectParser = MavenProjectParser(
+                downloader,
+                mavenParserBuilder,
+                JavaParser.fromJavaVersion(),
+                InMemoryExecutionContext(errorConsumer)
+            )
+
+        }
+
+    }
+
+    @Test
+    fun wrongBootVersion() {
+
+        val pom = MavenParser.builder().build().parse(
+            """<?xml version="1.0" encoding="UTF-8"?>
+            <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+                <modelVersion>4.0.0</modelVersion>
+                <parent>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-starter-parent</artifactId>
+                    <version>2.4.13</version>
+                    <relativePath/> <!-- lookup parent from repository -->
+                </parent>
+                <groupId>com.example</groupId>
+                <artifactId>acme</artifactId>
+                <version>0.0.1-SNAPSHOT</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter</artifactId>
+                    </dependency>
+            
+                    <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-test</artifactId>
+                        <scope>test</scope>
+                    </dependency>
+                </dependencies>
+            </project>
+            """.trimIndent()).map{ it.withSourcePath(Paths.get("/project/pom.xml")) };
+
+        val props = PropertiesParser().parse("")
+            .map { it.withSourcePath(Paths.get("/project/src/main/resources/application.properties")) };
+
+        val results = IntegrationSchedulerPoolRecipe().run(pom + props);
+
+        assertThat(results.isEmpty()).isTrue();
+
+    }
+
+    @Test
+    fun noIntegrationDependency() {
+
+        val pom = MavenParser.builder().build().parse(
+            """<?xml version="1.0" encoding="UTF-8"?>
+            <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+                <modelVersion>4.0.0</modelVersion>
+                <parent>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-starter-parent</artifactId>
+                    <version>2.5.7</version>
+                    <relativePath/> <!-- lookup parent from repository -->
+                </parent>
+                <groupId>com.example</groupId>
+                <artifactId>acme</artifactId>
+                <version>0.0.1-SNAPSHOT</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter</artifactId>
+                    </dependency>
+            
+                    <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-test</artifactId>
+                        <scope>test</scope>
+                    </dependency>
+                </dependencies>
+            </project>
+            """.trimIndent()
+        ).map { it.withSourcePath(Paths.get("/project/pom.xml")) };
+
+        val props = PropertiesParser().parse("")
+            .map { it.withSourcePath(Paths.get("/project/src/main/resources/application.properties")) };
+
+        val results = IntegrationSchedulerPoolRecipe().run(pom + props)
+
+        assertThat(results.isEmpty()).isTrue();
+    }
+
+    @Test
+    fun noSchedulerProperty() {
+
+        val pom = File(testFolder, "pom.xml");
+        pom.writeText(
+            """<?xml version="1.0" encoding="UTF-8"?>
+            <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+                <modelVersion>4.0.0</modelVersion>
+                <parent>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-starter-parent</artifactId>
+                    <version>2.5.7</version>
+                    <relativePath/> <!-- lookup parent from repository -->
+                </parent>
+                <groupId>com.example</groupId>
+                <artifactId>acme</artifactId>
+                <version>0.0.1-SNAPSHOT</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter</artifactId>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-integration</artifactId>
+                    </dependency>
+            
+                    <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-test</artifactId>
+                        <scope>test</scope>
+                    </dependency>
+                </dependencies>
+            </project>
+            """
+        );
+
+        val props = File(testFolder, "/src/main/resources/application.properties");
+        props.parentFile.mkdirs();
+        props.writeText("server.port=5674");
+
+        val java = File(testFolder, "/src/main/java/demo/Example.java");
+        java.parentFile.mkdirs();
+        java.writeText(
+            """
+            package demo;
+            
+            import org.springframework.boot.SpringApplication;
+            import org.springframework.boot.autoconfigure.SpringBootApplication;
+            
+            @SpringBootApplication
+            public class ExampleApplication {
+            
+                public static void main(String[] args) {
+                    SpringApplication.run(ExampleApplication.class, args);
+                }
+            
+            }
+          """.trimIndent()
+        );
+
+        val sources = mavenProjectParser?.parse(pom.toPath().parent);
+
+        val results = IntegrationSchedulerPoolRecipe().run(sources)
+
+        assertThat(results.isEmpty()).isFalse();
+
+        assertThat(results.first().after.printAll()).isEqualTo(
+            """
+            package demo;
+            
+            import org.springframework.boot.SpringApplication;
+            import org.springframework.boot.autoconfigure.SpringBootApplication;
+            
+            // TODO: Scheduler thread pool size for Spring Integration either in properties or config server
+            @SpringBootApplication
+            public class ExampleApplication {
+            
+                public static void main(String[] args) {
+                    SpringApplication.run(ExampleApplication.class, args);
+                }
+            
+            }
+          """.trimIndent()
+        );
+
+    }
+
+    @Test
+    fun schedulerPropertyPresent() {
+
+        val pom = File(testFolder, "pom.xml");
+        pom.writeText(
+            """<?xml version="1.0" encoding="UTF-8"?>
+            <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+                <modelVersion>4.0.0</modelVersion>
+                <parent>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-starter-parent</artifactId>
+                    <version>2.5.7</version>
+                    <relativePath/> <!-- lookup parent from repository -->
+                </parent>
+                <groupId>com.example</groupId>
+                <artifactId>acme</artifactId>
+                <version>0.0.1-SNAPSHOT</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter</artifactId>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-integration</artifactId>
+                    </dependency>
+            
+                    <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-test</artifactId>
+                        <scope>test</scope>
+                    </dependency>
+                </dependencies>
+            </project>
+            """
+        );
+
+        val props = File(testFolder, "/src/main/resources/application.properties");
+        props.parentFile.mkdirs();
+        props.writeText(
+            "server.port=6473\n" +
+                    "spring.task.scheduling.pool.size=4\n" +
+                    "spring.application.name=demo\n"
+        );
+
+        val java = File(testFolder, "/src/main/java/demo/Example.java");
+        java.parentFile.mkdirs();
+        java.writeText(
+            """
+            package demo;
+            
+            import org.springframework.boot.SpringApplication;
+            import org.springframework.boot.autoconfigure.SpringBootApplication;
+            
+            @SpringBootApplication
+            public class ExampleApplication {
+            
+                public static void main(String[] args) {
+                    SpringApplication.run(ExampleApplication.class, args);
+                }
+            
+            }
+          """.trimIndent()
+        );
+
+        val sources = mavenProjectParser?.parse(pom.toPath().parent);
+
+        val results = IntegrationSchedulerPoolRecipe().run(sources)
+
+        assertThat(results.isEmpty()).isFalse();
+
+        assertThat(results.first().after.printAll()).isEqualTo(
+            "server.port=6473\n" +
+            "# TODO: Consider Scheduler thread pool size for Spring Integration\n" +
+            "spring.task.scheduling.pool.size=4\n" +
+            "spring.application.name=demo\n"
+        );
+
+    }
+
+    @Test
+    fun noSchedulerPropertyYaml() {
+
+        val pom = File(testFolder, "pom.xml");
+        pom.writeText(
+            """<?xml version="1.0" encoding="UTF-8"?>
+            <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+                <modelVersion>4.0.0</modelVersion>
+                <parent>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-starter-parent</artifactId>
+                    <version>2.5.7</version>
+                    <relativePath/> <!-- lookup parent from repository -->
+                </parent>
+                <groupId>com.example</groupId>
+                <artifactId>acme</artifactId>
+                <version>0.0.1-SNAPSHOT</version>
+                <properties>
+                    <java.version>11</java.version>
+                </properties>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter</artifactId>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-integration</artifactId>
+                    </dependency>
+            
+                    <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-test</artifactId>
+                        <scope>test</scope>
+                    </dependency>
+                </dependencies>
+            </project>
+            """
+        );
+
+        val props = File(testFolder, "/src/main/resources/application.yml");
+        props.parentFile.mkdirs();
+        props.writeText(
+            """
+                server:
+                  port: 4563
+            """.trimIndent()
+        );
+
+        val java = File(testFolder, "/src/main/java/demo/Example.java");
+        java.parentFile.mkdirs();
+        java.writeText(
+          """
+            package demo;
+            
+            import org.springframework.boot.SpringApplication;
+            import org.springframework.boot.autoconfigure.SpringBootApplication;
+            
+            @SpringBootApplication
+            public class ExampleApplication {
+            
+                public static void main(String[] args) {
+                    SpringApplication.run(ExampleApplication.class, args);
+                }
+            
+            }
+          """.trimIndent()
+        );
+
+        val sources = mavenProjectParser?.parse(pom.toPath().parent);
+
+        val results = IntegrationSchedulerPoolRecipe().run(sources)
+
+        assertThat(results.isEmpty()).isFalse();
+
+        assertThat(results.first().after.printAll()).isEqualTo(
+            """
+            package demo;
+            
+            import org.springframework.boot.SpringApplication;
+            import org.springframework.boot.autoconfigure.SpringBootApplication;
+            
+            // TODO: Scheduler thread pool size for Spring Integration either in properties or config server
+            @SpringBootApplication
+            public class ExampleApplication {
+            
+                public static void main(String[] args) {
+                    SpringApplication.run(ExampleApplication.class, args);
+                }
+            
+            }
+          """.trimIndent()
+        );
+
+    }
+
+    @Test
+    fun schedulerPropertyPresentYaml() {
+
+        val pom = File(testFolder, "pom.xml");
+        pom.writeText(
+            """<?xml version="1.0" encoding="UTF-8"?>
+            <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+                <modelVersion>4.0.0</modelVersion>
+                <parent>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-starter-parent</artifactId>
+                    <version>2.5.7</version>
+                    <relativePath/> <!-- lookup parent from repository -->
+                </parent>
+                <groupId>com.example</groupId>
+                <artifactId>acme</artifactId>
+                <version>0.0.1-SNAPSHOT</version>
+                <properties>
+                    <java.version>11</java.version>
+                </properties>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter</artifactId>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-integration</artifactId>
+                    </dependency>
+            
+                    <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-test</artifactId>
+                        <scope>test</scope>
+                    </dependency>
+                </dependencies>
+            </project>
+            """
+        );
+
+        val props = File(testFolder, "/src/main/resources/application.yml");
+        props.parentFile.mkdirs();
+        props.writeText(
+            """
+                server:
+                  port: 4563
+                spring:
+                  task:
+                    scheduling:
+                      foo: bar
+                      pool:
+                        size: 6
+                      bar: foo
+                  application:
+                    name: demo
+            """.trimIndent()
+        );
+
+        val java = File(testFolder, "/src/main/java/demo/Example.java");
+        java.parentFile.mkdirs();
+        java.writeText(
+            """
+            package demo;
+            
+            import org.springframework.boot.SpringApplication;
+            import org.springframework.boot.autoconfigure.SpringBootApplication;
+            
+            @SpringBootApplication
+            public class ExampleApplication {
+            
+                public static void main(String[] args) {
+                    SpringApplication.run(ExampleApplication.class, args);
+                }
+            
+            }
+          """.trimIndent()
+        );
+
+        val sources = mavenProjectParser?.parse(pom.toPath().parent);
+
+        val results = IntegrationSchedulerPoolRecipe().run(sources)
+
+        assertThat(results.isEmpty()).isFalse();
+
+        assertThat(results.first().after.printAll()).isEqualTo(
+            """
+                server:
+                  port: 4563
+                spring:
+                  task:
+                    scheduling:
+                      foo: bar
+                      pool:
+                # TODO: Consider Scheduler thread pool size for Spring Integration
+                        size: 6
+                      bar: foo
+                  application:
+                    name: demo
+            """.trimIndent()
+        );
+
+    }
+}


### PR DESCRIPTION
Fixes #138 

PR for initial feedback because there is usually plenty of feedback ;-)

(cc @fabapp2 )

If conditions are met comment made in `application.properties` file either over the `spring.task.scheduling.pool.size` property or just at the end if property not found. YAML properties still left to add.
