### PR TITLE
Polish. Generate JavaDoc with the appropriate indent in RemoveConstructorBindingAnnotation.

### DIFF
--- a/src/main/java/org/openrewrite/java/spring/boot3/RemoveConstructorBindingAnnotation.java
+++ b/src/main/java/org/openrewrite/java/spring/boot3/RemoveConstructorBindingAnnotation.java
@@ -104,7 +104,7 @@ public class RemoveConstructorBindingAnnotation extends Recipe {
                                 maybeRemoveImport(ANNOTATION_CONSTRUCTOR_BINDING);
                                 return null;
                             }
-                            return anno.withComments(maybeAddJavaDoc(anno.getComments()));
+                            return anno.withComments(maybeAddJavaDoc(anno.getComments(), anno.getPrefix().getIndent()));
                         }
                         return anno;
                     }));
@@ -117,7 +117,7 @@ public class RemoveConstructorBindingAnnotation extends Recipe {
              * Generates a properly structured Javadoc to enable autoformatting features
              * like {@link org.openrewrite.xml.format.NormalizeLineBreaks}.
              */
-            private List<Comment> maybeAddJavaDoc(List<Comment> comments) {
+            private List<Comment> maybeAddJavaDoc(List<Comment> comments, String indent) {
                 String message = "You need to remove ConstructorBinding on class level and move it to appropriate";
                 if (comments.isEmpty() || comments.stream()
                         .filter(o -> o instanceof Javadoc.DocComment)
@@ -126,16 +126,16 @@ public class RemoveConstructorBindingAnnotation extends Recipe {
                         .noneMatch(o -> o.print(getCursor()).equals(message))) {
 
                     List<Javadoc> javadoc = new ArrayList<>();
-                    javadoc.add(new Javadoc.LineBreak(randomId(), "\n * ", Markers.EMPTY));
+                    javadoc.add(new Javadoc.LineBreak(randomId(), "\n" + indent + " * ", Markers.EMPTY));
                     javadoc.add(new Javadoc.Text(randomId(), Markers.EMPTY, "TODO:"));
-                    javadoc.add(new Javadoc.LineBreak(randomId(), "\n * ", Markers.EMPTY));
+                    javadoc.add(new Javadoc.LineBreak(randomId(), "\n" + indent + " * ", Markers.EMPTY));
                     javadoc.add(new Javadoc.Text(randomId(), Markers.EMPTY, message));
-                    javadoc.add(new Javadoc.LineBreak(randomId(), "\n * ", Markers.EMPTY));
+                    javadoc.add(new Javadoc.LineBreak(randomId(), "\n" + indent + " * ", Markers.EMPTY));
                     javadoc.add(new Javadoc.Text(randomId(), Markers.EMPTY, "constructor."));
-                    javadoc.add(new Javadoc.LineBreak(randomId(), "\n ", Markers.EMPTY));
+                    javadoc.add(new Javadoc.LineBreak(randomId(), "\n" + indent + " ", Markers.EMPTY));
 
                     List<Comment> newComments = new ArrayList<>(comments);
-                    newComments.add(new Javadoc.DocComment(randomId(), Markers.EMPTY, javadoc, "\n"));
+                    newComments.add(new Javadoc.DocComment(randomId(), Markers.EMPTY, javadoc, "\n" + indent));
                     return newComments;
                 }
                 return comments;

--- a/src/testWithSpringBoot_2_4/kotlin/org/openrewrite/java/spring/boot3/RemoveConstructorBindingAnnotationTest.kt
+++ b/src/testWithSpringBoot_2_4/kotlin/org/openrewrite/java/spring/boot3/RemoveConstructorBindingAnnotationTest.kt
@@ -303,4 +303,43 @@ class RemoveConstructorBindingAnnotationTest : JavaRecipeTest {
             }
         """
     )
+
+    @Test
+    fun addCommentToInnerClass() = assertChanged(
+        before = """
+            import org.springframework.boot.context.properties.ConfigurationProperties;
+            import org.springframework.boot.context.properties.ConstructorBinding;
+            
+            class A {
+                @ConfigurationProperties
+                @ConstructorBinding
+                static class B {
+                    B() {
+                    }
+                    B(int n) {
+                    }
+                }
+            }
+        """,
+        after = """
+            import org.springframework.boot.context.properties.ConfigurationProperties;
+            import org.springframework.boot.context.properties.ConstructorBinding;
+            
+            class A {
+                @ConfigurationProperties
+                /**
+                 * TODO:
+                 * You need to remove ConstructorBinding on class level and move it to appropriate
+                 * constructor.
+                 */
+                @ConstructorBinding
+                static class B {
+                    B() {
+                    }
+                    B(int n) {
+                    }
+                }
+            }
+        """
+    )
 }


### PR DESCRIPTION
Changes:

- The generated JavaDoc will be indented with the annotation prefix.