### PR TITLE
Boot version check fix. Annotation matching fix

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -173,7 +173,7 @@ dependencies {
     implementation("org.openrewrite:rewrite-maven:${rewriteVersion}")
 
     // for locating list of released Spring Boot versions
-    implementation("com.squareup.okhttp3:okhttp:latest.release")
+    implementation("com.squareup.okhttp3:okhttp:4+")
 
     // eliminates "unknown enum constant DeprecationLevel.WARNING" warnings from the build log
     // see https://github.com/gradle/kotlin-dsl-samples/issues/1301 for why (okhttp is leaking parts of kotlin stdlib)

--- a/src/main/java/org/openrewrite/java/spring/boot2/search/LoggingShutdownHooks.java
+++ b/src/main/java/org/openrewrite/java/spring/boot2/search/LoggingShutdownHooks.java
@@ -69,7 +69,7 @@ public class LoggingShutdownHooks extends Recipe {
                     return maven;
                 }
 
-                DependencyMatcher matcher = DependencyMatcher.build("org.springframework.boot:spring-boot:2.5.X").getValue();
+                DependencyMatcher matcher = DependencyMatcher.build("org.springframework.boot:spring-boot:2.4.X").getValue();
                 assert matcher != null;
                 for (Pom.Dependency d : maven.getModel().getDependencies(Scope.Compile)) {
                     if (matcher.matches(d.getGroupId(), d.getArtifactId(), d.getVersion())) {

--- a/src/test/kotlin/org/openrewrite/java/spring/boot2/search/IntegrationSchedulerPoolRecipeTest.kt
+++ b/src/test/kotlin/org/openrewrite/java/spring/boot2/search/IntegrationSchedulerPoolRecipeTest.kt
@@ -92,7 +92,7 @@ class IntegrationSchedulerPoolRecipeTest {
                 <parent>
                     <groupId>org.springframework.boot</groupId>
                     <artifactId>spring-boot-starter-parent</artifactId>
-                    <version>2.4.13</version>
+                    <version>2.5.7</version>
                     <relativePath/> <!-- lookup parent from repository -->
                 </parent>
                 <groupId>com.example</groupId>
@@ -133,7 +133,7 @@ class IntegrationSchedulerPoolRecipeTest {
                 <parent>
                     <groupId>org.springframework.boot</groupId>
                     <artifactId>spring-boot-starter-parent</artifactId>
-                    <version>2.5.7</version>
+                    <version>2.4.13</version>
                     <relativePath/> <!-- lookup parent from repository -->
                 </parent>
                 <groupId>com.example</groupId>
@@ -175,7 +175,7 @@ class IntegrationSchedulerPoolRecipeTest {
                 <parent>
                     <groupId>org.springframework.boot</groupId>
                     <artifactId>spring-boot-starter-parent</artifactId>
-                    <version>2.5.7</version>
+                    <version>2.4.13</version>
                     <relativePath/> <!-- lookup parent from repository -->
                 </parent>
                 <groupId>com.example</groupId>
@@ -213,6 +213,7 @@ class IntegrationSchedulerPoolRecipeTest {
             
             import org.springframework.boot.SpringApplication;
             import org.springframework.boot.autoconfigure.SpringBootApplication;
+            import org.springframework.context.annotation.Bean;
             
             @SpringBootApplication
             public class ExampleApplication {
@@ -221,6 +222,11 @@ class IntegrationSchedulerPoolRecipeTest {
                     SpringApplication.run(ExampleApplication.class, args);
                 }
             
+            	@Bean
+                public String hello() {
+                    return "hello";
+                }
+
             }
           """.trimIndent()
         );
@@ -237,6 +243,7 @@ class IntegrationSchedulerPoolRecipeTest {
             
             import org.springframework.boot.SpringApplication;
             import org.springframework.boot.autoconfigure.SpringBootApplication;
+            import org.springframework.context.annotation.Bean;
             
             // TODO: Scheduler thread pool size for Spring Integration either in properties or config server
             @SpringBootApplication
@@ -246,6 +253,11 @@ class IntegrationSchedulerPoolRecipeTest {
                     SpringApplication.run(ExampleApplication.class, args);
                 }
             
+            	@Bean
+                public String hello() {
+                    return "hello";
+                }
+
             }
           """.trimIndent()
         );
@@ -264,7 +276,7 @@ class IntegrationSchedulerPoolRecipeTest {
                 <parent>
                     <groupId>org.springframework.boot</groupId>
                     <artifactId>spring-boot-starter-parent</artifactId>
-                    <version>2.5.7</version>
+                    <version>2.4.13</version>
                     <relativePath/> <!-- lookup parent from repository -->
                 </parent>
                 <groupId>com.example</groupId>
@@ -345,7 +357,7 @@ class IntegrationSchedulerPoolRecipeTest {
                 <parent>
                     <groupId>org.springframework.boot</groupId>
                     <artifactId>spring-boot-starter-parent</artifactId>
-                    <version>2.5.7</version>
+                    <version>2.4.13</version>
                     <relativePath/> <!-- lookup parent from repository -->
                 </parent>
                 <groupId>com.example</groupId>
@@ -442,7 +454,7 @@ class IntegrationSchedulerPoolRecipeTest {
                 <parent>
                     <groupId>org.springframework.boot</groupId>
                     <artifactId>spring-boot-starter-parent</artifactId>
-                    <version>2.5.7</version>
+                    <version>2.4.13</version>
                     <relativePath/> <!-- lookup parent from repository -->
                 </parent>
                 <groupId>com.example</groupId>

--- a/src/test/kotlin/org/openrewrite/java/spring/boot2/search/LoggingShutdownHooksTest.kt
+++ b/src/test/kotlin/org/openrewrite/java/spring/boot2/search/LoggingShutdownHooksTest.kt
@@ -50,7 +50,7 @@ class LoggingShutdownHooksTest : MavenRecipeTest {
                 <parent>
                     <groupId>org.springframework.boot</groupId>
                     <artifactId>spring-boot-starter-parent</artifactId>
-                    <version>2.5.7</version>
+                    <version>2.4.13</version>
                     <relativePath/> <!-- lookup parent from repository -->
                 </parent>
                 <groupId>com.example</groupId>
@@ -73,7 +73,7 @@ class LoggingShutdownHooksTest : MavenRecipeTest {
                 <parent>
                     <groupId>org.springframework.boot</groupId>
                     <artifactId>spring-boot-starter-parent</artifactId>
-                    <version>2.5.7</version>
+                    <version>2.4.13</version>
                     <relativePath/> <!-- lookup parent from repository -->
                 </parent>
                 <groupId>com.example</groupId>
@@ -97,7 +97,7 @@ class LoggingShutdownHooksTest : MavenRecipeTest {
                 <parent>
                     <groupId>org.springframework.boot</groupId>
                     <artifactId>spring-boot-starter-parent</artifactId>
-                    <version>2.5.7</version>
+                    <version>2.4.13</version>
                     <relativePath/> <!-- lookup parent from repository -->
                 </parent>
                 <groupId>com.example</groupId>
@@ -121,7 +121,7 @@ class LoggingShutdownHooksTest : MavenRecipeTest {
                 <parent>
                     <groupId>org.springframework.boot</groupId>
                     <artifactId>spring-boot-starter-parent</artifactId>
-                    <version>2.4.9</version>
+                    <version>2.3.12</version>
                     <relativePath/> <!-- lookup parent from repository -->
                 </parent>
                 <groupId>com.example</groupId>
@@ -145,7 +145,7 @@ class LoggingShutdownHooksTest : MavenRecipeTest {
                 <parent>
                     <groupId>org.springframework.boot</groupId>
                     <artifactId>spring-boot-starter-parent</artifactId>
-                    <version>2.6.3</version>
+                    <version>2.5.7</version>
                     <relativePath/> <!-- lookup parent from repository -->
                 </parent>
                 <groupId>com.example</groupId>
@@ -161,7 +161,7 @@ class LoggingShutdownHooksTest : MavenRecipeTest {
             </project>
         """
     )
-    
+
     private fun assertLoggingShutdownHook(isOn: Boolean, before: String) {
         val sourceFiles = MavenParser.builder().build().parse(before).plus(application)
         assertThat(LoggingShutdownHooks().run(sourceFiles)).hasSize(if(isOn) 1 else 0)


### PR DESCRIPTION
- Fix boot version check. Should be 2.4.x rather thaan 2.5.x
- `@SpringBootApplication` annotation matcher created not used by accident