### PR TITLE
Saml2 property changes only for 2.7

### DIFF
--- a/src/main/resources/META-INF/rewrite/spring-boot-30.yml
+++ b/src/main/resources/META-INF/rewrite/spring-boot-30.yml
@@ -35,7 +35,6 @@ recipeList:
   - org.openrewrite.java.spring.boot2.MoveAutoConfigurationToImportsFile
   - org.openrewrite.java.spring.boot3.ActuatorEndpointSanitization
   - org.openrewrite.java.spring.boot3.MigrateMaxHttpHeaderSize
-  - org.openrewrite.java.spring.boot3.Saml
   - org.openrewrite.java.spring.boot3.DowngradeServletApiWhenUsingJetty
   - org.openrewrite.java.spring.boot3.ConfigurationOverEnableSecurity
   - org.openrewrite.java.spring.boot3.SpringBootProperties_3_0_0
@@ -60,34 +59,6 @@ recipeList:
       groupId: org.springframework.boot
       artifactId: spring-boot-starter-parent
       newVersion: 3.0.x
----
-type: specs.openrewrite.org/v1beta/recipe
-name: org.openrewrite.java.spring.boot3.Saml
-displayName: Migrate SAML configuration to Spring Boot 3.0 in yaml format
-description: Renames spring.security.saml2.relyingparty.registration.(any).identityprovider to spring.security.saml2.relyingparty.registration.(any).assertingparty.
-tags:
-  - spring
-  - boot
-  - saml
-recipeList:
-  - org.openrewrite.yaml.ChangeKey:
-      oldKeyPath: $.spring.security.saml2.relyingparty.registration.*[?(@.identityprovider)]
-      newKey: assertingparty
-
----
-type: specs.openrewrite.org/v1beta/recipe
-name: org.openrewrite.java.spring.boot3.Saml
-displayName: Migrate SAML configuration to Spring Boot 3.0 in yaml format
-description: Renames spring.security.saml2.relyingparty.registration.(any).identityprovider to spring.security.saml2.relyingparty.registration.(any).assertingparty.
-tags:
-  - spring
-  - boot
-  - saml
-recipeList:
-  - org.openrewrite.yaml.ChangeKey:
-      oldKeyPath: $.spring.security.saml2.relyingparty.registration.*[?(@.identityprovider)]
-      newKey: assertingparty
-
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.spring.boot3.DowngradeServletApiWhenUsingJetty


### PR DESCRIPTION
Remove Saml2 property migration from boot 3.0 migration as it is meant for Boot 2.7 migration only