### PR TITLE
Removed BeanMethodsNotPublic from SpringBoot2BestPractices

### DIFF
--- a/src/main/resources/META-INF/rewrite/spring-boot-20.yml
+++ b/src/main/resources/META-INF/rewrite/spring-boot-20.yml
@@ -670,7 +670,6 @@ recipeList:
   - org.openrewrite.java.spring.NoRequestMappingAnnotation
   - org.openrewrite.java.spring.ImplicitWebAnnotationNames
   - org.openrewrite.java.spring.boot2.UnnecessarySpringExtension
-  - org.openrewrite.java.spring.BeanMethodsNotPublic
   - org.openrewrite.java.spring.NoAutowiredOnConstructor
   - org.openrewrite.java.spring.boot2.ConditionalOnBeanAnyNestedCondition
   - org.openrewrite.java.spring.boot2.RestTemplateBuilderRequestFactory


### PR DESCRIPTION
I don't think we can justify this as a standard best practice (which gets run in every Spring Boot upgrade recipe past 2.x), and it's a pretty noisy change for projects which don't already use this style.

The closest mention I see in Spring Boot reference docs is this:

https://docs.spring.io/spring-framework/docs/current/reference/html/core.html#beans-factorybeans-annotations

> The Java language visibility of @Bean methods does not have an immediate impact on the resulting bean definition in Spring’s container. You can freely declare your factory methods as you see fit in non-@Configuration classes and also for static methods anywhere. However, regular @Bean methods in @Configuration classes need to be overridable — that is, they must not be declared as private or final.

...and all the other code snippets on that page indeed use the `public` modifier for `@Bean` methods.