### PR TITLE
Boot 3: Remove @ConstructorBinding annotation 

### DIFF
--- a/src/main/java/org/openrewrite/java/spring/boot3/RemoveConstructorBindingAnnotation.java
+++ b/src/main/java/org/openrewrite/java/spring/boot3/RemoveConstructorBindingAnnotation.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2022 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.spring.boot3;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.internal.ListUtils;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaType;
+import org.openrewrite.java.tree.TypeUtils;
+
+/**
+ * @author Alex Boyko
+ */
+public class RemoveConstructorBindingAnnotation extends Recipe {
+
+    private static final String ANNOTATION_CONSTRUCTOR_BINDING = "org.springframework.boot.context.properties.ConstructorBinding";
+    private static final String ANNOTATION_CONFIG_PROPERTIES = "org.springframework.boot.context.properties.ConfigurationProperties";
+
+    @Override
+    public String getDisplayName() {
+        return "Remove Unnecessary @ConstructorBinding";
+    }
+
+    @Override
+    public String getDescription() {
+        return "As of Boot 3.0 @ConstructorBinding is no longer needed at the type level on @ConfigurationProperties classes and should be removed.";
+    }
+
+    @Override
+    public JavaIsoVisitor<ExecutionContext> getVisitor() {
+        return new JavaIsoVisitor<ExecutionContext>() {
+            @Override
+            public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration classDecl, ExecutionContext context) {
+                boolean isConfigPropsAnnotationPresent = classDecl.getLeadingAnnotations().stream().filter(a -> {
+                    JavaType.FullyQualified fqType = TypeUtils.asFullyQualified(a.getType());
+                    if (fqType != null && ANNOTATION_CONFIG_PROPERTIES.equals(fqType.getFullyQualifiedName())) {
+                        return true;
+                    }
+                    return false;
+                }).findFirst().isPresent();
+                J.ClassDeclaration c = super.visitClassDeclaration(classDecl, context);
+                if (isConfigPropsAnnotationPresent) {
+                    c = c.withLeadingAnnotations(ListUtils.map(c.getLeadingAnnotations(), anno -> {
+                        if (TypeUtils.isOfClassType(anno.getType(), ANNOTATION_CONSTRUCTOR_BINDING)) {
+                            maybeRemoveImport(ANNOTATION_CONSTRUCTOR_BINDING);
+                            return null;
+                        }
+                        return anno;
+                    }));
+                }
+                return c;
+            }
+        };
+    }
+
+}

--- a/src/testWithSpringBoot_2_4/kotlin/org/openrewrite/java/spring/boot3/RemoveConstructorBindingAnnotationTest.kt
+++ b/src/testWithSpringBoot_2_4/kotlin/org/openrewrite/java/spring/boot3/RemoveConstructorBindingAnnotationTest.kt
@@ -1,0 +1,208 @@
+/*
+ * Copyright 2022 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.spring.boot3
+
+import org.junit.jupiter.api.Test
+import org.openrewrite.Recipe
+import org.openrewrite.java.JavaParser
+import org.openrewrite.java.JavaRecipeTest
+
+/**
+ * @author Alex Boyko
+ */
+class RemoveConstructorBindingAnnotationTest : JavaRecipeTest {
+
+    override val parser: JavaParser
+        get() = JavaParser.fromJavaVersion()
+            .logCompilationWarningsAndErrors(true)
+            .classpath("spring-boot")
+            .build()
+
+    override val recipe: Recipe
+        get() = RemoveConstructorBindingAnnotation()
+
+
+    @Test
+    fun topLevelTypeAnnotation() = assertChanged(
+        before = """
+            import org.springframework.boot.context.properties.ConfigurationProperties;
+            import org.springframework.boot.context.properties.ConstructorBinding;
+            
+            @ConfigurationProperties
+            @ConstructorBinding
+            class A {
+                void method() {
+                }
+            }
+        """,
+        after = """
+            import org.springframework.boot.context.properties.ConfigurationProperties;
+            
+            @ConfigurationProperties
+            class A {
+                void method() {
+                }
+            }
+        """
+    )
+
+    @Test
+    fun constructorAnnotation() = assertUnchanged(
+        before = """
+            import org.springframework.boot.context.properties.ConfigurationProperties;
+            import org.springframework.boot.context.properties.ConstructorBinding;
+            
+            @ConfigurationProperties
+            class A {
+                @ConstructorBinding
+                A() {
+                }
+            }
+        """
+    )
+
+    @Test
+    fun topLevelTypeAnnotationWithoutConfigProperties() = assertUnchanged(
+        before = """
+            import org.springframework.boot.context.properties.ConstructorBinding;
+            
+            @ConstructorBinding
+            class A {
+            }
+        """
+    )
+
+    @Test
+    fun constructorAnnotationWithMultipleConstructors() = assertUnchanged(
+        before = """
+            import org.springframework.boot.context.properties.ConfigurationProperties;
+            import org.springframework.boot.context.properties.ConstructorBinding;
+            
+            @ConfigurationProperties
+            class A {
+                A() {
+                }
+                @ConstructorBinding
+                A(int n) {
+                }
+            }
+        """
+    )
+
+    @Test
+    fun noConstrBindingAnnotation() = assertUnchanged(
+        before = """
+            import org.springframework.boot.context.properties.ConfigurationProperties;
+            
+            @ConfigurationProperties
+            class A {
+                A() {
+                }
+                A(int n) {
+                }
+            }
+        """
+    )
+
+    @Test
+    fun topLevelTypeAnnotationInnerClass() = assertChanged(
+        before = """
+            import org.springframework.boot.context.properties.ConfigurationProperties;
+            import org.springframework.boot.context.properties.ConstructorBinding;
+            
+            class A {
+                void method() {
+                }
+                
+                @ConfigurationProperties
+                @ConstructorBinding
+                static class B {
+                }
+            }
+        """,
+        after = """
+            import org.springframework.boot.context.properties.ConfigurationProperties;
+            
+            class A {
+                void method() {
+                }
+                
+                @ConfigurationProperties
+                static class B {
+                }
+            }
+        """
+    )
+
+    @Test
+    fun constructorAnnotationInnerClass() = assertChanged(
+        before = """
+            import org.springframework.boot.context.properties.ConfigurationProperties;
+            import org.springframework.boot.context.properties.ConstructorBinding;
+            
+            @ConfigurationProperties
+            @ConstructorBinding
+            class A {
+                void method() {
+                }
+                
+                @ConfigurationProperties
+                static class B {
+                    @ConstructorBinding
+                    B() {
+                    }
+                }
+            }
+        """,
+        after = """
+            import org.springframework.boot.context.properties.ConfigurationProperties;
+            import org.springframework.boot.context.properties.ConstructorBinding;
+            
+            @ConfigurationProperties
+            class A {
+                void method() {
+                }
+                
+                @ConfigurationProperties
+                static class B {
+                    @ConstructorBinding
+                    B() {
+                    }
+                }
+            }
+        """
+    )
+
+    @Test
+    fun constructorAndTypeAnnotationWithMultipleConstructorsInnerClass() = assertUnchanged(
+        before = """
+            import org.springframework.boot.context.properties.ConfigurationProperties;
+            import org.springframework.boot.context.properties.ConstructorBinding;
+            
+            class A {
+                @ConfigurationProperties
+                static class B {
+                    B() {
+                    }
+                    @ConstructorBinding
+                    B(int n) {
+                    }
+                }
+            }
+        """
+    )
+
+}


### PR DESCRIPTION
Boot 3 allows for removal of type annotation `@ConstructorBinding` where type has `@ConfigurationProperties`.

See: https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-3.0.0-M2-Release-Notes#constructingbinding-no-longer-needed-at-the-type-level

cc: @fabapp2 