### PR TITLE
Add recipe to consolidate @ExtendWith and @ContextConfiguration

### DIFF
--- a/src/main/java/org/openrewrite/java/spring/boot2/ReplaceExtendWithAndContextConfiguration.java
+++ b/src/main/java/org/openrewrite/java/spring/boot2/ReplaceExtendWithAndContextConfiguration.java
@@ -15,6 +15,7 @@
  */
 package org.openrewrite.java.spring.boot2;
 
+import org.openrewrite.Applicability;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
@@ -25,7 +26,6 @@ import org.openrewrite.java.JavaTemplate;
 import org.openrewrite.java.search.UsesType;
 import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
-import org.openrewrite.java.tree.JavaSourceFile;
 
 import java.time.Duration;
 import java.util.List;
@@ -49,7 +49,7 @@ public class ReplaceExtendWithAndContextConfiguration extends Recipe {
     @Override
     public String getDescription() {
         return "Replaces `@ExtendWith(SpringRunner.class)` and `@ContextConfiguration` with `@SpringJunitConfig`, " +
-                "preserving attributes on `@ContextConfiguration`, unless `@ContextConfiguration(loader = ...)` is used.";
+               "preserving attributes on `@ContextConfiguration`, unless `@ContextConfiguration(loader = ...)` is used.";
     }
 
     @Override
@@ -59,14 +59,7 @@ public class ReplaceExtendWithAndContextConfiguration extends Recipe {
 
     @Override
     protected TreeVisitor<?, ExecutionContext> getSingleSourceApplicableTest() {
-        return new JavaIsoVisitor<ExecutionContext>() {
-            @Override
-            public JavaSourceFile visitJavaSourceFile(JavaSourceFile cu, ExecutionContext e) {
-                doAfterVisit(new UsesType<>(FQN_EXTEND_WITH));
-                doAfterVisit(new UsesType<>(FQN_CONTEXT_CONFIGURATION));
-                return cu;
-            }
-        };
+        return Applicability.and(new UsesType<>(FQN_EXTEND_WITH), new UsesType<>(FQN_CONTEXT_CONFIGURATION));
     }
 
     @Override
@@ -144,8 +137,8 @@ public class ReplaceExtendWithAndContextConfiguration extends Recipe {
         }
         return annotation.getArguments().stream()
                 .filter(arg -> arg instanceof J.Assignment
-                        && ((J.Assignment) arg).getVariable() instanceof J.Identifier
-                        && "loader".equals(((J.Identifier) ((J.Assignment) arg).getVariable()).getSimpleName()))
+                               && ((J.Assignment) arg).getVariable() instanceof J.Identifier
+                               && "loader".equals(((J.Identifier) ((J.Assignment) arg).getVariable()).getSimpleName()))
                 .map(J.Assignment.class::cast)
                 .findFirst();
     }

--- a/src/main/java/org/openrewrite/java/spring/boot2/ReplaceExtendWithAndContextConfiguration.java
+++ b/src/main/java/org/openrewrite/java/spring/boot2/ReplaceExtendWithAndContextConfiguration.java
@@ -48,7 +48,7 @@ public class ReplaceExtendWithAndContextConfiguration extends Recipe {
 
     @Override
     public String getDescription() {
-        return "Replaces `@ExtendWith(SpringRunner.class)` and `@ContextConfiguration` into `@SpringJunitConfig`, " +
+        return "Replaces `@ExtendWith(SpringRunner.class)` and `@ContextConfiguration` with `@SpringJunitConfig`, " +
                 "preserving attributes on `@ContextConfiguration`, unless `@ContextConfiguration(loader = ...)` is used.";
     }
 

--- a/src/main/java/org/openrewrite/java/spring/boot2/ReplaceExtendWithAndContextConfiguration.java
+++ b/src/main/java/org/openrewrite/java/spring/boot2/ReplaceExtendWithAndContextConfiguration.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.spring.boot2;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CopyOnWriteArrayList;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.java.AnnotationMatcher;
+import org.openrewrite.java.ChangeType;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.JavaTemplate;
+import org.openrewrite.java.search.UsesType;
+import org.openrewrite.java.tree.Expression;
+import org.openrewrite.java.tree.J;
+
+public class ReplaceExtendWithAndContextConfiguration extends Recipe {
+    private static final String FQN_EXTEND_WITH = "org.junit.jupiter.api.extension.ExtendWith";
+    private static final String FQN_CONTEXT_CONFIGURATION = "org.springframework.test.context.ContextConfiguration";
+    private static final String FQN_SPRING_JUNIT_CONFIG = "org.springframework.test.context.junit.jupiter.SpringJUnitConfig";
+
+    public ReplaceExtendWithAndContextConfiguration() {
+        doNext(new UnnecessarySpringExtension());
+        addSingleSourceApplicableTest(new UsesType<>(FQN_EXTEND_WITH));
+        addSingleSourceApplicableTest(new UsesType<>(FQN_CONTEXT_CONFIGURATION));
+    }
+
+    @Override
+    public String getDisplayName() {
+        return "Replace `@ExtendWith` and `@ContextConfiguration` with `@SpringJunitConfig`";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Replaces `@ExtendWith(SpringRunner.class)` and `@ContextConfiguration` into `@SpringJunitConfig`, " +
+            "preserving attributes on `@ContextConfiguration`, unless `@ContextConfiguration(loader = ...)` is used.";
+    }
+
+    @Override
+    public @Nullable Duration getEstimatedEffortPerOccurrence() {
+        return Duration.ofMinutes(2);
+    }
+
+    @Override
+    protected TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new JavaIsoVisitor<ExecutionContext>() {
+            private final AnnotationMatcher CONTEXT_CONFIGURATION_ANNOTATION_MATCHER = new AnnotationMatcher("@" + FQN_CONTEXT_CONFIGURATION, true);
+
+            @Override
+            public J.Annotation visitAnnotation(J.Annotation annotation, ExecutionContext context) {
+                J.Annotation a = super.visitAnnotation(annotation, context);
+
+                if (CONTEXT_CONFIGURATION_ANNOTATION_MATCHER.matches(a) && getCursor().getParentOrThrow().getValue() instanceof J.ClassDeclaration) {
+                    // @SpringJUnitConfig supports every attribute on @ContextConfiguration except loader()
+                    // If it's present, skip the transformation since removing @ContextConfiguration will do harm
+                    Optional<J.Assignment> loaderArg = findLoaderArgument(a);
+                    if (loaderArg.isPresent()) {
+                        return a;
+                    }
+
+                    // @ContextConfiguration value() is an alias for locations()
+                    // @SpringJUnitConfig value() is an alias for classes()
+                    // Since these are incompatible, we need to map value() to locations()
+                    // If value() is present (either explicitly or implicitly), replace it with locations()
+                    // Note that it's invalid to specify both value() and locations() on @ContextConfiguration
+                    if (a.getArguments() != null) {
+                        List<Expression> newArgs = new CopyOnWriteArrayList<>(a.getArguments());
+                        replaceValueArgumentWithLocations(a, newArgs);
+                        a = a.withArguments(newArgs);
+                    }
+
+                    // Change the @ContextConfiguration annotation to @SpringJUnitConfig
+                    maybeRemoveImport(FQN_CONTEXT_CONFIGURATION);
+                    maybeAddImport(FQN_SPRING_JUNIT_CONFIG);
+                    a = (J.Annotation) new ChangeType(FQN_CONTEXT_CONFIGURATION, FQN_SPRING_JUNIT_CONFIG, false)
+                        .getVisitor().visit(a, context, getCursor());
+                }
+
+                return a != null ? autoFormat(a, context) : annotation;
+            }
+
+            private void replaceValueArgumentWithLocations(J.Annotation a, List<Expression> newArgs) {
+                for (int i = 0; i < newArgs.size(); i++) {
+                    Expression expression = newArgs.get(i);
+                    if (expression instanceof J.Assignment) {
+                        J.Assignment assignment = (J.Assignment) expression;
+                        String name = ((J.Identifier) assignment.getVariable()).getSimpleName();
+                        if (name.equals("value")) {
+                            J.Assignment as = createLocationsAssignment(a, assignment.getAssignment())
+                                .withPrefix(expression.getPrefix());
+                            newArgs.set(i, as);
+                            break;
+                        }
+                    } else {
+                        // The implicit assignment to "value"
+                        J.Assignment as = createLocationsAssignment(a, expression).withPrefix(expression.getPrefix());
+                        newArgs.set(i, as);
+                        break;
+                    }
+                }
+            }
+
+            private J.Assignment createLocationsAssignment(J.Annotation annotation, Expression value) {
+                return (J.Assignment) ((J.Annotation) annotation.withTemplate(
+                    JavaTemplate.builder(this::getCursor, "locations = #{any(String)}").build(),
+                    annotation.getCoordinates().replaceArguments(),
+                    value
+                )).getArguments().get(0);
+            }
+        };
+    }
+
+    private static Optional<J.Assignment> findLoaderArgument(J.Annotation annotation) {
+        if (annotation.getArguments() == null) {
+            return Optional.empty();
+        }
+        return annotation.getArguments().stream()
+            .filter(arg -> arg instanceof J.Assignment
+                && ((J.Assignment) arg).getVariable() instanceof J.Identifier
+                && "loader".equals(((J.Identifier) ((J.Assignment) arg).getVariable()).getSimpleName()))
+            .map(J.Assignment.class::cast)
+            .findFirst();
+    }
+}

--- a/src/main/java/org/openrewrite/java/spring/boot2/UnnecessarySpringExtension.java
+++ b/src/main/java/org/openrewrite/java/spring/boot2/UnnecessarySpringExtension.java
@@ -51,7 +51,8 @@ public class UnnecessarySpringExtension extends Recipe {
             "org.springframework.boot.test.autoconfigure.data.neo4j.DataNeo4jTest",
             "org.springframework.boot.test.autoconfigure.data.r2dbc.DataR2dbcTest",
             "org.springframework.boot.test.autoconfigure.data.redis.DataRedisTest",
-            "org.springframework.batch.test.context.SpringBatchTest"
+            "org.springframework.batch.test.context.SpringBatchTest",
+            "org.springframework.test.context.junit.jupiter.SpringJUnitConfig"
     );
     private static final String EXTEND_WITH_SPRING_EXTENSION_ANNOTATION_PATTERN = "@org.junit.jupiter.api.extension.ExtendWith(org.springframework.test.context.junit.jupiter.SpringExtension.class)";
 

--- a/src/main/resources/META-INF/rewrite/spring-boot-24.yml
+++ b/src/main/resources/META-INF/rewrite/spring-boot-24.yml
@@ -141,6 +141,8 @@ recipeList:
   - org.openrewrite.java.spring.boot2.OutputCaptureExtension
   - org.openrewrite.java.spring.boot2.UnnecessarySpringRunWith
   - org.openrewrite.java.spring.boot2.UnnecessarySpringExtension
+# TODO Enable once tested on more projects through public.moderne.io
+#  - org.openrewrite.java.spring.boot2.ReplaceExtendWithAndContextConfiguration
   - org.openrewrite.java.spring.boot2.RemoveObsoleteSpringRunners
   - org.openrewrite.maven.AddDependency:
       groupId: org.springframework.boot
@@ -158,7 +160,6 @@ recipeList:
         - org.springframework.test.context.junit4.SpringRunner
         - org.springframework.test.context.junit4.SpringJUnit4ClassRunner
       extension: org.springframework.test.context.junit.jupiter.SpringExtension
-  - org.openrewrite.java.spring.boot2.ReplaceExtendWithAndContextConfiguration
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.spring.boot2.RemoveObsoleteSpringRunners

--- a/src/main/resources/META-INF/rewrite/spring-boot-24.yml
+++ b/src/main/resources/META-INF/rewrite/spring-boot-24.yml
@@ -158,6 +158,7 @@ recipeList:
         - org.springframework.test.context.junit4.SpringRunner
         - org.springframework.test.context.junit4.SpringJUnit4ClassRunner
       extension: org.springframework.test.context.junit.jupiter.SpringExtension
+  - org.openrewrite.java.spring.boot2.ReplaceExtendWithAndContextConfiguration
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.spring.boot2.RemoveObsoleteSpringRunners

--- a/src/testWithSpringBoot_2_3/java/org/openrewrite/java/spring/boot2/SpringBoot2JUnit4to5MigrationTest.java
+++ b/src/testWithSpringBoot_2_3/java/org/openrewrite/java/spring/boot2/SpringBoot2JUnit4to5MigrationTest.java
@@ -39,7 +39,7 @@ class SpringBoot2JUnit4to5MigrationTest implements RewriteTest {
             )
           )
           .parser(JavaParser.fromJavaVersion()
-            .classpath("spring-boot-test", "junit", "spring-test"));
+            .classpath("spring-boot-test", "junit", "spring-test", "spring-context"));
     }
 
     @Issue("https://github.com/openrewrite/rewrite-spring/issues/43")
@@ -76,6 +76,57 @@ class SpringBoot2JUnit4to5MigrationTest implements RewriteTest {
                             
                   @Test
                   void testFindAll() {
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite-spring/issues/296")
+    @Test
+    void springBootRunWithContextConfigurationReplacedWithSpringJUnitConfig() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              package org.springframework.samples.petclinic.system;
+
+              import org.junit.Test;
+              import org.junit.runner.RunWith;
+              import org.springframework.context.annotation.Configuration;
+              import org.springframework.test.context.ContextConfiguration;
+              import org.springframework.test.context.junit4.SpringRunner;
+
+              @RunWith(SpringRunner.class)
+              @ContextConfiguration(classes = ProductionConfigurationTests.CustomConfiguration.class)
+              public class ProductionConfigurationTests {
+
+                  @Test
+                  public void testFindAll() {
+                  }
+
+                  @Configuration
+                  static class CustomConfiguration {
+                  }
+              }
+              """,
+            """
+              package org.springframework.samples.petclinic.system;
+
+              import org.junit.jupiter.api.Test;
+              import org.springframework.context.annotation.Configuration;
+              import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+              @SpringJUnitConfig(classes = ProductionConfigurationTests.CustomConfiguration.class)
+              public class ProductionConfigurationTests {
+
+                  @Test
+                  void testFindAll() {
+                  }
+
+                  @Configuration
+                  static class CustomConfiguration {
                   }
               }
               """

--- a/src/testWithSpringBoot_2_3/java/org/openrewrite/java/spring/boot2/SpringBoot2JUnit4to5MigrationTest.java
+++ b/src/testWithSpringBoot_2_3/java/org/openrewrite/java/spring/boot2/SpringBoot2JUnit4to5MigrationTest.java
@@ -15,6 +15,7 @@
  */
 package org.openrewrite.java.spring.boot2;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.Issue;
 import org.openrewrite.config.Environment;
@@ -32,11 +33,7 @@ class SpringBoot2JUnit4to5MigrationTest implements RewriteTest {
           .recipe(Environment.builder()
             .scanRuntimeClasspath()
             .build()
-            .activateRecipes(
-              "org.openrewrite.java.spring.boot2.UnnecessarySpringRunWith",
-              "org.openrewrite.java.spring.boot2.UnnecessarySpringExtension",
-              "org.openrewrite.java.testing.junit5.JUnit4to5Migration"
-            )
+            .activateRecipes("org.openrewrite.java.spring.boot2.SpringBoot2JUnit4to5Migration")
           )
           .parser(JavaParser.fromJavaVersion()
             .classpath("spring-boot-test", "junit", "spring-test", "spring-context"));
@@ -72,7 +69,7 @@ class SpringBoot2JUnit4to5MigrationTest implements RewriteTest {
               import org.springframework.boot.test.context.SpringBootTest;
                             
               @SpringBootTest
-              public class ProductionConfigurationTests {
+              class ProductionConfigurationTests {
                             
                   @Test
                   void testFindAll() {
@@ -85,6 +82,7 @@ class SpringBoot2JUnit4to5MigrationTest implements RewriteTest {
 
     @Issue("https://github.com/openrewrite/rewrite-spring/issues/296")
     @Test
+    @Disabled("Requires inclusion of ReplaceExtendWithAndContextConfiguration after that's verified on more projects")
     void springBootRunWithContextConfigurationReplacedWithSpringJUnitConfig() {
         //language=java
         rewriteRun(
@@ -119,7 +117,7 @@ class SpringBoot2JUnit4to5MigrationTest implements RewriteTest {
               import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
               @SpringJUnitConfig(classes = ProductionConfigurationTests.CustomConfiguration.class)
-              public class ProductionConfigurationTests {
+              class ProductionConfigurationTests {
 
                   @Test
                   void testFindAll() {

--- a/src/testWithSpringBoot_2_4/java/org/openrewrite/java/spring/boot2/ReplaceExtendWithAndContextConfigurationTest.java
+++ b/src/testWithSpringBoot_2_4/java/org/openrewrite/java/spring/boot2/ReplaceExtendWithAndContextConfigurationTest.java
@@ -1,0 +1,272 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.spring.boot2;
+
+import static org.openrewrite.java.Assertions.java;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.Issue;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+@Issue("https://github.com/openrewrite/rewrite-spring/issues/296")
+class ReplaceExtendWithAndContextConfigurationTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(new ReplaceExtendWithAndContextConfiguration())
+          .parser(JavaParser.fromJavaVersion()
+            .classpath("spring-boot-test", "spring-test", "junit-jupiter-api", "spring-context"));
+    }
+
+    @Test
+    void extendWithContextConfigurationRemovedWithConfigurationClass() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              package org.example;
+                            
+              import org.junit.jupiter.api.extension.ExtendWith;
+              import org.springframework.context.annotation.Configuration;
+              import org.springframework.test.context.ContextConfiguration;
+              import org.springframework.test.context.junit.jupiter.SpringExtension;
+                            
+              @ExtendWith(SpringExtension.class)
+              @ContextConfiguration(classes = ExampleClass.ExampleConfiguration.class)
+              public class ExampleClass {
+                  @Configuration
+                  static class ExampleConfiguration {
+                  }
+              }
+              """,
+            """
+              package org.example;
+              
+              import org.springframework.context.annotation.Configuration;
+              import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+                            
+              @SpringJUnitConfig(classes = ExampleClass.ExampleConfiguration.class)
+              public class ExampleClass {
+                  @Configuration
+                  static class ExampleConfiguration {
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void extendWithContextConfigurationKeptWhenUsingLoaderArgument() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              package org.example;
+                            
+              import org.junit.jupiter.api.extension.ExtendWith;
+              import org.springframework.boot.test.context.SpringBootContextLoader;
+              import org.springframework.test.context.ContextConfiguration;
+              import org.springframework.test.context.junit.jupiter.SpringExtension;
+                            
+              @ExtendWith(SpringExtension.class)
+              @ContextConfiguration(loader = SpringBootContextLoader.class)
+              public class ExampleClass {
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void extendWithContextConfigurationUsesExplicitValueExplicitArray() {
+        doExtendWithContextConfigurationTest(
+          """
+            @ContextConfiguration(value = {"classpath:beans.xml"})
+            """,
+          """
+            @SpringJUnitConfig(locations = {"classpath:beans.xml"})
+            """
+        );
+    }
+
+    @Test
+    void extendWithContextConfigurationUsesExplicitValueImplicitArray() {
+        doExtendWithContextConfigurationTest(
+          """
+            @ContextConfiguration(value = "classpath:beans.xml")
+            """,
+          """
+            @SpringJUnitConfig(locations = "classpath:beans.xml")
+            """
+        );
+    }
+
+    @Test
+    void extendWithContextConfigurationUsesImplicitValueExplicitArray() {
+        doExtendWithContextConfigurationTest(
+          """
+            @ContextConfiguration({"classpath:beans.xml"})
+            """,
+          """
+            @SpringJUnitConfig(locations = {"classpath:beans.xml"})
+            """
+        );
+    }
+
+    @Test
+    void extendWithContextConfigurationUsesImplicitValueImplicitArray() {
+        doExtendWithContextConfigurationTest(
+          """
+            @ContextConfiguration("classpath:beans.xml")
+            """,
+          """
+            @SpringJUnitConfig(locations = "classpath:beans.xml")
+            """
+        );
+    }
+
+    @Test
+    void extendWithContextConfigurationUsesImplicitValueExplicitArrayMultipleValues() {
+        doExtendWithContextConfigurationTest(
+          """
+            @ContextConfiguration({"classpath:beans.xml", "classpath:more-beans.xml"})
+            """,
+          """
+            @SpringJUnitConfig(locations = {"classpath:beans.xml", "classpath:more-beans.xml"})
+            """
+        );
+    }
+
+    @Test
+    void extendWithContextConfigurationUsesExplicitValueExplicitArrayMultipleValues() {
+        doExtendWithContextConfigurationTest(
+          """
+            @ContextConfiguration(value = {"classpath:beans.xml", "classpath:more-beans.xml"})
+            """,
+          """
+            @SpringJUnitConfig(locations = {"classpath:beans.xml", "classpath:more-beans.xml"})
+            """
+        );
+    }
+
+    @Test
+    void extendWithContextConfigurationUsesExplicitValueExplicitArrayAndAdditionalArgumentsAfter() {
+        doExtendWithContextConfigurationTest(
+          """
+            @ContextConfiguration(value = {"classpath:beans.xml"}, inheritLocations = false)
+            """,
+          """
+            @SpringJUnitConfig(locations = {"classpath:beans.xml"}, inheritLocations = false)
+            """
+        );
+    }
+
+    @Test
+    void extendWithContextConfigurationUsesExplicitValueExplicitArrayAndAdditionalArgumentsBeforeAndAfter() {
+        doExtendWithContextConfigurationTest(
+          """
+            @ContextConfiguration(inheritInitializers = true, value = {"classpath:beans.xml"}, inheritLocations = false)
+            """,
+          """
+            @SpringJUnitConfig(inheritInitializers = true, locations = {"classpath:beans.xml"}, inheritLocations = false)
+            """
+        );
+    }
+
+    @Test
+    void extendWithContextConfigurationUsesAllSupportedContextConfigurationAttributesWithValueAttribute() {
+        doExtendWithContextConfigurationTest(
+          """
+            @ContextConfiguration(
+                value = {"classpath:beans.xml"},
+                classes = {},
+                initializers = {},
+                inheritLocations = true,
+                inheritInitializers = false,
+                name = "name"
+            )
+            """,
+          """
+            @SpringJUnitConfig(
+                    locations = {"classpath:beans.xml"},
+                    classes = {},
+                    initializers = {},
+                    inheritLocations = true,
+                    inheritInitializers = false,
+                    name = "name"
+            )
+            """
+        );
+    }
+
+    @Test
+    void extendWithContextConfigurationUsesAllSupportedContextConfigurationAttributesWithLocationsAttribute() {
+        doExtendWithContextConfigurationTest(
+          """
+            @ContextConfiguration(
+                classes = {},
+                initializers = {},
+                inheritLocations = true,
+                inheritInitializers = false,
+                name = "name",
+                locations = {"classpath:beans.xml"}
+            )
+            """,
+          """
+            @SpringJUnitConfig(
+                    classes = {},
+                    initializers = {},
+                    inheritLocations = true,
+                    inheritInitializers = false,
+                    name = "name",
+                    locations = {"classpath:beans.xml"}
+            )
+            """
+        );
+    }
+
+    void doExtendWithContextConfigurationTest(String contextConfigurationAnnotation, String springJunitConfigAnnotation) {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              package org.example;
+                            
+              import org.junit.jupiter.api.extension.ExtendWith;
+              import org.springframework.test.context.ContextConfiguration;
+              import org.springframework.test.context.junit.jupiter.SpringExtension;
+                            
+              @ExtendWith(SpringExtension.class)
+              """ + contextConfigurationAnnotation + """
+              public class ExampleClass {
+              }
+              """,
+            """
+              package org.example;
+                            
+              import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+              
+              """ + springJunitConfigAnnotation + """
+              public class ExampleClass {
+              }
+              """
+          )
+        );
+    }
+}

--- a/src/testWithSpringBoot_2_4/java/org/openrewrite/java/spring/boot2/ReplaceExtendWithAndContextConfigurationTest.java
+++ b/src/testWithSpringBoot_2_4/java/org/openrewrite/java/spring/boot2/ReplaceExtendWithAndContextConfigurationTest.java
@@ -15,13 +15,13 @@
  */
 package org.openrewrite.java.spring.boot2;
 
-import static org.openrewrite.java.Assertions.java;
-
 import org.junit.jupiter.api.Test;
 import org.openrewrite.Issue;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
 
 @Issue("https://github.com/openrewrite/rewrite-spring/issues/296")
 class ReplaceExtendWithAndContextConfigurationTest implements RewriteTest {
@@ -56,7 +56,7 @@ class ReplaceExtendWithAndContextConfigurationTest implements RewriteTest {
               """,
             """
               package org.example;
-              
+                            
               import org.springframework.context.annotation.Configuration;
               import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
                             
@@ -261,7 +261,7 @@ class ReplaceExtendWithAndContextConfigurationTest implements RewriteTest {
               package org.example;
                             
               import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
-              
+                            
               """ + springJunitConfigAnnotation + """
               public class ExampleClass {
               }

--- a/src/testWithSpringBoot_2_4/java/org/openrewrite/java/spring/boot2/ReplaceExtendWithAndContextConfigurationTest.java
+++ b/src/testWithSpringBoot_2_4/java/org/openrewrite/java/spring/boot2/ReplaceExtendWithAndContextConfigurationTest.java
@@ -241,7 +241,7 @@ class ReplaceExtendWithAndContextConfigurationTest implements RewriteTest {
         );
     }
 
-    void doExtendWithContextConfigurationTest(String contextConfigurationAnnotation, String springJunitConfigAnnotation) {
+    private void doExtendWithContextConfigurationTest(String contextConfigurationAnnotation, String springJunitConfigAnnotation) {
         //language=java
         rewriteRun(
           java(
@@ -253,19 +253,19 @@ class ReplaceExtendWithAndContextConfigurationTest implements RewriteTest {
               import org.springframework.test.context.junit.jupiter.SpringExtension;
                             
               @ExtendWith(SpringExtension.class)
-              """ + contextConfigurationAnnotation + """
+              %s
               public class ExampleClass {
               }
-              """,
+              """.formatted(contextConfigurationAnnotation),
             """
               package org.example;
                             
               import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
                             
-              """ + springJunitConfigAnnotation + """
+              %s
               public class ExampleClass {
               }
-              """
+              """.formatted(springJunitConfigAnnotation)
           )
         );
     }


### PR DESCRIPTION
This recipe will convert JUnit 5 test classes that use both `@ExtendWith` and `@ContextConfiguration` into [`@SpringJUnitConfig`](https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/test/context/junit/jupiter/SpringJUnitConfig.html).

It changes the `@ContextConfiguration` annotation into `@SpringJUnitConfig`, with a few modifications:

- The `loader()` attribute on `@ContextConfiguration` is not supported on `@SpringJUnitConfig`, so if this is encountered, the transformation is abandoned out of caution and to adhere to the "do no harm" principle.
- The `value()` attribute on `@ContextConfiguration` needs to be renamed to `locations()`. It's invalid for an existing `@ContextConfiguration` annotation to be using both `value()` and `locations()`, but if this were encountered, the recipe would overwrite any pre-existing value for `locations()`. 

The recipe reuses the existing recipe [`UnnecessarySpringExtension`](https://docs.openrewrite.org/reference/recipes/java/spring/boot2/unnecessaryspringextension) to remove the `@ExtendsWith(SpringExtension.class)` annotation. 

It will also apply to the [JUnit 4 to JUnit 5 migration recipe](https://docs.openrewrite.org/reference/recipes/java/spring/boot2/springboot2junit4to5migration) as it is added to the [`UnnecessarySpringRunWith`](https://docs.openrewrite.org/reference/recipes/java/spring/boot2/unnecessaryspringrunwith) recipe.

Closes #296 