### PR TITLE
[SB 3.0 recipe] Add recipe AddSetUseTrailingSlashMatch

### DIFF
--- a/src/main/java/org/openrewrite/java/spring/boot3/AddSetUseTrailingSlashMatch.java
+++ b/src/main/java/org/openrewrite/java/spring/boot3/AddSetUseTrailingSlashMatch.java
@@ -50,7 +50,12 @@ public class AddSetUseTrailingSlashMatch extends Recipe {
 
     @Override
     public String getDescription() {
-        return "todo.";
+        return "This is part of Spring MVC and WebFlux URL Matching Changes, as of Spring Framework 6.0, the trailing" +
+               " slash matching configuration option has been deprecated and its default value set to false. " +
+               "This means that previously, a controller `@GetMapping(\"/some/greeting\")` would match both" +
+               " `GET /some/greeting` and `GET /some/greeting/`, but it doesn't match `GET /some/greeting/` " +
+               "anymore by default and will result in an HTTP 404 error. This recipe is change the default with " +
+               "the global Spring MVC or Webflux configuration:";
     }
 
     @Override

--- a/src/main/java/org/openrewrite/java/spring/boot3/AddSetUseTrailingSlashMatch.java
+++ b/src/main/java/org/openrewrite/java/spring/boot3/AddSetUseTrailingSlashMatch.java
@@ -55,7 +55,7 @@ public class AddSetUseTrailingSlashMatch extends Recipe {
                "This means that previously, a controller `@GetMapping(\"/some/greeting\")` would match both" +
                " `GET /some/greeting` and `GET /some/greeting/`, but it doesn't match `GET /some/greeting/` " +
                "anymore by default and will result in an HTTP 404 error. This recipe is change the default with " +
-               "the global Spring MVC or Webflux configuration:";
+               "the global Spring MVC or Webflux configuration.";
     }
 
     @Override

--- a/src/main/java/org/openrewrite/java/spring/boot3/AddSetUseTrailingSlashMatch.java
+++ b/src/main/java/org/openrewrite/java/spring/boot3/AddSetUseTrailingSlashMatch.java
@@ -1,0 +1,224 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.spring.boot3;
+
+import org.openrewrite.Applicability;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.java.*;
+import org.openrewrite.java.search.UsesType;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaType;
+import org.openrewrite.java.tree.TypeTree;
+import org.openrewrite.java.tree.TypeUtils;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class AddSetUseTrailingSlashMatch extends Recipe {
+    private static final MethodMatcher WEB_MVC_setUseTrailingSlashMatch = new MethodMatcher(
+        "org.springframework.web.servlet.config.annotation.PathMatchConfigurer setUseTrailingSlashMatch(java.lang.Boolean)"
+    );
+    private static final MethodMatcher WEB_FLUX_setUseTrailingSlashMatch = new MethodMatcher(
+    "org.springframework.web.reactive.config.PathMatchConfigurer setUseTrailingSlashMatch(java.lang.Boolean)"
+    );
+
+    private static final String WEB_MVC_CONFIGUER = "org.springframework.web.servlet.config.annotation.WebMvcConfigurer";
+    private static final String WEB_FLUX_CONFIGUER = "org.springframework.web.reactive.config.WebFluxConfigurer";
+
+    private static final String WEB_MVC_PATH_MATCH_CONFIGURER = "org.springframework.web.servlet.config.annotation.PathMatchConfigurer";
+    private static final String WEB_FLUX_PATH_MATCH_CONFIGURER = "org.springframework.web.reactive.config.PathMatchConfigurer";
+
+    @Override
+    public String getDisplayName() {
+        return "Add `SetUseTrailingSlashMatch()` in configuration";
+    }
+
+    @Override
+    public String getDescription() {
+        return "todo.";
+    }
+
+    @Override
+    protected @Nullable TreeVisitor<?, ExecutionContext> getSingleSourceApplicableTest() {
+        // todo, change to use FindImplementations after the getVisitor() method is ready
+        return Applicability.or(new UsesType<>(WEB_MVC_CONFIGUER),
+            new UsesType<>(WEB_FLUX_CONFIGUER));
+    }
+
+    @Override
+    protected TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new JavaIsoVisitor<ExecutionContext>() {
+
+            @Override
+            public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration classDecl, ExecutionContext ctx) {
+                boolean isWebConfigClass = false;
+                boolean isWebMVC = false;
+                if (classDecl.getImplements() != null) {
+                    for (TypeTree impl : classDecl.getImplements()) {
+                        JavaType.FullyQualified fullyQualified = TypeUtils.asFullyQualified(impl.getType());
+                        if (fullyQualified != null &&
+                            (WEB_MVC_CONFIGUER.equals(fullyQualified.getFullyQualifiedName()) ||
+                             WEB_FLUX_CONFIGUER.equals(fullyQualified.getFullyQualifiedName()))
+                        ) {
+                            isWebMVC = WEB_MVC_CONFIGUER.equals(fullyQualified.getFullyQualifiedName());
+                            isWebConfigClass = true;
+                            break;
+                        }
+                    }
+                }
+
+                if (!isWebConfigClass) {
+                    return classDecl;
+                }
+
+                // Check whether this class has `configurePathMatch` method
+                // 1. if it already has, then check if it calls method `setUseTrailingSlashMatch`.
+                //      (1) if it has `setUseTrailingSlashMatch` called, do nothing.
+                //      (2) if it has not `setUseTrailingSlashMatch` called, add `setUseTrailingSlashMatch(true)` to
+                //      this method
+                // 2. if it has not `configurePathMatch` method, add it to this class.
+                boolean configMethodExists = classDecl.getBody().getStatements().stream()
+                    .filter(statement -> statement instanceof J.MethodDeclaration)
+                    .map(J.MethodDeclaration.class::cast)
+                    .anyMatch(methodDeclaration -> isWebMVCConfigurerMatchMethod(methodDeclaration) ||
+                                                   isWebFluxconfigurePathMatchingMethod(methodDeclaration));
+
+                if (configMethodExists) {
+                    return super.visitClassDeclaration(classDecl, ctx);
+                } else {
+                    // add a `configurePathMatch` or `configurePathMatching` method to this class
+                    JavaTemplate WebMvcConfigurePathMatchTemplate = JavaTemplate.builder(this::getCursor,
+                            "@Override public void configurePathMatch(PathMatchConfigurer configurer) { configurer" +
+                            ".setUseTrailingSlashMatch(true); }")
+                        .javaParser(() -> JavaParser.fromJavaVersion()
+                            .classpath("spring-webmvc", "spring-context", "spring-web")
+                            .build())
+                        .imports(WEB_MVC_PATH_MATCH_CONFIGURER,
+                            "org.springframework.web.servlet.config.annotation.WebMvcConfigurer",
+                            "org.springframework.context.annotation.Configuration")
+                        .build();
+
+                    JavaTemplate webFluxConfigurePathMatchingTemplate =
+                        JavaTemplate.builder(this::getCursor,
+                                "@Override public void configurePathMatching(PathMatchConfigurer configurer) { configurer" +
+                                ".setUseTrailingSlashMatch(true); }")
+                            .javaParser(() -> JavaParser.fromJavaVersion()
+                                .classpath("spring-webflux", "spring-context", "spring-web")
+                                .build())
+                            .imports(WEB_FLUX_PATH_MATCH_CONFIGURER,
+                                "org.springframework.web.reactive.config.WebFluxConfigurer",
+                                "org.springframework.context.annotation.Configuration")
+                            .build();
+
+
+                    JavaTemplate template = isWebMVC ? WebMvcConfigurePathMatchTemplate : webFluxConfigurePathMatchingTemplate;
+                    classDecl = classDecl.withBody(
+                        classDecl.getBody().withTemplate(
+                            template,
+                            classDecl.getBody().getCoordinates().lastStatement()
+                        ));
+
+                    String importPathMatchConfigurer = isWebMVC ? WEB_MVC_PATH_MATCH_CONFIGURER : WEB_FLUX_PATH_MATCH_CONFIGURER;
+                    maybeAddImport(importPathMatchConfigurer, false);
+                    return classDecl;
+                }
+            }
+
+            @Override
+            public J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration method,
+                                                              ExecutionContext executionContext) {
+
+                if (isWebMVCConfigurerMatchMethod(method) || isWebFluxconfigurePathMatchingMethod(method)) {
+
+                    if (findSetUseTrailingSlashMatchMethodCall.find(method)) {
+                        // do nothing
+                        return method;
+                    } else {
+                        // add statement
+
+                        JavaTemplate WebMvcTemplate = JavaTemplate.builder(this::getCursor,
+                                "#{any()}.setUseTrailingSlashMatch(true);")
+                            .javaParser(() -> JavaParser.fromJavaVersion()
+                                .classpath("spring-webmvc", "spring-context", "spring-web")
+                                .build())
+                            .imports(WEB_MVC_PATH_MATCH_CONFIGURER,
+                                "org.springframework.web.servlet.config.annotation.WebMvcConfigurer",
+                                "org.springframework.context.annotation.Configuration")
+                            .build();
+
+                        JavaTemplate WebFluxTemplate = JavaTemplate.builder(this::getCursor,
+                                "#{any()}.setUseTrailingSlashMatch(true);")
+                            .javaParser(() -> JavaParser.fromJavaVersion()
+                                .classpath("spring-webflux", "spring-context", "spring-web")
+                                .build())
+                            .imports(WEB_MVC_PATH_MATCH_CONFIGURER,
+                                "org.springframework.web.reactive.config.WebFluxConfigurer",
+                                "org.springframework.context.annotation.Configuration")
+                            .build();
+
+                        boolean isWebMVC = isWebMVCConfigurerMatchMethod(method);
+
+                        method = method.withBody(
+                            method.getBody().withTemplate(
+                                isWebMVC ? WebMvcTemplate : WebFluxTemplate,
+                                method.getBody().getCoordinates().lastStatement(),
+                                ((J.VariableDeclarations)method.getParameters().get(0)).getVariables().get(0).getName()
+                            ));
+
+                        return method;
+                    }
+                }
+
+                return method;
+            }
+        };
+    }
+
+    private static boolean isWebMVCConfigurerMatchMethod(J.MethodDeclaration method) {
+        return method.getName().getSimpleName().equals("configurePathMatch") &&
+               method.getMethodType().getParameterTypes().size() == 1 &&
+               method.getMethodType().getParameterTypes().get(0).toString().equals(WEB_MVC_PATH_MATCH_CONFIGURER);
+    }
+
+    private static boolean isWebFluxconfigurePathMatchingMethod(J.MethodDeclaration method) {
+        return method.getName().getSimpleName().equals("configurePathMatching") &&
+               method.getMethodType().getParameterTypes().size() == 1 &&
+               method.getMethodType().getParameterTypes().get(0).toString().equals(WEB_FLUX_PATH_MATCH_CONFIGURER);
+    }
+
+    private static class findSetUseTrailingSlashMatchMethodCall extends JavaIsoVisitor<AtomicBoolean> {
+        static boolean find(J j) {
+            return new findSetUseTrailingSlashMatchMethodCall()
+                .reduce(j, new AtomicBoolean()).get();
+        }
+
+        @Override
+        public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, AtomicBoolean found) {
+            if (found.get()) {
+                return method;
+            }
+            if (WEB_MVC_setUseTrailingSlashMatch.matches(method) ||
+                WEB_FLUX_setUseTrailingSlashMatch.matches(method)) {
+                found.set(true);
+                return method;
+            }
+
+            return super.visitMethodInvocation(method, found);
+        }
+    }
+}

--- a/src/main/java/org/openrewrite/java/spring/boot3/MaintainTrailingSlashURLMappings.java
+++ b/src/main/java/org/openrewrite/java/spring/boot3/MaintainTrailingSlashURLMappings.java
@@ -51,7 +51,7 @@ public class MaintainTrailingSlashURLMappings extends Recipe {
         for (SourceFile s : before) {
             if (s instanceof JavaSourceFile) {
                 JavaSourceFile cu = (JavaSourceFile) s;
-                anyConfigOverridden = FindWebMvcConfigurer.find(cu);
+                anyConfigOverridden = FindWebConfigurer.find(cu);
                 if (anyConfigOverridden) {
                     break;
                 }
@@ -66,9 +66,9 @@ public class MaintainTrailingSlashURLMappings extends Recipe {
         return before;
     }
 
-    private static class FindWebMvcConfigurer extends JavaIsoVisitor<AtomicBoolean> {
+    private static class FindWebConfigurer extends JavaIsoVisitor<AtomicBoolean> {
         static boolean find(J j) {
-            return new FindWebMvcConfigurer()
+            return new FindWebConfigurer()
                 .reduce(j, new AtomicBoolean()).get();
         }
 

--- a/src/main/java/org/openrewrite/java/spring/boot3/MaintainTrailingSlashURLMappings.java
+++ b/src/main/java/org/openrewrite/java/spring/boot3/MaintainTrailingSlashURLMappings.java
@@ -59,6 +59,7 @@ public class MaintainTrailingSlashURLMappings extends Recipe {
         }
 
         if (anyConfigOverridden) {
+            doNext(new AddSetUseTrailingSlashMatch());
             return before;
         }
 

--- a/src/testWithSpringBoot_2_7/java/org/openrewrite/java/spring/boot2/AddSetUseTrailingSlashMatchTest.java
+++ b/src/testWithSpringBoot_2_7/java/org/openrewrite/java/spring/boot2/AddSetUseTrailingSlashMatchTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openrewrite.java.spring.boot2;
 
 import org.junit.jupiter.api.Test;

--- a/src/testWithSpringBoot_2_7/java/org/openrewrite/java/spring/boot2/AddSetUseTrailingSlashMatchTest.java
+++ b/src/testWithSpringBoot_2_7/java/org/openrewrite/java/spring/boot2/AddSetUseTrailingSlashMatchTest.java
@@ -1,0 +1,194 @@
+package org.openrewrite.java.spring.boot2;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.java.spring.boot3.AddSetUseTrailingSlashMatch;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+public class AddSetUseTrailingSlashMatchTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.parser(JavaParser.fromJavaVersion().classpath("spring-webmvc", "spring-webflux", "spring-web", "spring-context"))
+          .recipe(new AddSetUseTrailingSlashMatch());
+    }
+
+    @Test
+    void noChangeIfExistWithWebMvcConfigurer() {
+        rewriteRun(
+          java(
+            """
+              package com.example.demo;
+
+              import org.springframework.context.annotation.Configuration;
+              import org.springframework.web.servlet.config.annotation.PathMatchConfigurer;
+              import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+              @Configuration
+              public class MyWebConfiguration implements WebMvcConfigurer {
+                  @Override
+                  public void configurePathMatch(PathMatchConfigurer configurer) {
+                      configurer.setUseTrailingSlashMatch(true);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void noChangeIfExistWithWebflux() {
+        rewriteRun(
+          java(
+            """
+              import org.springframework.context.annotation.Configuration;
+              import org.springframework.web.reactive.config.PathMatchConfigurer;
+              import org.springframework.web.reactive.config.WebFluxConfigurer;
+
+              @Configuration
+              public class MyWebConfig implements WebFluxConfigurer {
+                  @Override
+                  public void configurePathMatching(PathMatchConfigurer configurer) {
+                      configurer.setUseTrailingSlashMatch(true);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void addConfigurePathMatchMethodForWebMvcConfigurer() {
+        rewriteRun(
+          java(
+            """
+              package com.example.demo;
+
+              import org.springframework.context.annotation.Configuration;
+              import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+              @Configuration
+              public class MyWebConfiguration implements WebMvcConfigurer {
+              }
+              """,
+            """
+              package com.example.demo;
+
+              import org.springframework.context.annotation.Configuration;
+              import org.springframework.web.servlet.config.annotation.PathMatchConfigurer;
+              import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+              @Configuration
+              public class MyWebConfiguration implements WebMvcConfigurer {
+                  @Override
+                  public void configurePathMatch(PathMatchConfigurer configurer) {
+                      configurer.setUseTrailingSlashMatch(true);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void addConfigurePathMatchMethodForWebFluxConfigurer() {
+        rewriteRun(
+          java(
+            """
+              import org.springframework.context.annotation.Configuration;
+              import org.springframework.web.reactive.config.WebFluxConfigurer;
+
+              @Configuration
+              public class MyWebConfig implements WebFluxConfigurer {
+              }
+              """,
+            """
+              import org.springframework.context.annotation.Configuration;
+              import org.springframework.web.reactive.config.PathMatchConfigurer;
+              import org.springframework.web.reactive.config.WebFluxConfigurer;
+
+              @Configuration
+              public class MyWebConfig implements WebFluxConfigurer {
+                  @Override
+                  public void configurePathMatching(PathMatchConfigurer configurer) {
+                      configurer.setUseTrailingSlashMatch(true);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void addSetUseTrailingSlashMatchCallForWebMvcConfigurer() {
+        rewriteRun(
+          java(
+            """
+              package com.example.demo;
+
+              import org.springframework.context.annotation.Configuration;
+              import org.springframework.web.servlet.config.annotation.PathMatchConfigurer;
+              import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+              @Configuration
+              public class MyWebConfiguration implements WebMvcConfigurer {
+                  @Override
+                  public void configurePathMatch(PathMatchConfigurer configurer) {
+                  }
+              }
+              """,
+            """
+              package com.example.demo;
+
+              import org.springframework.context.annotation.Configuration;
+              import org.springframework.web.servlet.config.annotation.PathMatchConfigurer;
+              import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+              @Configuration
+              public class MyWebConfiguration implements WebMvcConfigurer {
+                  @Override
+                  public void configurePathMatch(PathMatchConfigurer configurer) {
+                      configurer.setUseTrailingSlashMatch(true);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void addSetUseTrailingSlashMatchForWebFluxConfigurer() {
+        rewriteRun(
+          java(
+            """
+              import org.springframework.context.annotation.Configuration;
+              import org.springframework.web.reactive.config.PathMatchConfigurer;
+              import org.springframework.web.reactive.config.WebFluxConfigurer;
+
+              @Configuration
+              public class MyWebConfig implements WebFluxConfigurer {
+                  @Override
+                  public void configurePathMatching(PathMatchConfigurer configurer) {
+                  }
+              }
+              """,
+            """
+              import org.springframework.context.annotation.Configuration;
+              import org.springframework.web.reactive.config.PathMatchConfigurer;
+              import org.springframework.web.reactive.config.WebFluxConfigurer;
+
+              @Configuration
+              public class MyWebConfig implements WebFluxConfigurer {
+                  @Override
+                  public void configurePathMatching(PathMatchConfigurer configurer) {
+                      configurer.setUseTrailingSlashMatch(true);
+                  }
+              }
+              """
+          )
+        );
+    }
+}


### PR DESCRIPTION
Add recipe `AddSetUseTrailingSlashMatch` to add `configurer.setUseTrailingSlashMatch(true);` method invocation to `WebMvcConfigurer` class or `WebFluxConfigurer` to change the default with the global Spring MVC or Webflux configuration.

This is part of SB 3.0 task [Maintain trailing slash in request mappings](https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-3.0-Migration-Guide#spring-mvc-and-webflux-url-matching-changes) , after this recipe, this task is completed.