### PR TITLE
Allow specification of the property key.

### DIFF
--- a/src/test/java/org/openrewrite/java/spring/data/UseTlsJdbcConnectionStringTest.java
+++ b/src/test/java/org/openrewrite/java/spring/data/UseTlsJdbcConnectionStringTest.java
@@ -26,7 +26,7 @@ class UseTlsJdbcConnectionStringTest implements RewriteTest {
 
     @Override
     public void defaults(RecipeSpec spec) {
-        spec.recipe(new UseTlsJdbcConnectionString(5021, 15021, "sslConnection=true;"));
+        spec.recipe(new UseTlsJdbcConnectionString(null, 5021, 15021, "sslConnection=true;"));
     }
 
     @Test
@@ -66,6 +66,25 @@ class UseTlsJdbcConnectionStringTest implements RewriteTest {
                 spring:
                     datasource:
                       url: 'jdbc:db2://10.2.1.101:5000/DB2INST1:currentSchema=DEV;commandTimeout=30;'
+              """
+          )
+        );
+    }
+
+    @Test
+    void allowCustomPropertyKey() {
+        rewriteRun(
+          spec -> spec.recipe(new UseTlsJdbcConnectionString("my.custom.url", 5021, 15021, "sslConnection=true;")),
+          yaml(
+            """
+              my:
+                custom:
+                  url: 'jdbc:db2://10.2.1.101:5021/DB2INST1:currentSchema=DEV;commandTimeout=30;'
+              """,
+            """
+              my:
+                custom:
+                  url: 'jdbc:db2://10.2.1.101:15021/DB2INST1:currentSchema=DEV;commandTimeout=30;sslConnection=true;'
               """
           )
         );


### PR DESCRIPTION
This allows for updating JDBC urls which are at different property keys, still within a Spring Boot application context. This particularly becomes useful when an application has more than a single JDBC connection. In these cases, the user often has to use custom properties to create each of their unique JDBC datasource configurations.