### PR TITLE
YAML Support for spring security saml rename of identityprovider to a…

### DIFF
--- a/src/main/java/org/openrewrite/java/spring/boot2/SAMLRelyingPartyPropertyYAMLMove.java
+++ b/src/main/java/org/openrewrite/java/spring/boot2/SAMLRelyingPartyPropertyYAMLMove.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2022 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.spring.boot2;
+
+import org.openrewrite.Cursor;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.yaml.YamlIsoVisitor;
+import org.openrewrite.yaml.tree.Yaml;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * @author Sandeep Nagaraj
+ */
+public class SAMLRelyingPartyPropertyYAMLMove extends Recipe {
+
+    @Override
+    public String getDisplayName() {
+        return "Move SAML relying party identity provider property to asserting party";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Renames spring.security.saml2.relyingparty.registration.(any).identityprovider to " +
+                "spring.security.saml2.relyingparty.registration.(any).assertingparty";
+    }
+
+    @Override
+    protected TreeVisitor<?, ExecutionContext> getVisitor() {
+
+        return new YamlIsoVisitor<ExecutionContext>() {
+            @Override
+            public Yaml.Mapping.Entry visitMappingEntry(Yaml.Mapping.Entry entry,
+                                                        ExecutionContext executionContext) {
+                entry = super.visitMappingEntry(entry, executionContext);
+
+                if (isIdentityProviderNode(entry) && isOfCorrectHierarchy()) {
+                    entry = entry.withKey(entry.getKey().withValue("assertingparty"));
+                }
+
+                return entry;
+            }
+
+            private boolean isOfCorrectHierarchy() {
+
+                Cursor current = getCursor();
+
+                List<Yaml.Mapping.Entry> yamlEntries = new ArrayList<>();
+
+                while (current != null) {
+                    if (current.getValue() instanceof Yaml.Mapping.Entry) {
+                        yamlEntries.add(current.getValue());
+                    }
+
+                    current = current.getParent();
+                }
+
+                String hierarchy = yamlEntries
+                        .stream()
+                        .map(entry -> entry.getKey().getValue())
+                        .collect(Collectors.joining("->"));
+
+                return hierarchy.matches("identityprovider->.*->registration->relyingparty->saml2->security->spring");
+            }
+
+            private boolean isIdentityProviderNode(Yaml.Mapping.Entry entry) {
+                return entry.getKey().getValue().equals("identityprovider");
+            }
+        };
+    }
+}

--- a/src/testWithSpringBoot_2_4/kotlin/org/openrewrite/java/spring/boot2/SAMLRelyingPartyPropertyYAMLTest.kt
+++ b/src/testWithSpringBoot_2_4/kotlin/org/openrewrite/java/spring/boot2/SAMLRelyingPartyPropertyYAMLTest.kt
@@ -1,0 +1,195 @@
+/*
+ * Copyright 2022 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.spring.boot2
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.openrewrite.Recipe
+import org.openrewrite.Result
+import org.openrewrite.java.JavaRecipeTest
+import org.openrewrite.yaml.YamlParser
+import java.nio.file.Paths
+
+
+/**
+ * @author Sandeep Nagaraj
+ */
+class SAMLRelyingPartyPropertyYAMLTest : JavaRecipeTest {
+
+    override val recipe: Recipe
+        get() = SAMLRelyingPartyPropertyYAMLMove()
+
+    @Test
+    fun movePropertyTestSingle() {
+        val result = runRecipe(
+            """
+                spring:
+                  security:
+                    saml2:
+                      relyingparty:
+                        registration:
+                          idpone:
+                            identityprovider:
+                              entity-id: https://idpone.com
+                              sso-url: https://idpone.com
+                              verification:
+                                credentials:
+                                  - certificate-location: "classpath:saml/idpone.crt"
+            """.trimIndent()
+        )
+        assertThat(result).hasSize(1)
+        assertThat(result[0].after!!.printAll()).isEqualTo("""
+                spring:
+                  security:
+                    saml2:
+                      relyingparty:
+                        registration:
+                          idpone:
+                            assertingparty:
+                              entity-id: https://idpone.com
+                              sso-url: https://idpone.com
+                              verification:
+                                credentials:
+                                  - certificate-location: "classpath:saml/idpone.crt"
+            """.trimIndent())
+    }
+
+    @Test
+    fun movePropertyTestMultiple() {
+        val result = runRecipe(
+            """
+                spring:
+                  security:
+                    saml2:
+                      relyingparty:
+                        registration:
+                          idpone:
+                            identityprovider:
+                              entity-id: https://idpone.com
+                              sso-url: https://idpone.com
+                              verification:
+                                credentials:
+                                  - certificate-location: "classpath:saml/idpone.crt"
+                          okta:
+                            identityprovider:
+                              entity-id: https://idpone.com
+                              sso-url: https://idpone.com
+                              verification:
+                                credentials:
+                                  - certificate-location: "classpath:saml/idpone.crt"
+            """.trimIndent()
+        )
+        assertThat(result).hasSize(1)
+        assertThat(result[0].after!!.printAll()).isEqualTo(
+            """
+                spring:
+                  security:
+                    saml2:
+                      relyingparty:
+                        registration:
+                          idpone:
+                            assertingparty:
+                              entity-id: https://idpone.com
+                              sso-url: https://idpone.com
+                              verification:
+                                credentials:
+                                  - certificate-location: "classpath:saml/idpone.crt"
+                          okta:
+                            assertingparty:
+                              entity-id: https://idpone.com
+                              sso-url: https://idpone.com
+                              verification:
+                                credentials:
+                                  - certificate-location: "classpath:saml/idpone.crt"
+            """.trimIndent()
+        )
+    }
+
+    @Test
+    fun movePropertyWhenCorrectHierarchyIsDetected() {
+        val inputYaml = """
+                some:
+                  random:
+                    thing:
+                      relyingparty:
+                        registration:
+                          idpone:
+                            identityprovider:
+                              entity-id: https://idpone.com
+                              sso-url: https://idpone.com
+                              verification:
+                                credentials:
+                                  - certificate-location: "classpath:saml/idpone.crt"
+
+            """.trimIndent()
+
+        val result = runRecipe(inputYaml)
+        assertThat(result).hasSize(0)
+    }
+
+    @Test
+    fun resolveBasedOnCorrectHierarchy() {
+        val result = runRecipe(
+            """
+                spring:
+                  security:
+                    saml2:
+                      relyingparty:
+                        registration:
+                          idpone:
+                            identityprovider:
+                              entity-id: https://idpone.com
+                              sso-url: https://idpone.com
+                              verification:
+                                credentials:
+                                  - certificate-location: "classpath:saml/idpone.crt"
+                relyingparty:
+                    registration:
+                        something:
+                            identityprovider: 
+                                of: value
+            """.trimIndent()
+        )
+        assertThat(result).hasSize(1)
+        assertThat(result[0].after!!.printAll()).isEqualTo(
+            """
+                spring:
+                  security:
+                    saml2:
+                      relyingparty:
+                        registration:
+                          idpone:
+                            assertingparty:
+                              entity-id: https://idpone.com
+                              sso-url: https://idpone.com
+                              verification:
+                                credentials:
+                                  - certificate-location: "classpath:saml/idpone.crt"
+                relyingparty:
+                    registration:
+                        something:
+                            identityprovider: 
+                                of: value
+            """.trimIndent())
+    }
+
+    private fun runRecipe(inputYaml: String): List<Result> {
+        val applicationYaml = YamlParser().parse(inputYaml)
+            .map { it.withSourcePath(Paths.get("src/main/resources/application.yml")) }
+
+        return recipe.run(applicationYaml)
+    }
+}


### PR DESCRIPTION
This PR handles the property move of spring security saml:
`spring.security.saml2.relyingparty.registration.(any).identityprovider` is moved to `spring.security.saml2.relyingparty.registration.(any).assertingparty`

You can find more info on [official spring docs](https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.7-Release-Notes#deprecations-in-spring-boot-27)
Here are the test cases this PR handles: 

### When there is only one identity provider:
![image](https://user-images.githubusercontent.com/59915704/176855480-f2b1d10f-c8c0-4816-abde-1ca5946adc23.png)

### When there are multiple identity provider:
![image](https://user-images.githubusercontent.com/59915704/176855705-9920fb2c-b626-4d74-9a44-ffd58611d170.png)

### Move identity provider only when a hierarchy pattern is detected
![image](https://user-images.githubusercontent.com/59915704/176855900-c689553e-7ca8-4500-b683-2aac05e8569a.png)
![image](https://user-images.githubusercontent.com/59915704/176856057-bce42342-4203-4959-a4ec-f47d6ecddb1a.png)

