### PR TITLE
Boot 3 upgrade adjustments

### DIFF
--- a/src/main/resources/META-INF/rewrite/spring-boot-27.yml
+++ b/src/main/resources/META-INF/rewrite/spring-boot-27.yml
@@ -19,7 +19,7 @@
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.spring.boot2.UpgradeSpringBoot_2_7
-displayName: Upgrade to Spring Boot 2.7
+displayName: Migrate to Spring Boot 2.7 from Spring Boot 2.0 through 2.6
 description: 'Upgrade to Spring Boot 2.7 from any prior 2.x version.'
 recipeList:
   # Upgrade to 2.6.x from 2.5.x

--- a/src/main/resources/META-INF/rewrite/spring-boot-30.yml
+++ b/src/main/resources/META-INF/rewrite/spring-boot-30.yml
@@ -30,7 +30,7 @@ recipeList:
   - org.openrewrite.java.spring.boot3.MavenPomUpgrade
   - org.openrewrite.java.migrate.jakarta.JavaxMigrationToJakarta
   - org.openrewrite.java.spring.boot3.RemoveConstructorBindingAnnotation
-  - org.openrewrite.java.spring.boot3.LegacyJmxExposure
+#  - org.openrewrite.java.spring.boot3.LegacyJmxExposure
   - org.openrewrite.java.spring.boot3.ActuatorEndpointSanitization
   - org.openrewrite.java.spring.boot3.Saml
   - org.openrewrite.java.spring.boot3.SpringBootProperties_3_0_0
@@ -96,18 +96,18 @@ recipeList:
       propertyKey: management.endpoint.configprops.additional-keys-to-sanitize
   - org.openrewrite.java.spring.DeleteSpringProperty:
       propertyKey: management.endpoint.env.additional-keys-to-sanitize
-  - org.openrewrite.java.spring.AddSpringProperty:
-      property: management.endpoint.configprops.show-values
-      value: ALWAYS
-      comment: "This value was added to maintain parity with SpringBoot 2.x and should be changed to either to \"NEVER\" or \"WHEN_AUTHORIZED\"."
-  - org.openrewrite.java.spring.AddSpringProperty:
-      property: management.endpoint.env.show-values
-      value: ALWAYS
-      comment: "This value was added to maintain parity with SpringBoot 2.x and should be changed to either to \"NEVER\" or \"WHEN_AUTHORIZED\"."
-  - org.openrewrite.java.spring.AddSpringProperty:
-      property: management.endpoint.quartz.show-values
-      value: ALWAYS
-      comment: "This value was added to maintain parity with SpringBoot 2.x and should be changed to either to \"NEVER\" or \"WHEN_AUTHORIZED\"."
+#  - org.openrewrite.java.spring.AddSpringProperty:
+#      property: management.endpoint.configprops.show-values
+#      value: ALWAYS
+#      comment: "This value was added to maintain parity with SpringBoot 2.x and should be changed to either to \"NEVER\" or \"WHEN_AUTHORIZED\"."
+#  - org.openrewrite.java.spring.AddSpringProperty:
+#      property: management.endpoint.env.show-values
+#      value: ALWAYS
+#      comment: "This value was added to maintain parity with SpringBoot 2.x and should be changed to either to \"NEVER\" or \"WHEN_AUTHORIZED\"."
+#  - org.openrewrite.java.spring.AddSpringProperty:
+#      property: management.endpoint.quartz.show-values
+#      value: ALWAYS
+#      comment: "This value was added to maintain parity with SpringBoot 2.x and should be changed to either to \"NEVER\" or \"WHEN_AUTHORIZED\"."
 
 ---
 ########################################################################################################################

--- a/src/testWithSpringBoot_3_0/java/org/openrewrite/java/spring/boot3/UpgradeSpringBoot3ConfigurationTest.java
+++ b/src/testWithSpringBoot_3_0/java/org/openrewrite/java/spring/boot3/UpgradeSpringBoot3ConfigurationTest.java
@@ -58,53 +58,53 @@ public class UpgradeSpringBoot3ConfigurationTest implements RewriteTest {
         );
     }
 
-    @Test
-    void actuatorEndpointSanitization() {
-        rewriteRun(
-                spec -> spec.recipe(Environment.builder()
-                        .scanRuntimeClasspath()
-                        .build()
-                        .activateRecipes("org.openrewrite.java.spring.boot3.ActuatorEndpointSanitization")
-                ),
-                properties(
-                        """
-                            # application.properties
-                            management.endpoint.configprops.additional-keys-to-sanitize=key1,key2
-                            management.endpoint.env.additional-keys-to-sanitize=key1,key2
-                        """,
-                        """
-                            # application.properties
-                            management.endpoint.configprops.show-values=ALWAYS
-                            management.endpoint.env.show-values=ALWAYS
-                            management.endpoint.quartz.show-values=ALWAYS
-                        """,
-                        s -> s.path("src/main/resources/application.properties")
-                ),
-                yaml(
-                        """
-                            management:
-                              endpoint:
-                                configprops:
-                                  additional-keys-to-sanitize: key1,key2
-                                env:
-                                  additional-keys-to-sanitize: key1,key2
-                        """,
-                        """
-                            management:
-                              endpoint:
-                                configprops:
-                                  # This value was added to maintain parity with SpringBoot 2.x and should be changed to either to "NEVER" or "WHEN_AUTHORIZED".
-                                  show-values: ALWAYS
-                                env:
-                                  # This value was added to maintain parity with SpringBoot 2.x and should be changed to either to "NEVER" or "WHEN_AUTHORIZED".
-                                  show-values: ALWAYS
-                                quartz:
-                                  # This value was added to maintain parity with SpringBoot 2.x and should be changed to either to "NEVER" or "WHEN_AUTHORIZED".
-                                  show-values: ALWAYS
-                        """,
-                        s -> s.path("src/main/resources/application.yml")
-                )
-        );
-    }
+//    @Test
+//    void actuatorEndpointSanitization() {
+//        rewriteRun(
+//                spec -> spec.recipe(Environment.builder()
+//                        .scanRuntimeClasspath()
+//                        .build()
+//                        .activateRecipes("org.openrewrite.java.spring.boot3.ActuatorEndpointSanitization")
+//                ),
+//                properties(
+//                        """
+//                            # application.properties
+//                            management.endpoint.configprops.additional-keys-to-sanitize=key1,key2
+//                            management.endpoint.env.additional-keys-to-sanitize=key1,key2
+//                        """,
+//                        """
+//                            # application.properties
+//                            management.endpoint.configprops.show-values=ALWAYS
+//                            management.endpoint.env.show-values=ALWAYS
+//                            management.endpoint.quartz.show-values=ALWAYS
+//                        """,
+//                        s -> s.path("src/main/resources/application.properties")
+//                ),
+//                yaml(
+//                        """
+//                            management:
+//                              endpoint:
+//                                configprops:
+//                                  additional-keys-to-sanitize: key1,key2
+//                                env:
+//                                  additional-keys-to-sanitize: key1,key2
+//                        """,
+//                        """
+//                            management:
+//                              endpoint:
+//                                configprops:
+//                                  # This value was added to maintain parity with SpringBoot 2.x and should be changed to either to "NEVER" or "WHEN_AUTHORIZED".
+//                                  show-values: ALWAYS
+//                                env:
+//                                  # This value was added to maintain parity with SpringBoot 2.x and should be changed to either to "NEVER" or "WHEN_AUTHORIZED".
+//                                  show-values: ALWAYS
+//                                quartz:
+//                                  # This value was added to maintain parity with SpringBoot 2.x and should be changed to either to "NEVER" or "WHEN_AUTHORIZED".
+//                                  show-values: ALWAYS
+//                        """,
+//                        s -> s.path("src/main/resources/application.yml")
+//                )
+//        );
+//    }
 
 }


### PR DESCRIPTION
- Display name for 2.6 upgrade inline with other 2.x upgrades
- Commented out extra properties added via actuator endpoint sanitization (We've decided to remove them, correct?)
- Comment out Legacy JMX exposure. Feedback from Boot team indicates they'd rather users to review which endpoints need to be exposed