### PR TITLE
Upgrade spring-cloud-dependencies to 2021.0.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@ build/
 .idea/
 .boot-releases
 out/
+bin/
+.project
+.classpath
+.settings/

--- a/src/main/resources/META-INF/rewrite/spring-boot2-upgrade-version.yml
+++ b/src/main/resources/META-INF/rewrite/spring-boot2-upgrade-version.yml
@@ -256,7 +256,7 @@ name: org.openrewrite.java.spring.boot2.UpgradeSpringBoot_2_6
 displayName: Upgrade to Spring Boot 2.6
 description: 'Upgrade to Spring Boot 2.6 from any prior 2.x version.'
 recipeList:
-  # Upgrade to 2.6.x from 2.5.x
+  # Upgrade to 2.5.x from 2.4.x
   - org.openrewrite.java.spring.boot2.UpgradeSpringBoot_2_5
   # Upgrade to 2.6.x from 2.5.x
   - org.openrewrite.maven.UpgradeDependencyVersion:
@@ -271,3 +271,10 @@ recipeList:
   # Update properties
   - org.openrewrite.java.spring.boot2.SpringBootProperties_2_6
   - org.openrewrite.java.spring.boot2.SpringBootPropertiesManual_2_6
+  
+  # Upgrade spring-cloud-dependencies release train
+  - org.openrewrite.maven.UpgradeDependencyVersion:
+      groupId: org.springframework.cloud
+      artifactId: "spring-cloud-dependencies"
+      newVersion: 2021.0.2
+      overrideManagedVersion: true


### PR DESCRIPTION
Fixes #181

Not 100% sure if `UpgradeDependencyVersion` also supports a `dependencyManagement` BOM import, but figured worth a try. Otherwise any feedback here should point to what is actually needed.

The goal would be to replace the version number as it appears below from (likely) 2020.0.5 to 2021.0.2, regardless of whether it's managed as a property or directly included.
```
<dependencyManagement>
    <dependencies>
        <dependency>
            <groupId>org.springframework.cloud</groupId>
            <artifactId>spring-cloud-dependencies</artifactId>
            <version>${spring.cloud-version}</version>
            <type>pom</type>
            <scope>import</scope>
        </dependency>
    </dependencies>
</dependencyManagement>
```