### PR TITLE
Dont convert autowired field if it is initialized in constructor

### DIFF
--- a/src/testWithSpringBoot_2_1/kotlin/org/openrewrite/java/spring/AutowiredFieldIntoConstructorParameterVisitorTest.kt
+++ b/src/testWithSpringBoot_2_1/kotlin/org/openrewrite/java/spring/AutowiredFieldIntoConstructorParameterVisitorTest.kt
@@ -254,5 +254,43 @@ class AutowiredFieldIntoConstructorParameterVisitorTest : JavaRecipeTest {
         """
     )
 
+    @Test
+    fun fieldInitializedInConstructor() = assertUnchanged(
+        before = """
+            package demo;
 
+            import org.springframework.beans.factory.annotation.Autowired;
+            
+            public class A {
+            
+                @Autowired
+                private String a;
+                
+                A() {
+                    this.a = "something";
+                }
+            
+            }
+        """
+    )
+
+    @Test
+    fun fieldInitializedInConstructorWithoutThis() = assertUnchanged(
+        before = """
+            package demo;
+
+            import org.springframework.beans.factory.annotation.Autowired;
+            
+            public class A {
+            
+                @Autowired
+                private String a;
+                
+                A() {
+                    a = "something";
+                }
+            
+            }
+        """
+    )
 }


### PR DESCRIPTION
@pway99 (cc: @martinlippert)

Code such as

```java
public class A {
            
                @Autowired
                private String a;
                
                A() {
                    this.a = "something";
                }
            
            }
```

or 

```java
public class A {
            
                @Autowired
                private String a;
                
                A(String a) {
                    this.a = a;
                }
            
            }
```

would still add the field as constructor parameter and add the assignment statement in the constructor. I suggest just short-circuiting and not doing anything in in this case... Not even remove the `@Autowired` in the second snippet...