### PR TITLE
Saml rename identity provider app prop

### DIFF
--- a/src/main/java/org/openrewrite/java/spring/boot2/SAMLRelyingPartyPropertyApplicationPropertiesMove.java
+++ b/src/main/java/org/openrewrite/java/spring/boot2/SAMLRelyingPartyPropertyApplicationPropertiesMove.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 the original author or authors.
+ * Copyright 2022 the original author or authors.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/openrewrite/java/spring/boot2/SAMLRelyingPartyPropertyApplicationPropertiesMove.java
+++ b/src/main/java/org/openrewrite/java/spring/boot2/SAMLRelyingPartyPropertyApplicationPropertiesMove.java
@@ -23,7 +23,7 @@ import org.openrewrite.TreeVisitor;
 import org.openrewrite.properties.PropertiesVisitor;
 import org.openrewrite.properties.tree.Properties;
 
-public class SAMLRelyingPartyPropertyApplicationPropertiesMove extends Recipe {
+public class SamlRelyingPartyPropertyApplicationPropertiesMove extends Recipe {
     private final static String REGEX_PATTERN = "(spring\\.security\\.saml2\\.relyingparty\\.registration\\..*)(\\.identityprovider)(.*)";
 
     @Override

--- a/src/main/java/org/openrewrite/java/spring/boot2/SAMLRelyingPartyPropertyApplicationPropertiesMove.java
+++ b/src/main/java/org/openrewrite/java/spring/boot2/SAMLRelyingPartyPropertyApplicationPropertiesMove.java
@@ -17,6 +17,7 @@ package org.openrewrite.java.spring.boot2;
 
 import org.jetbrains.annotations.NotNull;
 import org.openrewrite.ExecutionContext;
+import org.openrewrite.HasSourcePath;
 import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.properties.PropertiesVisitor;

--- a/src/main/java/org/openrewrite/java/spring/boot2/SAMLRelyingPartyPropertyApplicationPropertiesMove.java
+++ b/src/main/java/org/openrewrite/java/spring/boot2/SAMLRelyingPartyPropertyApplicationPropertiesMove.java
@@ -1,0 +1,17 @@
+package org.openrewrite.java.spring.boot2;
+
+import org.openrewrite.Recipe;
+
+public class SAMLRelyingPartyPropertyApplicationPropertiesMove extends Recipe {
+    @Override
+    public String getDisplayName() {
+        return "Move SAML relying party identity provider property to asserting party";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Renames spring.security.saml2.relyingparty.registration.(any).identityprovider to " +
+                "spring.security.saml2.relyingparty.registration.(any).assertingparty";
+    }
+
+}

--- a/src/main/java/org/openrewrite/java/spring/boot2/SAMLRelyingPartyPropertyApplicationPropertiesMove.java
+++ b/src/main/java/org/openrewrite/java/spring/boot2/SAMLRelyingPartyPropertyApplicationPropertiesMove.java
@@ -34,7 +34,7 @@ public class SamlRelyingPartyPropertyApplicationPropertiesMove extends Recipe {
     @Override
     public String getDescription() {
         return "Renames spring.security.saml2.relyingparty.registration.(any).identityprovider to " +
-                "spring.security.saml2.relyingparty.registration.(any).assertingparty";
+                "spring.security.saml2.relyingparty.registration.(any).assertingparty.";
     }
 
     @Override

--- a/src/main/java/org/openrewrite/java/spring/boot2/SAMLRelyingPartyPropertyApplicationPropertiesMove.java
+++ b/src/main/java/org/openrewrite/java/spring/boot2/SAMLRelyingPartyPropertyApplicationPropertiesMove.java
@@ -10,6 +10,8 @@ import java.util.UUID;
 import java.util.regex.Pattern;
 
 public class SAMLRelyingPartyPropertyApplicationPropertiesMove extends Recipe {
+//    private static Pattern IDENTITY_PROVIDER_PATTERN = Pattern.compile("spring\\.security\\.saml2\\.relyingparty\\.registration\\..*\\.(identityprovider).*");
+
     @Override
     public String getDisplayName() {
         return "Move SAML relying party identity provider property to asserting party";
@@ -25,7 +27,6 @@ public class SAMLRelyingPartyPropertyApplicationPropertiesMove extends Recipe {
     protected TreeVisitor<?, ExecutionContext> getVisitor() {
 
         return new PropertiesVisitor<ExecutionContext>() {
-
 
             @Override
             public Properties visitEntry(Properties.Entry entry, ExecutionContext executionContext) {

--- a/src/main/java/org/openrewrite/java/spring/boot2/SAMLRelyingPartyPropertyApplicationPropertiesMove.java
+++ b/src/main/java/org/openrewrite/java/spring/boot2/SAMLRelyingPartyPropertyApplicationPropertiesMove.java
@@ -22,9 +22,6 @@ import org.openrewrite.TreeVisitor;
 import org.openrewrite.properties.PropertiesVisitor;
 import org.openrewrite.properties.tree.Properties;
 
-import java.util.UUID;
-import java.util.regex.Pattern;
-
 public class SAMLRelyingPartyPropertyApplicationPropertiesMove extends Recipe {
     private final static String REGEX_PATTERN = "(spring\\.security\\.saml2\\.relyingparty\\.registration\\..*)(\\.identityprovider)(.*)";
 

--- a/src/main/java/org/openrewrite/java/spring/boot2/SAMLRelyingPartyPropertyApplicationPropertiesMove.java
+++ b/src/main/java/org/openrewrite/java/spring/boot2/SAMLRelyingPartyPropertyApplicationPropertiesMove.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openrewrite.java.spring.boot2;
 
 import org.openrewrite.ExecutionContext;

--- a/src/main/java/org/openrewrite/java/spring/boot2/SAMLRelyingPartyPropertyApplicationPropertiesMove.java
+++ b/src/main/java/org/openrewrite/java/spring/boot2/SAMLRelyingPartyPropertyApplicationPropertiesMove.java
@@ -23,12 +23,10 @@ import org.openrewrite.properties.PropertiesVisitor;
 import org.openrewrite.properties.tree.Properties;
 
 import java.util.UUID;
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class SAMLRelyingPartyPropertyApplicationPropertiesMove extends Recipe {
     private final static String REGEX_PATTERN = "(spring\\.security\\.saml2\\.relyingparty\\.registration\\..*)(\\.identityprovider)(.*)";
-    private final static Pattern IDENTITY_PROVIDER_PATTERN = Pattern.compile(REGEX_PATTERN);
 
     @Override
     public String getDisplayName() {
@@ -50,8 +48,7 @@ public class SAMLRelyingPartyPropertyApplicationPropertiesMove extends Recipe {
             public Properties visitEntry(Properties.Entry entry, ExecutionContext executionContext) {
 
                 Properties.Entry updatedEntry = entry;
-                Matcher matcher = IDENTITY_PROVIDER_PATTERN.matcher(entry.getKey());
-                if (matcher.matches()) {
+                if (entry.getKey().matches(REGEX_PATTERN)) {
                     updatedEntry = updateEntry(entry);
                 }
 

--- a/src/main/java/org/openrewrite/java/spring/boot2/SAMLRelyingPartyPropertyApplicationPropertiesMove.java
+++ b/src/main/java/org/openrewrite/java/spring/boot2/SAMLRelyingPartyPropertyApplicationPropertiesMove.java
@@ -1,6 +1,13 @@
 package org.openrewrite.java.spring.boot2;
 
+import org.openrewrite.ExecutionContext;
 import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.properties.PropertiesVisitor;
+import org.openrewrite.properties.tree.Properties;
+
+import java.util.UUID;
+import java.util.regex.Pattern;
 
 public class SAMLRelyingPartyPropertyApplicationPropertiesMove extends Recipe {
     @Override
@@ -13,5 +20,21 @@ public class SAMLRelyingPartyPropertyApplicationPropertiesMove extends Recipe {
         return "Renames spring.security.saml2.relyingparty.registration.(any).identityprovider to " +
                 "spring.security.saml2.relyingparty.registration.(any).assertingparty";
     }
+
+    @Override
+    protected TreeVisitor<?, ExecutionContext> getVisitor() {
+
+        return new PropertiesVisitor<ExecutionContext>() {
+
+
+            @Override
+            public Properties visitEntry(Properties.Entry entry, ExecutionContext executionContext) {
+                String updatedKey = entry.getKey().replaceAll("identityprovider", "assertingparty");
+                Properties.Entry updatedEntry = new Properties.Entry(UUID.randomUUID(), entry.getPrefix(), entry.getMarkers(), updatedKey, entry.getBeforeEquals(), entry.getValue());
+                return super.visitEntry(updatedEntry, executionContext);
+            }
+        };
+    }
+
 
 }

--- a/src/main/java/org/openrewrite/java/spring/boot2/SAMLRelyingPartyPropertyApplicationPropertiesMove.java
+++ b/src/main/java/org/openrewrite/java/spring/boot2/SAMLRelyingPartyPropertyApplicationPropertiesMove.java
@@ -47,25 +47,16 @@ public class SAMLRelyingPartyPropertyApplicationPropertiesMove extends Recipe {
             @Override
             public Properties visitEntry(Properties.Entry entry, ExecutionContext executionContext) {
 
-                Properties.Entry updatedEntry = entry;
                 if (entry.getKey().matches(REGEX_PATTERN)) {
-                    updatedEntry = updateEntry(entry);
+                    return super.visitEntry(updateEntry(entry), executionContext);
                 }
 
-                return super.visitEntry(updatedEntry, executionContext);
+                return super.visitEntry(entry, executionContext);
             }
 
             @NotNull
             private Properties.Entry updateEntry(Properties.Entry entry) {
-                String updatedKey =
-                        entry.getKey().replaceAll(REGEX_PATTERN, "$1.assertingparty$3");
-                return new Properties.Entry(UUID.randomUUID(),
-                        entry.getPrefix(),
-                        entry.getMarkers(),
-                        updatedKey,
-                        entry.getBeforeEquals(),
-                        entry.getValue()
-                );
+                return entry.withKey(entry.getKey().replaceAll(REGEX_PATTERN, "$1.assertingparty$3"));
             }
         };
     }

--- a/src/testWithSpringBoot_2_4/kotlin/org/openrewrite/java/spring/boot2/SAMLRelyingPartyPropertyApplicationPropertiesMoveTest.kt
+++ b/src/testWithSpringBoot_2_4/kotlin/org/openrewrite/java/spring/boot2/SAMLRelyingPartyPropertyApplicationPropertiesMoveTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 the original author or authors.
+ * Copyright 2022 the original author or authors.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/testWithSpringBoot_2_4/kotlin/org/openrewrite/java/spring/boot2/SAMLRelyingPartyPropertyApplicationPropertiesMoveTest.kt
+++ b/src/testWithSpringBoot_2_4/kotlin/org/openrewrite/java/spring/boot2/SAMLRelyingPartyPropertyApplicationPropertiesMoveTest.kt
@@ -23,7 +23,7 @@ import org.openrewrite.java.JavaRecipeTest
 import org.openrewrite.properties.PropertiesParser
 import java.nio.file.Paths
 
-class SAMLRelyingPartyPropertyApplicationPropertiesMoveTest : JavaRecipeTest {
+class SamlRelyingPartyPropertyApplicationPropertiesMoveTest : JavaRecipeTest {
 
     override val recipe: Recipe
         get() = SamlRelyingPartyPropertyApplicationPropertiesMove()

--- a/src/testWithSpringBoot_2_4/kotlin/org/openrewrite/java/spring/boot2/SAMLRelyingPartyPropertyApplicationPropertiesMoveTest.kt
+++ b/src/testWithSpringBoot_2_4/kotlin/org/openrewrite/java/spring/boot2/SAMLRelyingPartyPropertyApplicationPropertiesMoveTest.kt
@@ -26,7 +26,7 @@ import java.nio.file.Paths
 class SAMLRelyingPartyPropertyApplicationPropertiesMoveTest : JavaRecipeTest {
 
     override val recipe: Recipe
-        get() = SAMLRelyingPartyPropertyApplicationPropertiesMove()
+        get() = SamlRelyingPartyPropertyApplicationPropertiesMove()
 
     @Test
     fun movePropertyTestSingle() {

--- a/src/testWithSpringBoot_2_4/kotlin/org/openrewrite/java/spring/boot2/SAMLRelyingPartyPropertyApplicationPropertiesMoveTest.kt
+++ b/src/testWithSpringBoot_2_4/kotlin/org/openrewrite/java/spring/boot2/SAMLRelyingPartyPropertyApplicationPropertiesMoveTest.kt
@@ -30,6 +30,18 @@ class SAMLRelyingPartyPropertyApplicationPropertiesMoveTest : JavaRecipeTest {
             """.trimIndent())
     }
 
+    @Test
+    fun shouldNotMovePropertyInWrongHierarchy() {
+        val result = runRecipe(
+            """
+            spring.security.saml2.relyingparty.identityprovider.registration.idpone.entity-id=https://idpone.com
+            spring.identityprovider.security.saml2.relyingparty.registration.idpone.sso-url=https://idpone.com
+            spring.security.identityprovider.saml2.relyingparty.registration.idpone.verification.credentials.certificate-location=classpath:saml/idpone.crt
+            """.trimIndent()
+        )
+        assertThat(result).hasSize(0)
+    }
+
     private fun runRecipe(inputProperties: String): MutableList<Result> {
         val applicationProperties = PropertiesParser().parse(inputProperties)
             .map { it.withSourcePath(Paths.get("src/main/resources/application.properties")) }

--- a/src/testWithSpringBoot_2_4/kotlin/org/openrewrite/java/spring/boot2/SAMLRelyingPartyPropertyApplicationPropertiesMoveTest.kt
+++ b/src/testWithSpringBoot_2_4/kotlin/org/openrewrite/java/spring/boot2/SAMLRelyingPartyPropertyApplicationPropertiesMoveTest.kt
@@ -87,6 +87,20 @@ class SAMLRelyingPartyPropertyApplicationPropertiesMoveTest : JavaRecipeTest {
         assertThat(result).hasSize(0)
     }
 
+    @Test
+    fun shouldNotMovePropertiesOnFileWhichAreNotAppPropFile() {
+
+        val applicationProperties = PropertiesParser().parse("""
+            spring.security.saml2.relyingparty.registration.idpone.identityprovider.entity-id=https://idpone.com
+            spring.security.saml2.relyingparty.registration.idpone.identityprovider.sso-url=https://idpone.com
+            spring.security.saml2.relyingparty.registration.idpone.identityprovider.verification.credentials.certificate-location=classpath:saml/idpone.crt
+            """.trimIndent())
+            .map { it.withSourcePath(Paths.get("src/main/resources/random.properties")) }
+
+        val result = recipe.run(applicationProperties)
+        assertThat(result).hasSize(0)
+    }
+
     private fun runRecipe(inputProperties: String): MutableList<Result> {
         val applicationProperties = PropertiesParser().parse(inputProperties)
             .map { it.withSourcePath(Paths.get("src/main/resources/application.properties")) }

--- a/src/testWithSpringBoot_2_4/kotlin/org/openrewrite/java/spring/boot2/SAMLRelyingPartyPropertyApplicationPropertiesMoveTest.kt
+++ b/src/testWithSpringBoot_2_4/kotlin/org/openrewrite/java/spring/boot2/SAMLRelyingPartyPropertyApplicationPropertiesMoveTest.kt
@@ -47,6 +47,35 @@ class SAMLRelyingPartyPropertyApplicationPropertiesMoveTest : JavaRecipeTest {
         )
     }
 
+
+    @Test
+    fun movePropertyTestMultiple() {
+        val result = runRecipe(
+            """
+            spring.security.saml2.relyingparty.registration.idpone.identityprovider.entity-id=https://idpone.com
+            spring.security.saml2.relyingparty.registration.idpone.identityprovider.sso-url=https://idpone.com
+            spring.security.saml2.relyingparty.registration.idpone.identityprovider.verification.credentials.certificate-location=classpath:saml/idpone.crt
+            
+            spring.security.saml2.relyingparty.registration.okta.identityprovider.entity-id=https://idpone.com
+            spring.security.saml2.relyingparty.registration.okta.identityprovider.sso-url=https://idpone.com
+            spring.security.saml2.relyingparty.registration.okta.identityprovider.verification.credentials.certificate-location=classpath:saml/idpone.crt
+            """.trimIndent()
+        )
+        assertThat(result).hasSize(0)
+        assertThat(result).hasSize(1)
+        assertThat(result[0].after!!.printAll()).isEqualTo(
+            """
+            spring.security.saml2.relyingparty.registration.idpone.assertingparty.entity-id=https://idpone.com
+            spring.security.saml2.relyingparty.registration.idpone.assertingparty.sso-url=https://idpone.com
+            spring.security.saml2.relyingparty.registration.idpone.assertingparty.verification.credentials.certificate-location=classpath:saml/idpone.crt
+            
+            spring.security.saml2.relyingparty.registration.okta.assertingparty.entity-id=https://idpone.com
+            spring.security.saml2.relyingparty.registration.okta.assertingparty.sso-url=https://idpone.com
+            spring.security.saml2.relyingparty.registration.okta.assertingparty.verification.credentials.certificate-location=classpath:saml/idpone.crt
+            """.trimIndent()
+        )
+    }
+
     @Test
     fun shouldNotMovePropertyInWrongHierarchy() {
         val result = runRecipe(
@@ -59,9 +88,6 @@ class SAMLRelyingPartyPropertyApplicationPropertiesMoveTest : JavaRecipeTest {
         assertThat(result).hasSize(0)
     }
 
-
-    // TODO:
-    // what if there is another properties file which has same hierarchy
     private fun runRecipe(inputProperties: String): MutableList<Result> {
         val applicationProperties = PropertiesParser().parse(inputProperties)
             .map { it.withSourcePath(Paths.get("src/main/resources/application.properties")) }

--- a/src/testWithSpringBoot_2_4/kotlin/org/openrewrite/java/spring/boot2/SAMLRelyingPartyPropertyApplicationPropertiesMoveTest.kt
+++ b/src/testWithSpringBoot_2_4/kotlin/org/openrewrite/java/spring/boot2/SAMLRelyingPartyPropertyApplicationPropertiesMoveTest.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openrewrite.java.spring.boot2
 
 import org.assertj.core.api.Assertions.assertThat
@@ -23,11 +38,13 @@ class SAMLRelyingPartyPropertyApplicationPropertiesMoveTest : JavaRecipeTest {
             """.trimIndent()
         )
         assertThat(result).hasSize(1)
-        assertThat(result[0].after!!.printAll()).isEqualTo("""
+        assertThat(result[0].after!!.printAll()).isEqualTo(
+            """
             spring.security.saml2.relyingparty.registration.idpone.assertingparty.entity-id=https://idpone.com
             spring.security.saml2.relyingparty.registration.idpone.assertingparty.sso-url=https://idpone.com
             spring.security.saml2.relyingparty.registration.idpone.assertingparty.verification.credentials.certificate-location=classpath:saml/idpone.crt
-            """.trimIndent())
+            """.trimIndent()
+        )
     }
 
     @Test

--- a/src/testWithSpringBoot_2_4/kotlin/org/openrewrite/java/spring/boot2/SAMLRelyingPartyPropertyApplicationPropertiesMoveTest.kt
+++ b/src/testWithSpringBoot_2_4/kotlin/org/openrewrite/java/spring/boot2/SAMLRelyingPartyPropertyApplicationPropertiesMoveTest.kt
@@ -59,6 +59,9 @@ class SAMLRelyingPartyPropertyApplicationPropertiesMoveTest : JavaRecipeTest {
         assertThat(result).hasSize(0)
     }
 
+
+    // TODO:
+    // what if there is another properties file which has same hierarchy
     private fun runRecipe(inputProperties: String): MutableList<Result> {
         val applicationProperties = PropertiesParser().parse(inputProperties)
             .map { it.withSourcePath(Paths.get("src/main/resources/application.properties")) }

--- a/src/testWithSpringBoot_2_4/kotlin/org/openrewrite/java/spring/boot2/SAMLRelyingPartyPropertyApplicationPropertiesMoveTest.kt
+++ b/src/testWithSpringBoot_2_4/kotlin/org/openrewrite/java/spring/boot2/SAMLRelyingPartyPropertyApplicationPropertiesMoveTest.kt
@@ -1,0 +1,39 @@
+package org.openrewrite.java.spring.boot2
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.openrewrite.Recipe
+import org.openrewrite.Result
+import org.openrewrite.java.JavaRecipeTest
+import org.openrewrite.properties.PropertiesParser
+import java.nio.file.Paths
+
+class SAMLRelyingPartyPropertyApplicationPropertiesMoveTest : JavaRecipeTest {
+
+    override val recipe: Recipe
+        get() = SAMLRelyingPartyPropertyApplicationPropertiesMove()
+
+    @Test
+    fun movePropertyTestSingle() {
+        val result = runRecipe(
+            """
+            spring.security.saml2.relyingparty.registration.idpone.identityprovider.entity-id=https://idpone.com
+            spring.security.saml2.relyingparty.registration.idpone.identityprovider.sso-url=https://idpone.com
+            spring.security.saml2.relyingparty.registration.idpone.identityprovider.verification.credentials.certificate-location=classpath:saml/idpone.crt
+            """.trimIndent()
+        )
+        assertThat(result).hasSize(1)
+        assertThat(result[0].after!!.printAll()).isEqualTo("""
+            spring.security.saml2.relyingparty.registration.idpone.assertingparty.entity-id=https://idpone.com
+            spring.security.saml2.relyingparty.registration.idpone.assertingparty.sso-url=https://idpone.com
+            spring.security.saml2.relyingparty.registration.idpone.assertingparty.verification.credentials.certificate-location=classpath:saml/idpone.crt
+            """.trimIndent())
+    }
+
+    private fun runRecipe(inputProperties: String): MutableList<Result> {
+        val applicationProperties = PropertiesParser().parse(inputProperties)
+            .map { it.withSourcePath(Paths.get("src/main/resources/application.properties")) }
+
+        return recipe.run(applicationProperties)
+    }
+}

--- a/src/testWithSpringBoot_2_4/kotlin/org/openrewrite/java/spring/boot2/SAMLRelyingPartyPropertyApplicationPropertiesMoveTest.kt
+++ b/src/testWithSpringBoot_2_4/kotlin/org/openrewrite/java/spring/boot2/SAMLRelyingPartyPropertyApplicationPropertiesMoveTest.kt
@@ -87,20 +87,6 @@ class SAMLRelyingPartyPropertyApplicationPropertiesMoveTest : JavaRecipeTest {
         assertThat(result).hasSize(0)
     }
 
-    @Test
-    fun shouldNotMovePropertiesOnFileWhichAreNotAppPropFile() {
-
-        val applicationProperties = PropertiesParser().parse("""
-            spring.security.saml2.relyingparty.registration.idpone.identityprovider.entity-id=https://idpone.com
-            spring.security.saml2.relyingparty.registration.idpone.identityprovider.sso-url=https://idpone.com
-            spring.security.saml2.relyingparty.registration.idpone.identityprovider.verification.credentials.certificate-location=classpath:saml/idpone.crt
-            """.trimIndent())
-            .map { it.withSourcePath(Paths.get("src/main/resources/random.properties")) }
-
-        val result = recipe.run(applicationProperties)
-        assertThat(result).hasSize(0)
-    }
-
     private fun runRecipe(inputProperties: String): MutableList<Result> {
         val applicationProperties = PropertiesParser().parse(inputProperties)
             .map { it.withSourcePath(Paths.get("src/main/resources/application.properties")) }

--- a/src/testWithSpringBoot_2_4/kotlin/org/openrewrite/java/spring/boot2/SAMLRelyingPartyPropertyApplicationPropertiesMoveTest.kt
+++ b/src/testWithSpringBoot_2_4/kotlin/org/openrewrite/java/spring/boot2/SAMLRelyingPartyPropertyApplicationPropertiesMoveTest.kt
@@ -61,7 +61,6 @@ class SAMLRelyingPartyPropertyApplicationPropertiesMoveTest : JavaRecipeTest {
             spring.security.saml2.relyingparty.registration.okta.identityprovider.verification.credentials.certificate-location=classpath:saml/idpone.crt
             """.trimIndent()
         )
-        assertThat(result).hasSize(0)
         assertThat(result).hasSize(1)
         assertThat(result[0].after!!.printAll()).isEqualTo(
             """


### PR DESCRIPTION
This PR follow up [PR-205](https://github.com/openrewrite/rewrite-spring/pull/205) which handles yaml property move.

Its similar to PR-205 and handles same logic but for application properties