### PR TITLE
Enable recipe in JUnit 5 migration (#296)

### DIFF
--- a/src/main/resources/META-INF/rewrite/spring-boot-24.yml
+++ b/src/main/resources/META-INF/rewrite/spring-boot-24.yml
@@ -141,8 +141,7 @@ recipeList:
   - org.openrewrite.java.spring.boot2.OutputCaptureExtension
   - org.openrewrite.java.spring.boot2.UnnecessarySpringRunWith
   - org.openrewrite.java.spring.boot2.UnnecessarySpringExtension
-# TODO Enable once tested on more projects through public.moderne.io
-#  - org.openrewrite.java.spring.boot2.ReplaceExtendWithAndContextConfiguration
+  - org.openrewrite.java.spring.boot2.ReplaceExtendWithAndContextConfiguration
   - org.openrewrite.java.spring.boot2.RemoveObsoleteSpringRunners
   - org.openrewrite.maven.AddDependency:
       groupId: org.springframework.boot

--- a/src/testWithSpringBoot_2_3/java/org/openrewrite/java/spring/boot2/SpringBoot2JUnit4to5MigrationTest.java
+++ b/src/testWithSpringBoot_2_3/java/org/openrewrite/java/spring/boot2/SpringBoot2JUnit4to5MigrationTest.java
@@ -15,7 +15,6 @@
  */
 package org.openrewrite.java.spring.boot2;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.Issue;
 import org.openrewrite.config.Environment;
@@ -82,7 +81,6 @@ class SpringBoot2JUnit4to5MigrationTest implements RewriteTest {
 
     @Issue("https://github.com/openrewrite/rewrite-spring/issues/296")
     @Test
-    @Disabled("Requires inclusion of ReplaceExtendWithAndContextConfiguration after that's verified on more projects")
     void springBootRunWithContextConfigurationReplacedWithSpringJUnitConfig() {
         //language=java
         rewriteRun(


### PR DESCRIPTION
This PR enables the recipe to convert JUnit 5 test classes that use both `@ExtendWith` and `@ContextConfiguration` into [`@SpringJUnitConfig`](https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/test/context/junit/jupiter/SpringJUnitConfig.html) in the [JUnit 4 to JUnit 5 migration recipe](https://docs.openrewrite.org/reference/recipes/java/spring/boot2/springboot2junit4to5migration).

Closes #296 
See #297 