### PR TITLE
Security DSL

### DIFF
--- a/src/main/java/org/openrewrite/java/spring/boot2/ConvertToSecurityDslVisitor.java
+++ b/src/main/java/org/openrewrite/java/spring/boot2/ConvertToSecurityDslVisitor.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.spring.boot2;
+
+import org.openrewrite.Cursor;
+import org.openrewrite.Tree;
+import org.openrewrite.internal.StringUtils;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.tree.*;
+import org.openrewrite.marker.Markers;
+import org.openrewrite.marker.Markup;
+
+import java.util.*;
+
+public class ConvertToSecurityDslVisitor<P> extends JavaIsoVisitor<P> {
+
+    private static final String MSG_FLATTEN_CHAIN = "http-security-dsl-flatten-invocation-chain";
+
+    private static final String MSG_TOP_INVOCATION = "top-method-invocation";
+
+    private String securityFqn;
+
+    private Collection<String> convertableMethods;
+
+    public ConvertToSecurityDslVisitor(String securityFqn, Collection<String> convertableMethods) {
+        this.securityFqn = securityFqn;
+        this.convertableMethods = convertableMethods;
+    }
+
+    @Override
+    public J.MethodInvocation visitMethodInvocation(J.MethodInvocation initialMethod, P executionContext) {
+        J.MethodInvocation method = super.visitMethodInvocation(initialMethod, executionContext);
+        if (isApplicableMethod(method)) {
+            final List<J.MethodInvocation> chain = computeAndMarkChain(method);
+            JavaType.FullyQualified httpSecurityType = method.getMethodType().getDeclaringType();
+            final String methodName = method.getSimpleName();
+            final J.MethodInvocation m = method;
+            method = httpSecurityType.getMethods().stream().filter(aMethod -> methodName.equals(aMethod.getName()) && aMethod.getParameterTypes().size() == 1).findFirst().map(newMethodType -> {
+                String paramName = generateParamNameFromMethodName(m.getSimpleName());
+                return m
+                        .withMethodType(newMethodType)
+                        .withArguments(Collections.singletonList(chain.isEmpty() ? createDefaultsCall(newMethodType.getParameterTypes().get(0)) : createLambdaParam(paramName, newMethodType.getParameterTypes().get(0), chain)));
+            }).orElse(method);
+        }
+        Boolean msg = getCursor().pollMessage(MSG_FLATTEN_CHAIN);
+        if (Boolean.TRUE.equals(msg)) {
+            method = (J.MethodInvocation) method.getSelect();
+        }
+        // Auto-format the top invocation call if anything has changed down the tree
+        if (initialMethod != method && (getCursor().getParent(2) == null || !(getCursor().getParent(2).getValue() instanceof J.MethodInvocation))) {
+            method = autoFormat(method, executionContext);
+        }
+        return method;
+    }
+
+    private static String generateParamNameFromMethodName(String n) {
+        int i = n.length() - 1;
+        for (; i >= 0 && Character.isLowerCase(n.charAt(i)); i--) {}
+        if (i >= 0) {
+            return StringUtils.uncapitalize(i == 0 ? n : n.substring(i));
+        }
+        return n;
+    }
+
+    private J.Lambda createLambdaParam(String paramName, JavaType paramType, List<J.MethodInvocation> chain) {
+        J.Identifier param = createIdentifier(paramName, paramType);
+        J.MethodInvocation body = unfoldMethodInvocationChain(createIdentifier(paramName, paramType), chain);
+        return new J.Lambda(Tree.randomId(), Space.EMPTY, Markers.EMPTY,
+                new J.Lambda.Parameters(Tree.randomId(), Space.EMPTY, Markers.EMPTY, false, Collections.singletonList(new JRightPadded<>(param, Space.EMPTY, Markers.EMPTY))),
+                Space.build(" ", Collections.emptyList()),
+                body,
+                JavaType.Primitive.Void
+        );
+    }
+
+    private J.Identifier createIdentifier(String name, JavaType type) {
+        return new J.Identifier(Tree.randomId(), Space.EMPTY, Markers.EMPTY, name, type, null);
+    }
+
+    private J.MethodInvocation unfoldMethodInvocationChain(J.Identifier core, List<J.MethodInvocation> chain) {
+        Expression select = core;
+        J.MethodInvocation invocation = null;
+        for (J.MethodInvocation inv : chain) {
+            invocation = inv.withSelect(select);
+            select = invocation;
+        }
+        // Check if top-level invocation to remove the prefix as the prefix is space before the root call, i.e. before httpSecurity identifier. We don't want to have inside the lambda
+        if (invocation.getMarkers().getMarkers().stream().filter(Markup.Info.class::isInstance).map(Markup.Info.class::cast).anyMatch(marker -> MSG_TOP_INVOCATION.equals(marker.getMessage()))) {
+            invocation = invocation
+                    .withMarkers(invocation.getMarkers().removeByType(Markup.Info.class))
+                    .withPrefix(Space.EMPTY);
+        }
+        return invocation;
+    }
+
+    private boolean isApplicableMethod(J.MethodInvocation m) {
+        JavaType.Method type = m.getMethodType();
+        if (type != null) {
+            JavaType.FullyQualified declaringType = type.getDeclaringType();
+            if (declaringType != null && securityFqn.equals(declaringType.getFullyQualifiedName())
+                    && type.getParameterTypes().isEmpty() && convertableMethods.contains(m.getSimpleName())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public boolean isApplicableTopLevelMethodInvocation(J.MethodInvocation m) {
+        if (isApplicableMethod(m)) {
+            return true;
+        } else if (m.getSelect() instanceof J.MethodInvocation) {
+            return isApplicableTopLevelMethodInvocation((J.MethodInvocation) m.getSelect());
+        }
+        return false;
+    }
+
+    private boolean isApplicableCallCursor(Cursor c) {
+        if (c != null && c.getValue() instanceof J.MethodInvocation) {
+            J.MethodInvocation inv = c.getValue();
+            if (!TypeUtils.isOfClassType(inv.getType(), securityFqn)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private List<J.MethodInvocation> computeAndMarkChain(J.MethodInvocation m) {
+        List<J.MethodInvocation> chain = new ArrayList<>();
+        Cursor cursor = getCursor().getParent(2);
+        if (isApplicableCallCursor(cursor)) {
+            for (; cursor != null && isApplicableCallCursor(cursor); cursor = cursor.getParent(2)) {
+                cursor.putMessage(MSG_FLATTEN_CHAIN, true);
+                chain.add(cursor.getValue());
+            }
+        }
+        if (cursor == null || !(cursor.getValue() instanceof J.MethodInvocation) && !chain.isEmpty()) {
+            // top invocation is at the end of the chain - mark it. We'd need to strip off prefix from this invocation later
+            J.MethodInvocation topInvocation = chain.remove(chain.size() - 1);
+            // removed above, now add it back with the marker
+            chain.add(topInvocation.withMarkers(topInvocation.getMarkers().addIfAbsent(new Markup.Info(Tree.randomId(), MSG_TOP_INVOCATION, null))));
+        }
+        // mark all and() methods for flattening as well but do not include in the chain
+        for (; cursor != null && cursor.getValue() instanceof J.MethodInvocation && isAndMethod(cursor.getValue()); cursor = cursor.getParent(2)) {
+            cursor.putMessage(MSG_FLATTEN_CHAIN, true);
+        }
+        return chain;
+    }
+
+    private boolean isAndMethod(J.MethodInvocation andMethod) {
+        return "and".equals(andMethod.getSimpleName()) && (andMethod.getArguments().isEmpty() || andMethod.getArguments().get(0) instanceof J.Empty);
+    }
+
+    private J.MethodInvocation createDefaultsCall(JavaType type) {
+        JavaType.Method methodType = TypeUtils.asFullyQualified(type).getMethods().stream().filter(m -> "withDefaults".equals(m.getName()) && m.getParameterTypes().isEmpty() && m.getFlags().contains(Flag.Static)).findFirst().orElse(null);
+        if (methodType == null) {
+            throw new IllegalStateException();
+        }
+        maybeAddImport(methodType.getDeclaringType().getFullyQualifiedName(), methodType.getName());
+        return new J.MethodInvocation(Tree.randomId(), Space.EMPTY, Markers.EMPTY, null, null,
+                new J.Identifier(Tree.randomId(), Space.EMPTY, Markers.EMPTY, "withDefaults", null, null),
+                JContainer.empty(), methodType)
+                .withSelect(null);
+    }
+
+}

--- a/src/main/java/org/openrewrite/java/spring/boot2/HttpSecurityLambdaDsl.java
+++ b/src/main/java/org/openrewrite/java/spring/boot2/HttpSecurityLambdaDsl.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.spring.boot2;
+
+import org.openrewrite.*;
+import org.openrewrite.java.search.UsesType;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+public final class HttpSecurityLambdaDsl extends Recipe {
+
+    private static final String FQN_HTTP_SECURITY = "org.springframework.security.config.annotation.web.builders.HttpSecurity";
+
+    private static final Collection<String> APPLICABLE_METHOD_NAMES = Arrays.asList(new String[] {
+            "anonymous", "authorizeRequests", "cors", "csrf", "exceptionHandling", "formLogin",
+            "headers", "httpBasic", "jee", "logout", "oauth2Client", "oauth2Login", "oauth2ResourceServer",
+            "openidLogin", "portMapper", "rememberMe", "requestCache", "requestMatchers", "requiresChannel",
+            "saml2Login", "securityContext", "servletApi", "sessionManagement", "x509"
+    });
+
+    @Override
+    public String getDisplayName() {
+        return "Convert HttpSecurity chained calls into Lambda DSL";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Converts HttpSecurity chained call from Spring-Security pre 5.2.x into new lambda DSL style calls and removes `and()` methods.";
+    }
+
+    @Override
+    protected TreeVisitor<?, ExecutionContext> getApplicableTest() {
+        return new UsesType<>(FQN_HTTP_SECURITY);
+    }
+
+    @Override
+    public ConvertToSecurityDslVisitor<ExecutionContext> getVisitor() {
+        return new ConvertToSecurityDslVisitor<>(FQN_HTTP_SECURITY, APPLICABLE_METHOD_NAMES);
+    }
+
+}

--- a/src/main/java/org/openrewrite/java/spring/boot2/ServerHttpSecurityLambdaDsl.java
+++ b/src/main/java/org/openrewrite/java/spring/boot2/ServerHttpSecurityLambdaDsl.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.spring.boot2;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.search.UsesType;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+public final class ServerHttpSecurityLambdaDsl extends Recipe {
+
+    private static final String FQN_SERVER_HTTP_SECURITY = "org.springframework.security.config.web.server.ServerHttpSecurity";
+
+    private static final Collection<String> APPLICABLE_METHOD_NAMES = Arrays.asList(new String[]{
+            "anonymous", "authorizeExchange", "cors", "csrf", "exceptionHandling", "formLogin",
+            "headers", "httpBasic", "logout", "oauth2Client", "oauth2Login", "oauth2ResourceServer",
+            "redirectToHttps", "requestCache", "x509"
+    });
+
+    @Override
+    public String getDisplayName() {
+        return "Convert ServerHttpSecurity chained calls into Lambda DSL";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Converts ServerHttpSecurity chained call from Spring-Security pre 5.2.x into new lambda DSL style calls and removes `and()` methods.";
+    }
+
+    @Override
+    protected TreeVisitor<?, ExecutionContext> getApplicableTest() {
+        return new UsesType<>(FQN_SERVER_HTTP_SECURITY);
+    }
+
+    @Override
+    public ConvertToSecurityDslVisitor<ExecutionContext> getVisitor() {
+        return new ConvertToSecurityDslVisitor<>(FQN_SERVER_HTTP_SECURITY, APPLICABLE_METHOD_NAMES);
+    }
+
+}

--- a/src/testWithSpringBoot_2_4/java/org/openrewrite/java/spring/boot2/HttpSecurityLambdaDslTest.java
+++ b/src/testWithSpringBoot_2_4/java/org/openrewrite/java/spring/boot2/HttpSecurityLambdaDslTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.spring.boot2;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+public class HttpSecurityLambdaDslTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(new HttpSecurityLambdaDsl())
+          .parser(JavaParser.fromJavaVersion()
+            .classpath("spring-beans", "spring-context", "spring-boot", "spring-security", "spring-web", "tomcat-embed", "spring-core"));
+    }
+
+    @Test
+    void simple() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+
+@EnableWebSecurity
+public class ConventionalSecurityConfig extends WebSecurityConfigurerAdapter {
+
+    @Override
+    protected void configure(HttpSecurity http) throws Exception {
+        http
+            .authorizeRequests()
+                .antMatchers("/blog/**").permitAll()
+                .anyRequest().authenticated();
+    }
+}
+              """,
+            """
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+
+@EnableWebSecurity
+public class ConventionalSecurityConfig extends WebSecurityConfigurerAdapter {
+
+    @Override
+    protected void configure(HttpSecurity http) throws Exception {
+        http
+                .authorizeRequests(requests -> requests
+                        .antMatchers("/blog/**").permitAll()
+                        .anyRequest().authenticated());
+    }
+}
+              """
+          )
+        );
+    }
+
+    @Test
+    void advanced() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+
+@EnableWebSecurity
+public class ConventionalSecurityConfig extends WebSecurityConfigurerAdapter {
+
+    @Override
+    protected void configure(HttpSecurity http) throws Exception {
+        http
+            .authorizeRequests()
+                .antMatchers("/blog/**").permitAll()
+                .anyRequest().authenticated()
+                .and()
+            .formLogin()
+                .loginPage("/login")
+                .permitAll()
+                .and()
+            .rememberMe();
+    }
+}
+              """,
+            """
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+
+import static org.springframework.security.config.Customizer.withDefaults;
+
+@EnableWebSecurity
+public class ConventionalSecurityConfig extends WebSecurityConfigurerAdapter {
+
+    @Override
+    protected void configure(HttpSecurity http) throws Exception {
+        http
+                .authorizeRequests(requests -> requests
+                        .antMatchers("/blog/**").permitAll()
+                        .anyRequest().authenticated())
+                .formLogin(login -> login
+                        .loginPage("/login")
+                        .permitAll())
+                .rememberMe(withDefaults());
+    }
+}
+              """
+          )
+        );
+    }
+
+}

--- a/src/testWithSpringBoot_2_4/java/org/openrewrite/java/spring/boot2/ServerHttpSecurityLambdaDslTest.java
+++ b/src/testWithSpringBoot_2_4/java/org/openrewrite/java/spring/boot2/ServerHttpSecurityLambdaDslTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.spring.boot2;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+public class ServerHttpSecurityLambdaDslTest implements RewriteTest {
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(new ServerHttpSecurityLambdaDsl())
+          .parser(JavaParser.fromJavaVersion()
+            .classpath("spring-beans", "spring-context", "spring-boot", "spring-security", "spring-web", "tomcat-embed", "spring-core"));
+    }
+
+    @Test
+    void simple() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity;
+import org.springframework.security.config.web.server.ServerHttpSecurity;
+import org.springframework.security.web.server.SecurityWebFilterChain;
+
+@EnableWebFluxSecurity
+public class SecurityConfig {
+
+	@Bean
+	SecurityWebFilterChain springSecurityFilterChain(ServerHttpSecurity http) {
+        http.authorizeExchange().pathMatchers("/blog/**").permitAll().anyExchange().authenticated();
+        return http.build();
+	}
+}
+              """,
+            """
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity;
+import org.springframework.security.config.web.server.ServerHttpSecurity;
+import org.springframework.security.web.server.SecurityWebFilterChain;
+
+@EnableWebFluxSecurity
+public class SecurityConfig {
+
+	@Bean
+	SecurityWebFilterChain springSecurityFilterChain(ServerHttpSecurity http) {
+        http.authorizeExchange(exchange -> exchange.pathMatchers("/blog/**").permitAll().anyExchange().authenticated());
+        return http.build();
+	}
+}
+              """
+          )
+        );
+    }
+
+    @Test
+    void advanced() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity;
+import org.springframework.security.config.web.server.ServerHttpSecurity;
+import org.springframework.security.web.server.SecurityWebFilterChain;
+
+@EnableWebFluxSecurity
+public class SecurityConfig {
+
+	@Bean
+	SecurityWebFilterChain springSecurityFilterChain(ServerHttpSecurity http) {
+	
+        http.authorizeExchange().pathMatchers("/blog/**").permitAll().anyExchange().authenticated().and().httpBasic()
+                .and().formLogin().loginPage("/login");
+		return http.build();
+	}
+}
+              """,
+            """
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity;
+import org.springframework.security.config.web.server.ServerHttpSecurity;
+import org.springframework.security.web.server.SecurityWebFilterChain;
+
+import static org.springframework.security.config.Customizer.withDefaults;
+
+@EnableWebFluxSecurity
+public class SecurityConfig {
+
+	@Bean
+	SecurityWebFilterChain springSecurityFilterChain(ServerHttpSecurity http) {
+        http.authorizeExchange(exchange -> exchange.pathMatchers("/blog/**").permitAll().anyExchange().authenticated()).httpBasic(withDefaults()).formLogin(login -> login.loginPage("/login"));
+		return http.build();
+	}
+}
+              """
+          )
+        );
+    }
+
+}


### PR DESCRIPTION
Convert method invocation http on `HttpSecurity` and `ServerHttpSecurity` to the new Lambda DSL syntax. See [Spring Security - Lambda DSL](https://spring.io/blog/2019/11/21/spring-security-lambda-dsl)