### PR TITLE
Precise Bean Type recipe for Spring 5 AOT

### DIFF
--- a/src/main/java/org/openrewrite/java/spring/boot3/PreciseBeanType.java
+++ b/src/main/java/org/openrewrite/java/spring/boot3/PreciseBeanType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openrewrite.java.spring.boot3;
 
 import org.openrewrite.Cursor;

--- a/src/main/java/org/openrewrite/java/spring/boot3/PreciseBeanType.java
+++ b/src/main/java/org/openrewrite/java/spring/boot3/PreciseBeanType.java
@@ -1,0 +1,100 @@
+package org.openrewrite.java.spring.boot3;
+
+import org.openrewrite.Cursor;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.search.UsesType;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaType;
+import org.openrewrite.java.tree.TypeTree;
+import org.openrewrite.java.tree.TypeUtils;
+
+public class PreciseBeanType extends Recipe {
+    private final static String BEAN = "org.springframework.context.annotation.Bean";
+
+    private final static String MSG_KEY = "returnType";
+
+    @Override
+    public String getDisplayName() {
+        return "Replace Bean method return types with concrete types being returned. This is required for Spring 6 AOT";
+    }
+
+    @Override
+    protected TreeVisitor<?, ExecutionContext> getSingleSourceApplicableTest() {
+        return new UsesType<ExecutionContext>(BEAN);
+    }
+
+    @Override
+    protected TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new JavaIsoVisitor<ExecutionContext>() {
+            @Override
+            public J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration method, ExecutionContext executionContext) {
+                J.MethodDeclaration m = super.visitMethodDeclaration(method, executionContext);
+                if (isBeanMethod(m)) {
+                    Object o = getCursor().pollMessage(MSG_KEY);
+                    if (o != null) {
+                        if (!o.equals(method.getReturnTypeExpression().getType())) {
+                            if (o instanceof JavaType.FullyQualified) {
+                                JavaType.FullyQualified actualType = (JavaType.FullyQualified) o;
+                                if (m.getReturnTypeExpression() instanceof J.Identifier) {
+                                    J.Identifier identifierReturnExpr = (J.Identifier) m.getReturnTypeExpression();
+                                    maybeAddImport(actualType);
+                                    if (identifierReturnExpr.getType() instanceof JavaType.FullyQualified) {
+                                        maybeRemoveImport((JavaType.FullyQualified) identifierReturnExpr.getType());
+                                    }
+                                    m = m.withReturnTypeExpression(identifierReturnExpr
+                                            .withType(actualType)
+                                            .withSimpleName(actualType.getClassName())
+                                    );
+                                } else if (m.getReturnTypeExpression() instanceof J.ParameterizedType) {
+                                    J.ParameterizedType parameterizedType = (J.ParameterizedType) m.getReturnTypeExpression();
+                                    maybeAddImport(actualType);
+                                    if (parameterizedType.getType() instanceof JavaType.FullyQualified) {
+                                        maybeRemoveImport((JavaType.FullyQualified) parameterizedType.getType());
+                                    }
+                                    m = m.withReturnTypeExpression(parameterizedType
+                                            .withType(actualType)
+                                            .withClazz(TypeTree.build(actualType.getClassName()).withType(actualType))
+                                    );
+                                }
+
+                            } else if (o instanceof JavaType.Array) {
+                                JavaType.Array actualType = (JavaType.Array) o;
+                                if (m.getReturnTypeExpression() instanceof J.ArrayType && actualType.getElemType() instanceof JavaType.FullyQualified) {
+                                    JavaType.FullyQualified actualElementType = (JavaType.FullyQualified) actualType.getElemType();
+                                    J.ArrayType arrayType = (J.ArrayType) m.getReturnTypeExpression();
+                                    maybeAddImport(actualElementType);
+                                    if (arrayType.getElementType() instanceof JavaType.FullyQualified) {
+                                        maybeRemoveImport((JavaType.FullyQualified) arrayType.getElementType());
+                                    }
+                                    m = m.withReturnTypeExpression(arrayType
+                                            .withElementType(TypeTree.build(actualElementType.getClassName()).withType(actualType))
+                                    );
+                                }
+                            }
+                        }
+                    }
+                }
+                return m;
+            }
+
+            private boolean isBeanMethod(J.MethodDeclaration m) {
+                return m.getLeadingAnnotations().stream().anyMatch(a -> TypeUtils.isOfClassType(a.getType(), BEAN));
+            }
+
+            @Override
+            public J.Return visitReturn(J.Return _return, ExecutionContext executionContext) {
+                Cursor methodCursor = getCursor();
+                while (methodCursor != null && !(methodCursor.getValue() instanceof J.Lambda || methodCursor.getValue() instanceof J.MethodDeclaration)) {
+                    methodCursor = methodCursor.getParent();
+                }
+                if (methodCursor != null && methodCursor.getValue() instanceof J.MethodDeclaration) {
+                    methodCursor.putMessage(MSG_KEY, _return.getExpression().getType());
+                }
+                return super.visitReturn(_return, executionContext);
+            }
+        };
+    }
+}

--- a/src/testWithSpringBoot_2_4/kotlin/org/openrewrite/java/spring/boot3/PreciseBeanTypeTest.kt
+++ b/src/testWithSpringBoot_2_4/kotlin/org/openrewrite/java/spring/boot3/PreciseBeanTypeTest.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openrewrite.java.spring.boot3
 
 import org.junit.jupiter.api.Test

--- a/src/testWithSpringBoot_2_4/kotlin/org/openrewrite/java/spring/boot3/PreciseBeanTypeTest.kt
+++ b/src/testWithSpringBoot_2_4/kotlin/org/openrewrite/java/spring/boot3/PreciseBeanTypeTest.kt
@@ -1,0 +1,114 @@
+package org.openrewrite.java.spring.boot3
+
+import org.junit.jupiter.api.Test
+import org.openrewrite.Recipe
+import org.openrewrite.java.JavaParser
+import org.openrewrite.java.JavaRecipeTest
+
+class PreciseBeanTypeTest : JavaRecipeTest {
+
+    override val parser: JavaParser
+        get() = JavaParser.fromJavaVersion()
+            .logCompilationWarningsAndErrors(true)
+            .classpath("spring-context", "spring-boot")
+            .build()
+
+    override val recipe: Recipe
+        get() = PreciseBeanType()
+
+
+    @Test
+    fun simplestCase() = assertChanged(
+        before = """
+            import org.springframework.context.annotation.Bean;
+            import java.util.List;
+            import java.util.ArrayList;
+            
+            class A {
+                @Bean
+                List bean1() {
+                    return new ArrayList();
+                }
+            }
+        """,
+        after = """
+            import org.springframework.context.annotation.Bean;
+            import java.util.ArrayList;
+            
+            class A {
+                @Bean
+                ArrayList bean1() {
+                    return new ArrayList();
+                }
+            }
+        """
+    )
+
+    @Test
+    fun nestedCase() = assertChanged(
+        before = """
+            import org.springframework.context.annotation.Bean;
+            import java.util.List;
+            import java.util.ArrayList;
+            import java.util.Stack;
+            import java.util.concurrent.Callable;
+            
+            class A {
+                @Bean
+                List bean1() {
+                    Callable<List> callable = () -> {
+                        return new ArrayList();
+                    };
+                    return new Stack();
+                }
+            }
+        """,
+        after = """
+            import org.springframework.context.annotation.Bean;
+            import java.util.List;
+            import java.util.ArrayList;
+            import java.util.Stack;
+            import java.util.concurrent.Callable;
+            
+            class A {
+                @Bean
+                Stack bean1() {
+                    Callable<List> callable = () -> {
+                        return new ArrayList();
+                    };
+                    return new Stack();
+                }
+            }
+        """
+    )
+
+    @Test
+    fun notApplicableCase() = assertUnchanged(
+        before = """
+            import org.springframework.context.annotation.Bean;
+            import java.util.ArrayList;
+            
+            class A {
+                @Bean
+                ArrayList bean1() {
+                    return new ArrayList();
+                }
+            }
+        """
+    )
+
+    @Test
+    fun notApplicablePrimitiveTypeCase() = assertUnchanged(
+        before = """
+            import org.springframework.context.annotation.Bean;
+            
+            class A {
+                @Bean
+                String bean1() {
+                    return "hello";
+                }
+            }
+        """
+    )
+
+}


### PR DESCRIPTION
Switch bean method return type declaration to precise type from the return statement. This recipe should be useful for AOT.

Feedback is very welcomed @pway99 (cc @martinlippert)