### PR TITLE
Adopt TypeValidation.builder

### DIFF
--- a/src/testWithSpringBoot_1_5/java/org/openrewrite/java/spring/boot2/RestTemplateBuilderRequestFactoryTest.java
+++ b/src/testWithSpringBoot_1_5/java/org/openrewrite/java/spring/boot2/RestTemplateBuilderRequestFactoryTest.java
@@ -35,7 +35,7 @@ class RestTemplateBuilderRequestFactoryTest implements RewriteTest {
     void useSupplierArgument() {
         //language=java
         rewriteRun(
-          spec -> { spec.typeValidationOptions(new TypeValidation(true, true, true, false)); },
+          spec -> spec.typeValidationOptions(TypeValidation.builder().methodInvocations(false).build()),
           java(
             """
               import org.springframework.boot.web.client.RestTemplateBuilder;


### PR DESCRIPTION
As newly introduced field constructorInvocations broke compilation. 
https://github.com/openrewrite/rewrite/commit/3713130abc9e1d33035bfe2a05bdc5a3c44dda72 
https://github.com/openrewrite/rewrite/commit/25881a39cccea07da3476e6f59fe3546c6b1cd3e#diff-a3cf032c10c69c8adebc020b5c717393e8b1e11e6d32e6132010bb38fbd147a5R33