### PR TITLE
R…elax WebSecurityConfigurerAdapter update constraints

### DIFF
--- a/src/main/java/org/openrewrite/java/spring/boot2/WebSecurityConfigurerAdapter.java
+++ b/src/main/java/org/openrewrite/java/spring/boot2/WebSecurityConfigurerAdapter.java
@@ -73,7 +73,7 @@ public class WebSecurityConfigurerAdapter extends Recipe {
             public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration classDecl, ExecutionContext context) {
                 if (TypeUtils.isAssignableTo(FQN_WEB_SECURITY_CONFIGURER_ADAPTER, classDecl.getType())
                         && classDecl.getLeadingAnnotations().stream().anyMatch(a -> TypeUtils.isOfClassType(a.getType(), FQN_CONFIGURATION))) {
-                    if (isNonConvertable(classDecl)) {
+                    if (!isConvertable(classDecl)) {
                         return classDecl.withMarkers(classDecl.getMarkers()
                                 .searchResult("Migrate manually based on https://spring.io/blog/2022/02/21/spring-security-without-the-websecurityconfigureradapter"));
                     }
@@ -84,17 +84,17 @@ public class WebSecurityConfigurerAdapter extends Recipe {
                 return super.visitClassDeclaration(classDecl, context);
             }
 
-            private boolean isNonConvertable(J.ClassDeclaration classDecl) {
+            private boolean isConvertable(J.ClassDeclaration classDecl) {
                 if (classDecl.getType() != null) {
                     for (JavaType.Method method : classDecl.getType().getMethods()) {
                         if (USER_DETAILS_SERVICE_BEAN_METHOD_MATCHER.matches(method)
                                 || AUTHENTICATION_MANAGER_BEAN_METHOD_MATCHER.matches(method)
                                 || CONFIGURE_AUTH_MANAGER_SECURITY_METHOD_MATCHER.matches(method)) {
-                            return true;
+                            return false;
                         }
                     }
                 }
-                return false;
+                return true;
             }
 
             @Override

--- a/src/main/java/org/openrewrite/java/spring/boot2/WebSecurityConfigurerAdapter.java
+++ b/src/main/java/org/openrewrite/java/spring/boot2/WebSecurityConfigurerAdapter.java
@@ -80,8 +80,8 @@ public class WebSecurityConfigurerAdapter extends Recipe {
                             hasConflict = true;
                         }
                     }
+                    getCursor().putMessage(HAS_CONFLICT, hasConflict);
                     if (!hasConflict) {
-                        getCursor().putMessage(HAS_CONFLICT, false);
                         maybeRemoveImport(FQN_WEB_SECURITY_CONFIGURER_ADAPTER);
                         classDecl = classDecl.withExtends(null);
                     }

--- a/src/testWithSpringBoot_2_4/kotlin/org/openrewrite/java/spring/boot2/WebSecurityConfigurerAdapterTest.kt
+++ b/src/testWithSpringBoot_2_4/kotlin/org/openrewrite/java/spring/boot2/WebSecurityConfigurerAdapterTest.kt
@@ -188,10 +188,10 @@ class WebSecurityConfigurerAdapterTest : JavaRecipeTest {
         import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
         import org.springframework.security.ldap.userdetails.PersonContextMapper;
 
-        /*~~(Migrate manually based on https://spring.io/blog/2022/02/21/spring-security-without-the-websecurityconfigureradapter)~~>*/@Configuration
+        @Configuration
         public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
 
-            @Override
+            /*~~(Migrate manually based on https://spring.io/blog/2022/02/21/spring-security-without-the-websecurityconfigureradapter)~~>*/@Override
             protected void configure(AuthenticationManagerBuilder auth) {
                 auth
                     .ldapAuthentication()
@@ -253,7 +253,7 @@ class WebSecurityConfigurerAdapterTest : JavaRecipeTest {
             import org.springframework.security.authentication.AuthenticationManager;
             import org.springframework.security.core.userdetails.UserDetailsService;
 
-            /*~~(Migrate manually based on https://spring.io/blog/2022/02/21/spring-security-without-the-websecurityconfigureradapter)~~>*/@Configuration
+            @Configuration
             public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
             
                 @Override
@@ -265,12 +265,12 @@ class WebSecurityConfigurerAdapterTest : JavaRecipeTest {
                         .httpBasic(withDefaults());
                 }
                 
-                @Override
+                /*~~(Migrate manually based on https://spring.io/blog/2022/02/21/spring-security-without-the-websecurityconfigureradapter)~~>*/@Override
                 public UserDetailsService userDetailsServiceBean() throws Exception  {
                     return null;
                 }
                 
-                @Override
+                /*~~(Migrate manually based on https://spring.io/blog/2022/02/21/spring-security-without-the-websecurityconfigureradapter)~~>*/@Override
                 public AuthenticationManager authenticationManagerBean() throws Exception {
                     return null;
                 }


### PR DESCRIPTION
Relax WebSecurityConfigurerAdapter update constraints to allow for transformations when an unrelated method is present. (issue #214)
  - If the configuration class should override the `userDetailsServiceBean`, `authenticationManagerBean`, or `configure(AuthenticationManagerBuilder)` then mark them with a comment and exit the transformation.
  - Remove`configureHttpSecurityMethodInnerClass` and `configureHttpSecurityMethodInnerClassWithNoApplicableMethod` tests since they appear to be very unlikely configurations.