### PR TITLE
Flatten configuration class if possible

### DIFF
--- a/src/main/java/org/openrewrite/java/spring/boot2/WebSecurityConfigurerAdapter.java
+++ b/src/main/java/org/openrewrite/java/spring/boot2/WebSecurityConfigurerAdapter.java
@@ -22,18 +22,14 @@ import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.java.JavaTemplate;
 import org.openrewrite.java.MethodMatcher;
+import org.openrewrite.java.format.AutoFormatVisitor;
 import org.openrewrite.java.search.UsesType;
-import org.openrewrite.java.tree.J;
-import org.openrewrite.java.tree.JavaType;
-import org.openrewrite.java.tree.Space;
-import org.openrewrite.java.tree.TypeUtils;
+import org.openrewrite.java.tree.*;
 import org.openrewrite.marker.Markers;
 import org.openrewrite.marker.SearchResult;
 
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Comparator;
+import java.util.*;
+import java.util.stream.Collectors;
 
 /**
  * @author Alex Boyko
@@ -67,6 +63,8 @@ public class WebSecurityConfigurerAdapter extends Recipe {
 
     private static final String HAS_CONFLICT = "has-conflict";
 
+    private static final String FLATTEN_CLASSES = "flatten-classes";
+
     @Override
     public String getDisplayName() {
         return "Spring Security 5.4 introduces the ability to configure HttpSecurity by creating a SecurityFilterChain bean";
@@ -87,21 +85,123 @@ public class WebSecurityConfigurerAdapter extends Recipe {
         return new JavaIsoVisitor<ExecutionContext>() {
             @Override
             public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration classDecl, ExecutionContext context) {
-                if (TypeUtils.isAssignableTo(FQN_WEB_SECURITY_CONFIGURER_ADAPTER, classDecl.getType())
-                        && classDecl.getLeadingAnnotations().stream().anyMatch(a -> TypeUtils.isOfClassType(a.getType(), FQN_CONFIGURATION))) {
-                    boolean hasConflict = false;
+                boolean isWebSecurityConfigurerAdapterClass = TypeUtils.isAssignableTo(FQN_WEB_SECURITY_CONFIGURER_ADAPTER, classDecl.getType())
+                        && isClassAnnotatedWith(classDecl, FQN_CONFIGURATION);
+                boolean hasConflict = false;
+                if (isWebSecurityConfigurerAdapterClass) {
                     for (JavaType.Method method : classDecl.getType().getMethods()) {
                         if (isConflictingMethod(method, method.getName())) {
                             hasConflict = true;
+                            break;
                         }
                     }
                     getCursor().putMessage(HAS_CONFLICT, hasConflict);
-                    if (!hasConflict) {
-                        maybeRemoveImport(FQN_WEB_SECURITY_CONFIGURER_ADAPTER);
-                        classDecl = classDecl.withExtends(null);
+                    maybeRemoveImport(FQN_WEB_SECURITY_CONFIGURER_ADAPTER);
+                }
+                classDecl = super.visitClassDeclaration(classDecl, context);
+                if (!isWebSecurityConfigurerAdapterClass) {
+                    classDecl = processAnyClass(classDecl);
+                } else if (!hasConflict) {
+                    classDecl = processSecurityAdapterClass(classDecl);
+                }
+                return classDecl;
+            }
+
+            private J.ClassDeclaration processSecurityAdapterClass(J.ClassDeclaration classDecl) {
+                classDecl = classDecl.withExtends(null);
+                // Flatten configuration classes if applicable
+                Cursor enclosingClassCursor = getCursor().getParent();
+                while (enclosingClassCursor != null && !(enclosingClassCursor.getValue() instanceof J.ClassDeclaration)) {
+                    enclosingClassCursor = enclosingClassCursor.getParent();
+                }
+                if (enclosingClassCursor != null && enclosingClassCursor.getValue() instanceof J.ClassDeclaration) {
+                    J.ClassDeclaration enclosingClass = enclosingClassCursor.getValue();
+                    if (isMetaAnnotated(enclosingClass.getType(), FQN_CONFIGURATION, new HashSet<>()) && canMergeClassDeclarations(enclosingClass, classDecl)) {
+                        // can flatten. Outer class is annotated as configuration bean
+                        List<J.ClassDeclaration> classesToFlatten = enclosingClassCursor.getMessage(FLATTEN_CLASSES);
+                        if (classesToFlatten == null) {
+                            classesToFlatten = new ArrayList<>();
+                            enclosingClassCursor.putMessage(FLATTEN_CLASSES, classesToFlatten);
+                        }
+                        // only applicable to former subclasses of WebSecurityConfigurereAdapter - other classes won't be flattened
+                        classesToFlatten.add(classDecl);
+                        // Remove imports for annotations being removed together with class declaration
+                        // It is impossible in the general case to tell whether some of these annotations might apply to the bean methods
+                        // However, a set of hardcoded annotations can be moved in the future
+                        for (J.Annotation a : classDecl.getLeadingAnnotations()) {
+                            JavaType.FullyQualified type = TypeUtils.asFullyQualified(a.getType());
+                            if (type != null) {
+                                maybeRemoveImport(type);
+                            }
+                        }
+                        classDecl = null; // remove class
                     }
                 }
-                return super.visitClassDeclaration(classDecl, context);
+                return classDecl;
+            }
+
+            private boolean canMergeClassDeclarations(J.ClassDeclaration a, J.ClassDeclaration b) {
+                Set<String> aVars = getAllVarNames(a);
+                Set<String> bVars = getAllVarNames(b);
+                for (String av : aVars) {
+                    if (bVars.contains(av)) {
+                        return false;
+                    }
+                }
+                Set<String> aMethods = getAllMethodSignatures(a);
+                Set<String> bMethods = getAllMethodSignatures(b);
+                for (String am : aMethods) {
+                    if (bMethods.contains(am)) {
+                        return false;
+                    }
+                }
+                return true;
+            }
+
+            private Set<String> getAllVarNames(J.ClassDeclaration c) {
+                return c.getBody().getStatements().stream()
+                        .filter(J.VariableDeclarations.class::isInstance)
+                        .map(J.VariableDeclarations.class::cast)
+                        .flatMap(vd -> vd.getVariables().stream())
+                        .map(v -> v.getName().getSimpleName())
+                        .collect(Collectors.toSet());
+            }
+
+            private Set<String> getAllMethodSignatures(J.ClassDeclaration c) {
+                return c.getBody().getStatements().stream()
+                        .filter(J.MethodDeclaration.class::isInstance)
+                        .map(J.MethodDeclaration.class::cast)
+                        .map(this::simpleMethodSignature)
+                        .collect(Collectors.toSet());
+            }
+
+            private String simpleMethodSignature(J.MethodDeclaration method) {
+                String fullSignature = MethodMatcher.methodPattern(method);
+                int firstSpaceIdx = fullSignature.indexOf(' ');
+                return firstSpaceIdx < 0 ? fullSignature : fullSignature.substring(firstSpaceIdx + 1);
+            }
+
+            private J.ClassDeclaration processAnyClass(J.ClassDeclaration classDecl) {
+                // regular class case
+                List<J.ClassDeclaration> toFlatten = getCursor().pollMessage(FLATTEN_CLASSES);
+                if (toFlatten != null) {
+                    // The message won't be 'null' for a configuration class
+                    List<Statement> statements = new ArrayList<>(classDecl.getBody().getStatements().size() + toFlatten.size());
+                    statements.addAll(classDecl.getBody().getStatements());
+                    for (J.ClassDeclaration fc : toFlatten) {
+                        for (Statement s : fc.getBody().getStatements()) {
+                            statements.add(s);
+                        }
+                    }
+                    classDecl = classDecl.withBody(classDecl.getBody().withStatements(statements));
+                    //TODO: not sure how to autoformat only the statements added to the class declaration
+                    doAfterVisit(new AutoFormatVisitor<>());
+                }
+                return classDecl;
+            }
+
+            private boolean isClassAnnotatedWith(J.ClassDeclaration classDecl, String annotationType) {
+                return classDecl.getLeadingAnnotations().stream().anyMatch(a -> TypeUtils.isOfClassType(a.getType(), annotationType));
             }
 
             private boolean isConflictingMethod(@Nullable JavaType.Method methodType, String methodName) {
@@ -118,11 +218,13 @@ public class WebSecurityConfigurerAdapter extends Recipe {
                 if (isConflictingMethod(m.getMethodType(), method.getSimpleName())) {
                     m = SearchResult.found(m, "Migrate manually based on https://spring.io/blog/2022/02/21/spring-security-without-the-websecurityconfigureradapter");
                 } else if (!classCursor.getMessage(HAS_CONFLICT, true)) {
-                    if (CONFIGURE_HTTP_SECURITY_METHOD_MATCHER.matches(m, classCursor.getValue())) {
-                        JavaType securityChainType = JavaType.buildType(FQN_SECURITY_FILTER_CHAIN);
+                    J.ClassDeclaration c = classCursor.getValue();
+                    if (CONFIGURE_HTTP_SECURITY_METHOD_MATCHER.matches(m, c)) {
+                        JavaType.FullyQualified securityChainType = (JavaType.FullyQualified) JavaType.buildType(FQN_SECURITY_FILTER_CHAIN);
                         JavaType.Method type = m.getMethodType();
+                        String newMethodName = computeBeanNameFromClassName(c.getSimpleName(), securityChainType.getClassName());
                         if (type != null) {
-                            type = type.withName("filterChain").withReturnType(securityChainType);
+                            type = type.withName(newMethodName).withReturnType(securityChainType);
                         }
 
                         Space returnPrefix = m.getReturnTypeExpression() == null ? Space.EMPTY : m.getReturnTypeExpression().getPrefix();
@@ -133,18 +235,19 @@ public class WebSecurityConfigurerAdapter extends Recipe {
                                     }
                                     return anno;
                                 }))
-                                .withReturnTypeExpression(new J.Identifier(Tree.randomId(), returnPrefix, Markers.EMPTY,"SecurityFilterChain", securityChainType, null))
-                                .withName(m.getName().withSimpleName("filterChain"))
+                                .withReturnTypeExpression(new J.Identifier(Tree.randomId(), returnPrefix, Markers.EMPTY,securityChainType.getClassName(), securityChainType, null))
+                                .withName(m.getName().withSimpleName(newMethodName))
                                 .withMethodType(type)
                                 .withModifiers(ListUtils.map(m.getModifiers(), modifier -> EXPLICIT_ACCESS_LEVELS.contains(modifier.getType()) ? null : modifier));
 
                         m = addBeanAnnotation(m, getCursor());
                         maybeAddImport(FQN_SECURITY_FILTER_CHAIN);
                     } else if (CONFIGURE_WEB_SECURITY_METHOD_MATCHER.matches(m, classCursor.getValue())) {
-                        JavaType securityCustomizerType = JavaType.buildType(FQN_WEB_SECURITY_CUSTOMIZER);
+                        JavaType.FullyQualified securityCustomizerType = (JavaType.FullyQualified) JavaType.buildType(FQN_WEB_SECURITY_CUSTOMIZER);
                         JavaType.Method type = m.getMethodType();
+                        String newMethodName = computeBeanNameFromClassName(c.getSimpleName(), securityCustomizerType.getClassName());
                         if (type != null) {
-                            type = type.withName("webSecurityCustomizer").withReturnType(securityCustomizerType);
+                            type = type.withName(newMethodName).withReturnType(securityCustomizerType);
                         }
                         Space returnPrefix = m.getReturnTypeExpression() == null ? Space.EMPTY : m.getReturnTypeExpression().getPrefix();
                         m = m.withLeadingAnnotations(ListUtils.map(m.getLeadingAnnotations(), anno -> {
@@ -156,8 +259,8 @@ public class WebSecurityConfigurerAdapter extends Recipe {
                                 }))
                                 .withMethodType(type)
                                 .withParameters(Collections.emptyList())
-                                .withReturnTypeExpression(new J.Identifier(Tree.randomId(), returnPrefix, Markers.EMPTY,"WebSecurityCustomizer", securityCustomizerType, null))
-                                .withName(m.getName().withSimpleName("webSecurityCustomizer"))
+                                .withReturnTypeExpression(new J.Identifier(Tree.randomId(), returnPrefix, Markers.EMPTY,securityCustomizerType.getClassName(), securityCustomizerType, null))
+                                .withName(m.getName().withSimpleName(newMethodName))
                                 .withModifiers(ListUtils.map(m.getModifiers(), modifier -> EXPLICIT_ACCESS_LEVELS.contains(modifier.getType()) ? null : modifier));
 
                         m = addBeanAnnotation(m, getCursor());
@@ -208,6 +311,38 @@ public class WebSecurityConfigurerAdapter extends Recipe {
                 return m.withTemplate(template, m.getCoordinates().addAnnotation(Comparator.comparing(J.Annotation::getSimpleName)));
             }
 
+
         };
     }
+
+    private static String computeBeanNameFromClassName(String className, String beanType) {
+        String lowerCased = Character.toLowerCase(className.charAt(0)) + className.substring(1);
+        String newName = lowerCased
+                .replace("WebSecurityConfigurerAdapter", beanType)
+                .replace("SecurityConfigurerAdapter", beanType)
+                .replace("ConfigurerAdapter", beanType)
+                .replace("Adapter", beanType);
+        if (lowerCased.equals(newName)) {
+            newName = newName + beanType;
+        }
+        return newName;
+    }
+
+    private static boolean isMetaAnnotated(JavaType.FullyQualified t, String fqn, Set<JavaType.FullyQualified> visited) {
+        for (JavaType.FullyQualified a : t.getAnnotations()) {
+            if (!visited.contains(a)) {
+                visited.add(a);
+                if (fqn.equals(a.getFullyQualifiedName())) {
+                    return true;
+                } else {
+                    boolean metaAnnotated = isMetaAnnotated(a, fqn, visited);
+                    if (metaAnnotated) {
+                        return true;
+                    }
+                }
+            }
+        }
+        return false;
+    }
+
 }

--- a/src/testWithSpringBoot_2_4/java/org/openrewrite/java/spring/boot2/WebSecurityConfigurerAdapterTest.java
+++ b/src/testWithSpringBoot_2_4/java/org/openrewrite/java/spring/boot2/WebSecurityConfigurerAdapterTest.java
@@ -32,7 +32,7 @@ class WebSecurityConfigurerAdapterTest implements RewriteTest {
     public void defaults(RecipeSpec spec) {
         spec.recipe(new WebSecurityConfigurerAdapter())
           .parser(JavaParser.fromJavaVersion()
-            .classpath("spring-beans", "spring-context", "spring-boot", "spring-security", "spring-web", "tomcat-embed"));
+            .classpath("spring-beans", "spring-context", "spring-boot", "spring-security", "spring-web", "tomcat-embed", "spring-core"));
     }
 
     @Test
@@ -78,7 +78,7 @@ class WebSecurityConfigurerAdapterTest implements RewriteTest {
               public class SecurityConfiguration {
               
                   @Bean
-                  SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+                  SecurityFilterChain securityConfigurationSecurityFilterChain(HttpSecurity http) throws Exception {
                       http
                           .authorizeHttpRequests((authz) -> authz
                               .anyRequest().authenticated()
@@ -153,7 +153,7 @@ class WebSecurityConfigurerAdapterTest implements RewriteTest {
               public class SecurityConfiguration {
 
                   @Bean
-                  WebSecurityCustomizer webSecurityCustomizer() {
+                  WebSecurityCustomizer securityConfigurationWebSecurityCustomizer() {
                       return (web) -> {
                           web.ignoring().antMatchers("/ignore1", "/ignore2");
                       };
@@ -325,7 +325,7 @@ class WebSecurityConfigurerAdapterTest implements RewriteTest {
               public class SecurityConfiguration {
                             
                   @Bean
-                  SecurityFilterChain filterChain(HttpSecurity http) {
+                  SecurityFilterChain securityConfigurationSecurityFilterChain(HttpSecurity http) {
                       System.out.println(getApplicationContext());
                       http
                           .authorizeHttpRequests((authz) -> authz
@@ -385,7 +385,7 @@ class WebSecurityConfigurerAdapterTest implements RewriteTest {
               public class SecurityConfiguration {
                             
                   @Bean
-                  SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+                  SecurityFilterChain securityConfigurationSecurityFilterChain(HttpSecurity http) throws Exception {
                       http
                           .authorizeHttpRequests((authz) -> authz
                               .anyRequest().authenticated()
@@ -405,4 +405,200 @@ class WebSecurityConfigurerAdapterTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void multipleClasses() throws Exception {
+        rewriteRun(
+          java(
+            """
+              import org.springframework.context.annotation.Bean;
+              import org.springframework.context.annotation.Configuration;
+              import org.springframework.core.annotation.Order;
+              import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+              import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+              import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+              import org.springframework.security.core.userdetails.UserDetailsService;
+              import org.springframework.security.provisioning.InMemoryUserDetailsManager;
+
+              @EnableWebSecurity
+              public class MultiHttpSecurityConfig {
+              	@Bean
+              	public UserDetailsService userDetailsService() throws Exception {
+              		InMemoryUserDetailsManager manager = new InMemoryUserDetailsManager();
+              		return manager;
+              	}
+
+              	@Configuration
+              	@Order(1)
+              	public static class ApiWebSecurityConfigurationAdapter extends WebSecurityConfigurerAdapter {
+              		protected void configure(HttpSecurity http) throws Exception {
+              			http
+              				.antMatcher("/api/**")
+              				.authorizeRequests()
+              					.anyRequest().hasRole("ADMIN")
+              					.and()
+              				.httpBasic();
+              		}
+              	}
+
+              	@Configuration
+              	public static class FormLoginWebSecurityConfigurerAdapter extends WebSecurityConfigurerAdapter {
+
+              		@Override
+              		protected void configure(HttpSecurity http) throws Exception {
+              			http
+              				.authorizeRequests()
+              					.anyRequest().authenticated()
+              					.and()
+              				.formLogin();
+              		}
+              	}
+              }
+            """,
+            """
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.provisioning.InMemoryUserDetailsManager;
+import org.springframework.security.web.SecurityFilterChain;
+
+@EnableWebSecurity
+public class MultiHttpSecurityConfig {
+    @Bean
+    public UserDetailsService userDetailsService() throws Exception {
+        InMemoryUserDetailsManager manager = new InMemoryUserDetailsManager();
+        return manager;
+    }
+
+    @Bean
+    SecurityFilterChain apiWebSecurityConfigurationSecurityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .antMatcher("/api/**")
+                .authorizeRequests()
+                .anyRequest().hasRole("ADMIN")
+                .and()
+                .httpBasic();
+        return http.build();
+    }
+
+    @Bean
+    SecurityFilterChain formLoginSecurityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .authorizeRequests()
+                .anyRequest().authenticated()
+                .and()
+                .formLogin();
+        return http.build();
+    }
 }
+              """
+          )
+        );
+    }
+
+    @Test
+    void multipleClassesNoFlattening() throws Exception {
+        rewriteRun(
+          java(
+            """
+              import org.springframework.context.annotation.Bean;
+              import org.springframework.context.annotation.Configuration;
+              import org.springframework.core.annotation.Order;
+              import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+              import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+              import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+              import org.springframework.security.core.userdetails.UserDetailsService;
+              import org.springframework.security.provisioning.InMemoryUserDetailsManager;
+
+              @EnableWebSecurity
+              public class MultiHttpSecurityConfig {
+                private int a;
+              	@Bean
+              	public UserDetailsService userDetailsService() throws Exception {
+              		InMemoryUserDetailsManager manager = new InMemoryUserDetailsManager();
+              		return manager;
+              	}
+
+              	@Configuration
+              	@Order(1)
+              	public static class ApiWebSecurityConfigurationAdapter extends WebSecurityConfigurerAdapter {
+              	    private String a;
+              		protected void configure(HttpSecurity http) throws Exception {
+              			http
+              				.antMatcher("/api/**")
+              				.authorizeRequests()
+              					.anyRequest().hasRole("ADMIN")
+              					.and()
+              				.httpBasic();
+              		}
+              	}
+
+              	@Configuration
+              	public static class FormLoginWebSecurityConfigurerAdapter extends WebSecurityConfigurerAdapter {
+
+              		@Override
+              		protected void configure(HttpSecurity http) throws Exception {
+              			http
+              				.authorizeRequests()
+              					.anyRequest().authenticated()
+              					.and()
+              				.formLogin();
+              		}
+              	}
+              }
+            """,
+            """
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.provisioning.InMemoryUserDetailsManager;
+import org.springframework.security.web.SecurityFilterChain;
+
+@EnableWebSecurity
+public class MultiHttpSecurityConfig {
+    private int a;
+
+    @Bean
+    public UserDetailsService userDetailsService() throws Exception {
+        InMemoryUserDetailsManager manager = new InMemoryUserDetailsManager();
+        return manager;
+    }
+
+    @Configuration
+    @Order(1)
+    public static class ApiWebSecurityConfigurationAdapter {
+        private String a;
+
+        @Bean
+        SecurityFilterChain apiWebSecurityConfigurationSecurityFilterChain(HttpSecurity http) throws Exception {
+            http
+                    .antMatcher("/api/**")
+                    .authorizeRequests()
+                    .anyRequest().hasRole("ADMIN")
+                    .and()
+                    .httpBasic();
+            return http.build();
+        }
+    }
+    
+    @Bean
+    SecurityFilterChain formLoginSecurityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .authorizeRequests()
+                .anyRequest().authenticated()
+                .and()
+                .formLogin();
+        return http.build();
+    }
+}
+              """
+          )
+        );
+    }
+}
+
+

--- a/src/testWithSpringBoot_2_4/java/org/openrewrite/java/spring/boot2/WebSecurityConfigurerAdapterTest.java
+++ b/src/testWithSpringBoot_2_4/java/org/openrewrite/java/spring/boot2/WebSecurityConfigurerAdapterTest.java
@@ -78,7 +78,7 @@ class WebSecurityConfigurerAdapterTest implements RewriteTest {
               public class SecurityConfiguration {
               
                   @Bean
-                  SecurityFilterChain securityConfigurationSecurityFilterChain(HttpSecurity http) throws Exception {
+                  SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
                       http
                           .authorizeHttpRequests((authz) -> authz
                               .anyRequest().authenticated()
@@ -153,7 +153,7 @@ class WebSecurityConfigurerAdapterTest implements RewriteTest {
               public class SecurityConfiguration {
 
                   @Bean
-                  WebSecurityCustomizer securityConfigurationWebSecurityCustomizer() {
+                  WebSecurityCustomizer webSecurityCustomizer() {
                       return (web) -> {
                           web.ignoring().antMatchers("/ignore1", "/ignore2");
                       };
@@ -325,7 +325,7 @@ class WebSecurityConfigurerAdapterTest implements RewriteTest {
               public class SecurityConfiguration {
                             
                   @Bean
-                  SecurityFilterChain securityConfigurationSecurityFilterChain(HttpSecurity http) {
+                  SecurityFilterChain filterChain(HttpSecurity http) {
                       System.out.println(getApplicationContext());
                       http
                           .authorizeHttpRequests((authz) -> authz
@@ -385,7 +385,7 @@ class WebSecurityConfigurerAdapterTest implements RewriteTest {
               public class SecurityConfiguration {
                             
                   @Bean
-                  SecurityFilterChain securityConfigurationSecurityFilterChain(HttpSecurity http) throws Exception {
+                  SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
                       http
                           .authorizeHttpRequests((authz) -> authz
                               .anyRequest().authenticated()
@@ -411,88 +411,88 @@ class WebSecurityConfigurerAdapterTest implements RewriteTest {
         rewriteRun(
           java(
             """
-              import org.springframework.context.annotation.Bean;
-              import org.springframework.context.annotation.Configuration;
-              import org.springframework.core.annotation.Order;
-              import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-              import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-              import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
-              import org.springframework.security.core.userdetails.UserDetailsService;
-              import org.springframework.security.provisioning.InMemoryUserDetailsManager;
+            import org.springframework.context.annotation.Bean;
+            import org.springframework.context.annotation.Configuration;
+            import org.springframework.core.annotation.Order;
+            import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+            import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+            import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+            import org.springframework.security.core.userdetails.UserDetailsService;
+            import org.springframework.security.provisioning.InMemoryUserDetailsManager;
 
-              @EnableWebSecurity
-              public class MultiHttpSecurityConfig {
-              	@Bean
-              	public UserDetailsService userDetailsService() throws Exception {
-              		InMemoryUserDetailsManager manager = new InMemoryUserDetailsManager();
-              		return manager;
-              	}
+            @EnableWebSecurity
+            public class MultiHttpSecurityConfig {
+            	@Bean
+            	public UserDetailsService userDetailsService() throws Exception {
+            		InMemoryUserDetailsManager manager = new InMemoryUserDetailsManager();
+            		return manager;
+            	}
 
-              	@Configuration
-              	@Order(1)
-              	public static class ApiWebSecurityConfigurationAdapter extends WebSecurityConfigurerAdapter {
-              		protected void configure(HttpSecurity http) throws Exception {
-              			http
-              				.antMatcher("/api/**")
-              				.authorizeRequests()
-              					.anyRequest().hasRole("ADMIN")
-              					.and()
-              				.httpBasic();
-              		}
-              	}
+            	@Configuration
+            	@Order(1)
+            	public static class ApiWebSecurityConfigurationAdapter extends WebSecurityConfigurerAdapter {
+            		protected void configure(HttpSecurity http) throws Exception {
+            			http
+            				.antMatcher("/api/**")
+            				.authorizeRequests()
+            					.anyRequest().hasRole("ADMIN")
+            					.and()
+            				.httpBasic();
+            		}
+            	}
 
-              	@Configuration
-              	public static class FormLoginWebSecurityConfigurerAdapter extends WebSecurityConfigurerAdapter {
+            	@Configuration
+            	public static class FormLoginWebSecurityConfigurerAdapter extends WebSecurityConfigurerAdapter {
 
-              		@Override
-              		protected void configure(HttpSecurity http) throws Exception {
-              			http
-              				.authorizeRequests()
-              					.anyRequest().authenticated()
-              					.and()
-              				.formLogin();
-              		}
-              	}
-              }
+            		@Override
+            		protected void configure(HttpSecurity http) throws Exception {
+            			http
+            				.authorizeRequests()
+            					.anyRequest().authenticated()
+            					.and()
+            				.formLogin();
+            		}
+            	}
+            }
             """,
             """
-import org.springframework.context.annotation.Bean;
-import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.core.userdetails.UserDetailsService;
-import org.springframework.security.provisioning.InMemoryUserDetailsManager;
-import org.springframework.security.web.SecurityFilterChain;
-
-@EnableWebSecurity
-public class MultiHttpSecurityConfig {
-    @Bean
-    public UserDetailsService userDetailsService() throws Exception {
-        InMemoryUserDetailsManager manager = new InMemoryUserDetailsManager();
-        return manager;
-    }
-
-    @Bean
-    SecurityFilterChain apiWebSecurityConfigurationSecurityFilterChain(HttpSecurity http) throws Exception {
-        http
-                .antMatcher("/api/**")
-                .authorizeRequests()
-                .anyRequest().hasRole("ADMIN")
-                .and()
-                .httpBasic();
-        return http.build();
-    }
-
-    @Bean
-    SecurityFilterChain formLoginSecurityFilterChain(HttpSecurity http) throws Exception {
-        http
-                .authorizeRequests()
-                .anyRequest().authenticated()
-                .and()
-                .formLogin();
-        return http.build();
-    }
-}
-              """
+            import org.springframework.context.annotation.Bean;
+            import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+            import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+            import org.springframework.security.core.userdetails.UserDetailsService;
+            import org.springframework.security.provisioning.InMemoryUserDetailsManager;
+            import org.springframework.security.web.SecurityFilterChain;
+            
+            @EnableWebSecurity
+            public class MultiHttpSecurityConfig {
+                @Bean
+                public UserDetailsService userDetailsService() throws Exception {
+                    InMemoryUserDetailsManager manager = new InMemoryUserDetailsManager();
+                    return manager;
+                }
+            
+                @Bean
+                SecurityFilterChain apiWebSecurityConfigurationSecurityFilterChain(HttpSecurity http) throws Exception {
+                    http
+                            .antMatcher("/api/**")
+                            .authorizeRequests()
+                            .anyRequest().hasRole("ADMIN")
+                            .and()
+                            .httpBasic();
+                    return http.build();
+                }
+            
+                @Bean
+                SecurityFilterChain formLoginSecurityFilterChain(HttpSecurity http) throws Exception {
+                    http
+                            .authorizeRequests()
+                            .anyRequest().authenticated()
+                            .and()
+                            .formLogin();
+                    return http.build();
+                }
+            }
+            """
           )
         );
     }
@@ -501,7 +501,7 @@ public class MultiHttpSecurityConfig {
     void multipleClassesNoFlattening() throws Exception {
         rewriteRun(
           java(
-            """
+              """
               import org.springframework.context.annotation.Bean;
               import org.springframework.context.annotation.Configuration;
               import org.springframework.core.annotation.Order;
@@ -547,54 +547,54 @@ public class MultiHttpSecurityConfig {
               		}
               	}
               }
-            """,
+              """,
             """
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.core.annotation.Order;
-import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.core.userdetails.UserDetailsService;
-import org.springframework.security.provisioning.InMemoryUserDetailsManager;
-import org.springframework.security.web.SecurityFilterChain;
+              import org.springframework.context.annotation.Bean;
+              import org.springframework.context.annotation.Configuration;
+              import org.springframework.core.annotation.Order;
+              import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+              import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+              import org.springframework.security.core.userdetails.UserDetailsService;
+              import org.springframework.security.provisioning.InMemoryUserDetailsManager;
+              import org.springframework.security.web.SecurityFilterChain;
 
-@EnableWebSecurity
-public class MultiHttpSecurityConfig {
-    private int a;
+              @EnableWebSecurity
+              public class MultiHttpSecurityConfig {
+                  private int a;
 
-    @Bean
-    public UserDetailsService userDetailsService() throws Exception {
-        InMemoryUserDetailsManager manager = new InMemoryUserDetailsManager();
-        return manager;
-    }
+                  @Bean
+                  public UserDetailsService userDetailsService() throws Exception {
+                      InMemoryUserDetailsManager manager = new InMemoryUserDetailsManager();
+                      return manager;
+                  }
 
-    @Configuration
-    @Order(1)
-    public static class ApiWebSecurityConfigurationAdapter {
-        private String a;
+                  @Configuration
+                  @Order(1)
+                  public static class ApiWebSecurityConfigurationAdapter {
+                      private String a;
 
-        @Bean
-        SecurityFilterChain apiWebSecurityConfigurationSecurityFilterChain(HttpSecurity http) throws Exception {
-            http
-                    .antMatcher("/api/**")
-                    .authorizeRequests()
-                    .anyRequest().hasRole("ADMIN")
-                    .and()
-                    .httpBasic();
-            return http.build();
-        }
-    }
-    
-    @Bean
-    SecurityFilterChain formLoginSecurityFilterChain(HttpSecurity http) throws Exception {
-        http
-                .authorizeRequests()
-                .anyRequest().authenticated()
-                .and()
-                .formLogin();
-        return http.build();
-    }
-}
+                      @Bean
+                      SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+                          http
+                                  .antMatcher("/api/**")
+                                  .authorizeRequests()
+                                  .anyRequest().hasRole("ADMIN")
+                                  .and()
+                                  .httpBasic();
+                          return http.build();
+                      }
+                  }
+                  
+                  @Bean
+                  SecurityFilterChain formLoginSecurityFilterChain(HttpSecurity http) throws Exception {
+                      http
+                              .authorizeRequests()
+                              .anyRequest().authenticated()
+                              .and()
+                              .formLogin();
+                      return http.build();
+                  }
+              }
               """
           )
         );


### PR DESCRIPTION
Fixes #278 

We cannot solve `@Order` annotation port on the bean methods. However, if it is important we can have a white list of annotations that if present over the configuration class can be moved over bean methods of that class.