### PR TITLE
Add @Configuration over a class having @Bean methods

### DIFF
--- a/src/main/java/org/openrewrite/java/spring/boot2/AddConfigurationAnnotationIfBeansPresent.java
+++ b/src/main/java/org/openrewrite/java/spring/boot2/AddConfigurationAnnotationIfBeansPresent.java
@@ -15,8 +15,6 @@
  */
 package org.openrewrite.java.spring.boot2;
 
-import java.util.Comparator;
-
 import org.openrewrite.Cursor;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Recipe;
@@ -31,117 +29,116 @@ import org.openrewrite.java.tree.JavaType;
 import org.openrewrite.java.tree.Statement;
 import org.openrewrite.java.tree.TypeUtils;
 
+import java.util.Comparator;
+
 public class AddConfigurationAnnotationIfBeansPresent extends Recipe {
 
-	private static final String CONFIGURATION_PACKAGE = "org.springframework.context.annotation";
+    private static final String FQN_BEAN = "org.springframework.context.annotation.Bean";
 
-	private static final String CONFIGURATION_SIMPLE_NAME = "Configuration";
+    @Override
+    public String getDisplayName() {
+        return "Add missing '@Configuration' annotation";
+    }
 
-	private static final String FQN_CONFIGURATION = CONFIGURATION_PACKAGE + "." + CONFIGURATION_SIMPLE_NAME;
+    @Override
+    public String getDescription() {
+        return "Class having `@Bean' annotation over any methods but missing '@Configuration' annotation over the declaring class would have '@Configuration' annotation added.";
+    }
 
-	private static final String FQN_BEAN = "org.springframework.context.annotation.Bean";
+    @Override
+    protected TreeVisitor<?, ExecutionContext> getApplicableTest() {
+        return new UsesType<>(FQN_BEAN);
+    }
 
-	@Override
-	public String getDisplayName() {
-		return "Add missing '@Configuration' annotation";
-	}
+    @Override
+    protected TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new AddConfigurationVisitor();
+    }
 
-	@Override
-	public String getDescription() {
-		return "Class having `@Bean' annotation over any methods but missing '@Configuration' annotation over the declaring class would have '@Configuration' annotation added.";
-	}
-	
-	@Override
-	protected TreeVisitor<?, ExecutionContext> getApplicableTest() {
-		return new UsesType<>(FQN_BEAN);
-	}
+    private static class AddConfigurationVisitor extends JavaIsoVisitor<ExecutionContext> {
 
-	@Override
-	protected TreeVisitor<?, ExecutionContext> getVisitor() {
-		return new JavaIsoVisitor<ExecutionContext>() {
+        private static final String CONFIGURATION_PACKAGE = "org.springframework.context.annotation";
+        private static final String CONFIGURATION_SIMPLE_NAME = "Configuration";
+        private static final String FQN_CONFIGURATION = CONFIGURATION_PACKAGE + "." + CONFIGURATION_SIMPLE_NAME;
+        private static final AnnotationMatcher BEAN_ANNOTATION_MATCHER = new AnnotationMatcher("@" + FQN_BEAN, true);
+        private static final AnnotationMatcher CONFIGURATION_ANNOTATION_MATCHER = new AnnotationMatcher("@" + FQN_CONFIGURATION, true);
 
-			@Override
-			public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration classDecl, ExecutionContext p) {
-				J.ClassDeclaration c = super.visitClassDeclaration(classDecl, p);
-				if (isApplicableClass(c, getCursor())) {
-					c = addConfigurationAnnotation(c);
-				}
-				return c;
-			}
+        @Override
+        public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration classDecl, ExecutionContext p) {
+            J.ClassDeclaration c = super.visitClassDeclaration(classDecl, p);
+            if (isApplicableClass(c, getCursor())) {
+                c = addConfigurationAnnotation(c);
+            }
+            return c;
+        }
 
-			private J.ClassDeclaration addConfigurationAnnotation(J.ClassDeclaration c) {
-				maybeAddImport(FQN_CONFIGURATION);
-				JavaTemplate template = JavaTemplate.builder(() -> getCursor(), "@" + CONFIGURATION_SIMPLE_NAME)
-						.imports(
-								FQN_CONFIGURATION)
-						.javaParser(() -> JavaParser.fromJavaVersion().dependsOn("package " + CONFIGURATION_PACKAGE
-								+ "; public @interface " + CONFIGURATION_SIMPLE_NAME + " {}").build())
-						.build();
-				return c.withTemplate(template,
-						c.getCoordinates().addAnnotation(Comparator.comparing(J.Annotation::getSimpleName)));
-			}
+        private J.ClassDeclaration addConfigurationAnnotation(J.ClassDeclaration c) {
+            maybeAddImport(FQN_CONFIGURATION);
+            JavaTemplate template = JavaTemplate.builder(() -> getCursor(), "@" + CONFIGURATION_SIMPLE_NAME)
+                    .imports(FQN_CONFIGURATION)
+                    .javaParser(() -> JavaParser.fromJavaVersion().dependsOn("package " + CONFIGURATION_PACKAGE
+                            + "; public @interface " + CONFIGURATION_SIMPLE_NAME + " {}").build())
+                    .build();
+            return c.withTemplate(template,
+                    c.getCoordinates().addAnnotation(Comparator.comparing(J.Annotation::getSimpleName)));
+        }
 
-		};
-	}
+        private static boolean isApplicableClass(J.ClassDeclaration classDecl, Cursor cursor) {
+            if (classDecl.getKind() != J.ClassDeclaration.Kind.Type.Class) {
+                return false;
+            }
 
-	public static boolean isApplicableClass(J.ClassDeclaration classDecl, Cursor cursor) {
-		if (classDecl.getKind() == J.ClassDeclaration.Kind.Type.Class) {
-			boolean isStatic = false;
-			for (J.Modifier m : classDecl.getModifiers()) {
-				if (m.getType() == J.Modifier.Type.Abstract) {
-					return false;
-				} else if (m.getType() == J.Modifier.Type.Static) {
-					isStatic = true;
-				}
-			}
+            boolean isStatic = false;
+            for (J.Modifier m : classDecl.getModifiers()) {
+                if (m.getType() == J.Modifier.Type.Abstract) {
+                    return false;
+                } else if (m.getType() == J.Modifier.Type.Static) {
+                    isStatic = true;
+                }
+            }
 
-			if (!isStatic) {
-				// no static keyword? check if it is top level class in the CU
-				J.CompilationUnit cu = cursor.dropParentUntil(J.CompilationUnit.class::isInstance).getValue();
-				if (!cu.getClasses().contains(classDecl)) {
-					return false;
-				}
-			}
+            if (!isStatic) {
+                // no static keyword? check if it is top level class in the CU
+                J.CompilationUnit cu = cursor.dropParentUntil(J.CompilationUnit.class::isInstance).getValue();
+                if (!cu.getClasses().contains(classDecl)) {
+                    return false;
+                }
+            }
 
-			// check if '@Configuration' is already over the class
-			AnnotationMatcher matcher = new AnnotationMatcher("@" + FQN_CONFIGURATION, true);
+            // check if '@Configuration' is already over the class
+            for (J.Annotation a : classDecl.getLeadingAnnotations()) {
+                JavaType.FullyQualified aType = TypeUtils.asFullyQualified(a.getType());
+                if (aType != null && CONFIGURATION_ANNOTATION_MATCHER.matchesAnnotationOrMetaAnnotation(aType)) {
+                    // Found '@Configuration' annotation
+                    return false;
+                }
+            }
+            // No '@Configuration' present. Check if any methods have '@Bean' annotation
+            for (Statement s : classDecl.getBody().getStatements()) {
+                if (s instanceof J.MethodDeclaration) {
+                    if (isBeanMethod((J.MethodDeclaration) s)) {
+                        return true;
+                    }
+                }
+            }
 
-			for (J.Annotation a : classDecl.getLeadingAnnotations()) {
-				JavaType.FullyQualified aType = TypeUtils.asFullyQualified(a.getType());
-				if (aType != null && matcher.matchesAnnotationOrMetaAnnotation(aType)) {
-					// Found '@Configuration' annotation
-					return false;
-				}
-			}
-			// No '@Configuration' present. Check if any methods have '@Bean' annotation
-			for (Statement s : classDecl.getBody().getStatements()) {
-				if (s instanceof J.MethodDeclaration) {
-					if (isBeanMethod((J.MethodDeclaration) s)) {
-						return true;
-					}
-				}
-			}
+            return false;
+        }
 
-		}
-		return false;
-	}
+        private static boolean isBeanMethod(J.MethodDeclaration methodDecl) {
+            for (J.Modifier m : methodDecl.getModifiers()) {
+                if (m.getType() == J.Modifier.Type.Abstract || m.getType() == J.Modifier.Type.Static) {
+                    return false;
+                }
+            }
+            for (J.Annotation a : methodDecl.getLeadingAnnotations()) {
+                JavaType.FullyQualified aType = TypeUtils.asFullyQualified(a.getType());
+                if (aType != null && BEAN_ANNOTATION_MATCHER.matchesAnnotationOrMetaAnnotation(aType)) {
+                    return true;
+                }
+            }
+            return false;
+        }
 
-	private static boolean isBeanMethod(J.MethodDeclaration methodDecl) {
-		for (J.Modifier m : methodDecl.getModifiers()) {
-			if (m.getType() == J.Modifier.Type.Abstract) {
-				return false;
-			} else if (m.getType() == J.Modifier.Type.Static) {
-				return false;
-			}
-		}
-		AnnotationMatcher beanAnnotationMatcher = new AnnotationMatcher("@" + FQN_BEAN, true);
-		for (J.Annotation a : methodDecl.getLeadingAnnotations()) {
-			JavaType.FullyQualified aType = TypeUtils.asFullyQualified(a.getType());
-			if (aType != null && beanAnnotationMatcher.matchesAnnotationOrMetaAnnotation(aType)) {
-				return true;
-			}
-		}
-		return false;
-	}
-
+    }
 }

--- a/src/main/java/org/openrewrite/java/spring/boot2/AddConfigurationAnnotationIfBeansPresent.java
+++ b/src/main/java/org/openrewrite/java/spring/boot2/AddConfigurationAnnotationIfBeansPresent.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.spring.boot2;
+
+import java.util.Comparator;
+
+import org.openrewrite.Cursor;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.AnnotationMatcher;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.java.JavaTemplate;
+import org.openrewrite.java.search.UsesType;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaType;
+import org.openrewrite.java.tree.Statement;
+import org.openrewrite.java.tree.TypeUtils;
+
+public class AddConfigurationAnnotationIfBeansPresent extends Recipe {
+
+	private static final String CONFIGURATION_PACKAGE = "org.springframework.context.annotation";
+
+	private static final String CONFIGURATION_SIMPLE_NAME = "Configuration";
+
+	private static final String FQN_CONFIGURATION = CONFIGURATION_PACKAGE + "." + CONFIGURATION_SIMPLE_NAME;
+
+	private static final String FQN_BEAN = "org.springframework.context.annotation.Bean";
+
+	@Override
+	public String getDisplayName() {
+		return "Add missing '@Configuration' annotation";
+	}
+
+	@Override
+	public String getDescription() {
+		return "Class having `@Bean' annotation over any methods but missing '@Configuration' annotation over the declaring class would have '@Configuration' annotation added.";
+	}
+	
+	@Override
+	protected TreeVisitor<?, ExecutionContext> getApplicableTest() {
+		return new UsesType<>(FQN_BEAN);
+	}
+
+	@Override
+	protected TreeVisitor<?, ExecutionContext> getVisitor() {
+		return new JavaIsoVisitor<ExecutionContext>() {
+
+			@Override
+			public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration classDecl, ExecutionContext p) {
+				J.ClassDeclaration c = super.visitClassDeclaration(classDecl, p);
+				if (isApplicableClass(c, getCursor())) {
+					c = addConfigurationAnnotation(c);
+				}
+				return c;
+			}
+
+			private J.ClassDeclaration addConfigurationAnnotation(J.ClassDeclaration c) {
+				maybeAddImport(FQN_CONFIGURATION);
+				JavaTemplate template = JavaTemplate.builder(() -> getCursor(), "@" + CONFIGURATION_SIMPLE_NAME)
+						.imports(
+								FQN_CONFIGURATION)
+						.javaParser(() -> JavaParser.fromJavaVersion().dependsOn("package " + CONFIGURATION_PACKAGE
+								+ "; public @interface " + CONFIGURATION_SIMPLE_NAME + " {}").build())
+						.build();
+				return c.withTemplate(template,
+						c.getCoordinates().addAnnotation(Comparator.comparing(J.Annotation::getSimpleName)));
+			}
+
+		};
+	}
+
+	public static boolean isApplicableClass(J.ClassDeclaration classDecl, Cursor cursor) {
+		if (classDecl.getKind() == J.ClassDeclaration.Kind.Type.Class) {
+			boolean isStatic = false;
+			for (J.Modifier m : classDecl.getModifiers()) {
+				if (m.getType() == J.Modifier.Type.Abstract) {
+					return false;
+				} else if (m.getType() == J.Modifier.Type.Static) {
+					isStatic = true;
+				}
+			}
+
+			if (!isStatic) {
+				// no static keyword? check if it is top level class in the CU
+				J.CompilationUnit cu = cursor.dropParentUntil(J.CompilationUnit.class::isInstance).getValue();
+				if (!cu.getClasses().contains(classDecl)) {
+					return false;
+				}
+			}
+
+			// check if '@Configuration' is already over the class
+			AnnotationMatcher matcher = new AnnotationMatcher("@" + FQN_CONFIGURATION, true);
+
+			for (J.Annotation a : classDecl.getLeadingAnnotations()) {
+				JavaType.FullyQualified aType = TypeUtils.asFullyQualified(a.getType());
+				if (aType != null && matcher.matchesAnnotationOrMetaAnnotation(aType)) {
+					// Found '@Configuration' annotation
+					return false;
+				}
+			}
+			// No '@Configuration' present. Check if any methods have '@Bean' annotation
+			for (Statement s : classDecl.getBody().getStatements()) {
+				if (s instanceof J.MethodDeclaration) {
+					if (isBeanMethod((J.MethodDeclaration) s)) {
+						return true;
+					}
+				}
+			}
+
+		}
+		return false;
+	}
+
+	private static boolean isBeanMethod(J.MethodDeclaration methodDecl) {
+		for (J.Modifier m : methodDecl.getModifiers()) {
+			if (m.getType() == J.Modifier.Type.Abstract) {
+				return false;
+			} else if (m.getType() == J.Modifier.Type.Static) {
+				return false;
+			}
+		}
+		AnnotationMatcher beanAnnotationMatcher = new AnnotationMatcher("@" + FQN_BEAN, true);
+		for (J.Annotation a : methodDecl.getLeadingAnnotations()) {
+			JavaType.FullyQualified aType = TypeUtils.asFullyQualified(a.getType());
+			if (aType != null && beanAnnotationMatcher.matchesAnnotationOrMetaAnnotation(aType)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+}

--- a/src/testWithSpringBoot_3_0/java/org/openrewrite/java/spring/boot3/AddConfigurationAnnotationIfBeansPresentTest.java
+++ b/src/testWithSpringBoot_3_0/java/org/openrewrite/java/spring/boot3/AddConfigurationAnnotationIfBeansPresentTest.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.spring.boot3;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.java.spring.boot2.AddConfigurationAnnotationIfBeansPresent;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+public class AddConfigurationAnnotationIfBeansPresentTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(new AddConfigurationAnnotationIfBeansPresent())
+          .parser(JavaParser.fromJavaVersion()
+            .classpath("spring-beans", "spring-context", "spring-boot", "spring-security", "spring-web", "spring-core"));
+    }
+
+    @Test
+    void enableWebSecurityNoBeans() {
+        rewriteRun(
+          java(
+            """
+              import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+
+              @EnableWebSecurity
+              class A {}
+              """
+          )
+        );
+    }
+
+    @Test
+    void enableWebSecurityWithBeans() {
+        rewriteRun(
+          java(
+            """
+              import org.springframework.context.annotation.Bean;
+              import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+
+              @EnableWebSecurity
+              class A {
+                @Bean String hello() { return "hello"; }
+              }
+              """,
+            """
+              import org.springframework.context.annotation.Bean;
+              import org.springframework.context.annotation.Configuration;
+              import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+
+              @Configuration   
+              @EnableWebSecurity
+              class A {
+                @Bean String hello() { return "hello"; }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void configurationMetaAnnotation() {
+        rewriteRun(
+          java(
+            """
+              import org.springframework.boot.autoconfigure.SpringBootApplication;
+              import org.springframework.context.annotation.Bean;
+
+              @SpringBootApplication
+              class A {
+                @Bean String hello() { return "hello"; }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void abstractClassWithBeans() {
+        rewriteRun(
+          java(
+            """
+              import org.springframework.context.annotation.Bean;
+
+              abstract class A {
+                @Bean String hello() { return "hello"; }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void noAnnotationsWithBean() {
+        rewriteRun(
+          java(
+            """
+              import org.springframework.context.annotation.Bean;
+
+              class A {
+                @Bean String hello() { return "hello"; }
+              }
+              """,
+            """
+              import org.springframework.context.annotation.Bean;
+              import org.springframework.context.annotation.Configuration;
+
+              @Configuration   
+              class A {
+                @Bean String hello() { return "hello"; }
+              }
+              """
+          )
+        );
+    }
+
+}


### PR DESCRIPTION
(Kind of a consequence from `@EnableXXXSEcurity` annotations)

If a class has methods annotated with `@Beans` or meta-subclasses of `@Bean` a declaring class likely needs to have `@Configuration` or some meta-subclass annotation. If it is missing the recipe would add `@Configuration`.
Useful if someone upgraded to Boot 3 and Security 6 manually without adding missing `@Configuration` next to `@EnableXXXSecurity` then this recipe would be useful.

I think it'll be useful in the IDE world mostly for those who forgot `@Configuration` in a class defining beans.