### PR TITLE
Periodic regression test of Spring Petclinic migration

### DIFF
--- a/.github/workflows/regression-test.yml
+++ b/.github/workflows/regression-test.yml
@@ -16,7 +16,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          fetch-depth: 0
           name: spring-projects/spring-petclinic
           ref: 1.5.x
       - uses: actions/setup-java@v3

--- a/.github/workflows/regression-test.yml
+++ b/.github/workflows/regression-test.yml
@@ -16,6 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
+          fetch-depth: 0
           name: spring-projects/spring-petclinic
           ref: refs/tags/1.5.x
       - uses: actions/setup-java@v3

--- a/.github/workflows/regression-test.yml
+++ b/.github/workflows/regression-test.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           name: spring-projects/spring-petclinic
-          ref: 1.5.x
+          ref: refs/tags/1.5.x
       - uses: actions/setup-java@v3
         with:
           distribution: temurin

--- a/.github/workflows/regression-test.yml
+++ b/.github/workflows/regression-test.yml
@@ -25,13 +25,13 @@ jobs:
           java-version: 8
 
       - name: Upgrade Maven Wrapper
-        run: ./mvnw wrapper:wrapper -Dmaven=3.8.7
+        run: ./mvnw -B wrapper:wrapper -Dmaven=3.8.7
 
       - name: Upgrade to Spring Boot 2.x
-        run: ./mvnw -U org.openrewrite.maven:rewrite-maven-plugin:run -Drewrite.recipeArtifactCoordinates=org.openrewrite.recipe:rewrite-spring:LATEST -DactiveRecipes=org.openrewrite.java.spring.boot2.SpringBoot1To2Migration
+        run: ./mvnw -B -U org.openrewrite.maven:rewrite-maven-plugin:run -Drewrite.recipeArtifactCoordinates=org.openrewrite.recipe:rewrite-spring:LATEST -DactiveRecipes=org.openrewrite.java.spring.boot2.SpringBoot1To2Migration
 
       - name: Upgrade to Java 17
-        run: ./mvnw -U org.openrewrite.maven:rewrite-maven-plugin:run -Drewrite.recipeArtifactCoordinates=org.openrewrite.recipe:rewrite-migrate-java:LATEST -DactiveRecipes=org.openrewrite.java.migrate.UpgradeToJava17
+        run: ./mvnw -B -U org.openrewrite.maven:rewrite-maven-plugin:run -Drewrite.recipeArtifactCoordinates=org.openrewrite.recipe:rewrite-migrate-java:LATEST -DactiveRecipes=org.openrewrite.java.migrate.UpgradeToJava17
 
       - uses: actions/setup-java@v3
         with:

--- a/.github/workflows/regression-test.yml
+++ b/.github/workflows/regression-test.yml
@@ -1,10 +1,10 @@
 ---
 name: regression-test
 
-on:
-  workflow_dispatch: {}
-  schedule:
-    - cron: 0 18 * * *
+on: [push]
+#  workflow_dispatch: {}
+#  schedule:
+#    - cron: 0 18 * * *
 
 concurrency:
   group: regression-test-${{ github.ref }}

--- a/.github/workflows/regression-test.yml
+++ b/.github/workflows/regression-test.yml
@@ -29,9 +29,13 @@ jobs:
 
       - name: Upgrade to Spring Boot 2.x
         run: ./mvnw -B -U org.openrewrite.maven:rewrite-maven-plugin:run -Drewrite.recipeArtifactCoordinates=org.openrewrite.recipe:rewrite-spring:LATEST -DactiveRecipes=org.openrewrite.java.spring.boot2.SpringBoot1To2Migration
+      - name: Show Spring Boot 2.x Changes
+        run: git diff
 
       - name: Upgrade to Java 17
         run: ./mvnw -B -U org.openrewrite.maven:rewrite-maven-plugin:run -Drewrite.recipeArtifactCoordinates=org.openrewrite.recipe:rewrite-migrate-java:LATEST -DactiveRecipes=org.openrewrite.java.migrate.UpgradeToJava17
+      - name: Show Java 17 Changes
+        run: git diff
 
       - uses: actions/setup-java@v3
         with:

--- a/.github/workflows/regression-test.yml
+++ b/.github/workflows/regression-test.yml
@@ -1,0 +1,42 @@
+---
+name: regression-test
+
+on:
+  workflow_dispatch: {}
+  schedule:
+    - cron: 0 18 * * *
+
+concurrency:
+  group: regression-test-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  regression-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          name: spring-projects/spring-petclinic
+          ref: 1.5.x
+      - uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: 8
+
+      - name: Upgrade Maven Wrapper
+        run: ./mvnw wrapper:wrapper -Dmaven=3.8.7
+
+      - name: Upgrade to Spring Boot 2.x
+        run: ./mvnw -U org.openrewrite.maven:rewrite-maven-plugin:run -Drewrite.recipeArtifactCoordinates=org.openrewrite.recipe:rewrite-spring:LATEST -DactiveRecipes=org.openrewrite.java.spring.boot2.SpringBoot1To2Migration
+
+      - name: Upgrade to Java 17
+        run: ./mvnw -U org.openrewrite.maven:rewrite-maven-plugin:run -Drewrite.recipeArtifactCoordinates=org.openrewrite.recipe:rewrite-migrate-java:LATEST -DactiveRecipes=org.openrewrite.java.migrate.UpgradeToJava17
+
+      - uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Maven Verify
+        run: ./mvnw verify

--- a/.github/workflows/regression-test.yml
+++ b/.github/workflows/regression-test.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          name: spring-projects/spring-petclinic
+          repository: spring-projects/spring-petclinic
           ref: refs/tags/1.5.x
       - uses: actions/setup-java@v3
         with:


### PR DESCRIPTION
Whenever I run a demo, I want to show a quick migration from Spring Petclinic branch 1.5.x to 2.x (maybe 3.x soon).
This time around I discovered a few [small](https://github.com/openrewrite/rewrite-testing-frameworks/issues/306) [imperfections](https://github.com/openrewrite/rewrite-spring/pull/277); with this periodic check I hope to catch those sooner.

What the regression test should ideally do:

1. checkout the [1.5.x branch](https://github.com/spring-projects/spring-petclinic/tree/1.5.x) of pet clinic
2. Upgrade that to Spring Boot 2.x
3. Update then to Java 17
4. Run Maven verify
5. Assert there's two test failures (or patch those just before)
6. Notify if there's any unexpected results

By using `-U org.openrewrite.maven:rewrite-maven-plugin:run` and `rewrite-spring:LATEST` this pipeline is not tied to any particular version of rewrite or rewrite-spring. That way it'll only signal issues after a new release of either rewrite or spring.