### PR TITLE
ChangeSpringPropertyKey no longer expands entire affected yaml

### DIFF
--- a/src/main/java/org/openrewrite/java/spring/ChangeSpringPropertyKey.java
+++ b/src/main/java/org/openrewrite/java/spring/ChangeSpringPropertyKey.java
@@ -70,18 +70,13 @@ public class ChangeSpringPropertyKey extends Recipe {
                 new org.openrewrite.properties.ChangePropertyKey(oldPropertyKey, newPropertyKey, true, null, false);
         org.openrewrite.properties.ChangePropertyKey subpropertiesChangePropertyKey =
                 new org.openrewrite.properties.ChangePropertyKey(Pattern.quote(oldPropertyKey + ".") + exceptRegex() + "(.*)", newPropertyKey + ".$1", true, null, true);
-        ExpandProperties expandYaml = new ExpandProperties();
         return ListUtils.map(before, s -> {
             if (s instanceof Yaml.Documents) {
-                Yaml.Documents after = (Yaml.Documents) yamlChangePropertyKey.getVisitor().visit(s, ctx);
-                if (after != s) {
-                    s = (Yaml.Documents) expandYaml.getVisitor().visit(after, ctx);
-                }
+                s = (Yaml.Documents) yamlChangePropertyKey.getVisitor().visit(s, ctx);
             } else if (s instanceof Properties.File) {
                 s = (Properties.File) propertiesChangePropertyKey.getVisitor().visit(s, ctx);
                 s = (Properties.File) subpropertiesChangePropertyKey.getVisitor().visit(s, ctx);
             }
-
             return s;
         });
     }

--- a/src/test/java/org/openrewrite/java/spring/ChangeSpringPropertyKeyTest.java
+++ b/src/test/java/org/openrewrite/java/spring/ChangeSpringPropertyKeyTest.java
@@ -45,8 +45,7 @@ public class ChangeSpringPropertyKeyTest implements RewriteTest {
                         """,
                         """
                             server:
-                              servlet:
-                                path: /tmp/my-server-path
+                              servlet.path: /tmp/my-server-path
                         """
                 )
         );
@@ -75,10 +74,7 @@ public class ChangeSpringPropertyKeyTest implements RewriteTest {
                         """
                             server:
                               port: 8888
-                            servlet:
-                              session:
-                                cookie:
-                                  path: /tmp/my-server-path
+                            servlet.session.cookie.path: /tmp/my-server-path
                         """
                 )
         );
@@ -113,15 +109,14 @@ public class ChangeSpringPropertyKeyTest implements RewriteTest {
                   """,
             """
                 spring:
-                  web:
-                    resources:
-                      chain:
-                        strategy:
-                          content:
-                            enabled: true
-                            paths:
-                              - /foo/**
-                              - /bar/**
+                  web.resources:
+                    chain:
+                      strategy:
+                        content:
+                          enabled: true
+                          paths:
+                            - /foo/**
+                            - /bar/**
                   """
           )
         );

--- a/src/testWithSpringBoot_2_4/java/org/openrewrite/java/spring/boot2/UpgradeSpringBoot2ConfigurationTest.java
+++ b/src/testWithSpringBoot_2_4/java/org/openrewrite/java/spring/boot2/UpgradeSpringBoot2ConfigurationTest.java
@@ -68,9 +68,7 @@ public class UpgradeSpringBoot2ConfigurationTest implements RewriteTest {
                                 active: dev
                             ---
                             spring:
-                              config:
-                                activate:
-                                  on-profile: prod
+                              config.activate.on-profile: prod
                         """,
                         s -> s.path("src/main/resources/application.yml")
                 )


### PR DESCRIPTION
Current state: if this recipe touches a yaml, then the entire file gets expanded to the indented syntax (no dot separation)

With this PR: yaml props modified by this recipe will always be dot-separated, but the rest of the file remains as it was

Ideally, we'd have some Style logic to attempt to maintain the source file's preferences, but in the interim, this PR should make the recipe more minimally-invasive