### PR TITLE
Change `ConfigurationOverEnableSecurity` to modify only before Boot3

### DIFF
--- a/src/main/java/org/openrewrite/java/spring/boot3/ConfigurationOverEnableSecurity.java
+++ b/src/main/java/org/openrewrite/java/spring/boot3/ConfigurationOverEnableSecurity.java
@@ -86,11 +86,13 @@ public class ConfigurationOverEnableSecurity extends Recipe {
                     return c;
                 }
 
-                boolean hasConfiguration = !FindAnnotations.find(bodiless, "@" + CONFIGURATION_FQN, true)
-                                               .isEmpty();
+                J.Annotation securityAnnotation = securityAnnotations.stream().findFirst().get();
+                boolean securityAnnotationHasConfiguration = new AnnotationMatcher("@" + CONFIGURATION_FQN, true)
+                    .matchesAnnotationOrMetaAnnotation(TypeUtils.asFullyQualified(securityAnnotation.getType()));
+
                 // The framework 6.+ (Boot 3+) removed `@Configuration` from `@EnableXXXSecurity`, so if it has not `@Configuration`, means it
                 // is already in version framework 6.+ (Boot 3+), and expected no change. otherwise we want to add `@Configuration`.
-                boolean isBoot3orPlus = !hasConfiguration;
+                boolean isBoot3orPlus = !securityAnnotationHasConfiguration;
                 if (isBoot3orPlus) {
                     return c;
                 }

--- a/src/main/java/org/openrewrite/java/spring/boot3/ConfigurationOverEnableSecurity.java
+++ b/src/main/java/org/openrewrite/java/spring/boot3/ConfigurationOverEnableSecurity.java
@@ -76,17 +76,22 @@ public class ConfigurationOverEnableSecurity extends Recipe {
                 // Avoid searching within the class declaration's body, lest we accidentally find an inner class's annotation
                 //noinspection DataFlowIssue
                 J.ClassDeclaration bodiless = c.withBody(null);
-                if (FindAnnotations.find(bodiless, "@" + CONFIGURATION_FQN, false).size() > 0) {
-                    return c;
-                }
+
                 Set<J.Annotation> securityAnnotations = FindAnnotations.find(bodiless, ENABLE_SECURITY_ANNOTATION_PATTERN, true);
-                if (securityAnnotations.size() == 0) {
+                if (securityAnnotations.isEmpty() || isExcluded(securityAnnotations)) {
                     return c;
                 }
-                if (securityAnnotations.stream()
-                        .map(a -> TypeUtils.asFullyQualified(a.getType()))
-                        .filter(Objects::nonNull)
-                        .anyMatch(it -> EXCLUSIONS.contains(it.getFullyQualifiedName()))) {
+
+                if (!FindAnnotations.find(bodiless, "@" + CONFIGURATION_FQN, false).isEmpty()) {
+                    return c;
+                }
+
+                boolean hasConfiguration = !FindAnnotations.find(bodiless, "@" + CONFIGURATION_FQN, true)
+                                               .isEmpty();
+                // The framework 6.+ (Boot 3+) removed `@Configuration` from `@EnableXXXSecurity`, so if it has not `@Configuration`, means it
+                // is already in version framework 6.+ (Boot 3+), and expected no change. otherwise we want to add `@Configuration`.
+                boolean isBoot3orPlus = !hasConfiguration;
+                if (isBoot3orPlus) {
                     return c;
                 }
 
@@ -99,6 +104,13 @@ public class ConfigurationOverEnableSecurity extends Recipe {
                 maybeAddImport(CONFIGURATION_FQN);
 
                 return c.withTemplate(template, c.getCoordinates().addAnnotation(Comparator.comparing(J.Annotation::getSimpleName)));
+            }
+
+            private boolean isExcluded(Set<J.Annotation> securityAnnotations) {
+                return (securityAnnotations.stream()
+                    .map(a -> TypeUtils.asFullyQualified(a.getType()))
+                    .filter(Objects::nonNull)
+                    .anyMatch(it -> EXCLUSIONS.contains(it.getFullyQualifiedName())));
             }
         };
     }

--- a/src/testWithSpringBoot_2_7/java/org/openrewrite/java/spring/boot2/ConfigurationOverEnableSecurityTest.java
+++ b/src/testWithSpringBoot_2_7/java/org/openrewrite/java/spring/boot2/ConfigurationOverEnableSecurityTest.java
@@ -13,10 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.openrewrite.java.spring.boot3;
+package org.openrewrite.java.spring.boot2;
 
 import org.junit.jupiter.api.Test;
 import org.openrewrite.java.JavaParser;
+import org.openrewrite.java.spring.boot3.ConfigurationOverEnableSecurity;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
@@ -39,6 +40,31 @@ public class ConfigurationOverEnableSecurityTest implements RewriteTest {
             """
               import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
               
+              @EnableWebSecurity
+              class A {}
+              """,
+            """
+              import org.springframework.context.annotation.Configuration;
+              import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+              
+              @Configuration
+              @EnableWebSecurity
+              class A {}
+              """
+          )
+        );
+    }
+
+    @Test
+    void doNotChangeIfItExist() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.springframework.context.annotation.Configuration;
+              import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+              
+              @Configuration
               @EnableWebSecurity
               class A {}
               """
@@ -71,6 +97,14 @@ public class ConfigurationOverEnableSecurityTest implements RewriteTest {
               
               @EnableWebFluxSecurity
               class A {}
+              """,
+            """
+              import org.springframework.context.annotation.Configuration;
+              import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity;
+              
+              @Configuration
+              @EnableWebFluxSecurity
+              class A {}
               """
           )
         );
@@ -84,6 +118,14 @@ public class ConfigurationOverEnableSecurityTest implements RewriteTest {
             """
               import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
               
+              @EnableMethodSecurity
+              class A {}
+              """,
+            """
+              import org.springframework.context.annotation.Configuration;
+              import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+              
+              @Configuration
               @EnableMethodSecurity
               class A {}
               """


### PR DESCRIPTION
Change `ConfigurationOverEnableSecurity` to modify only before Boot3. 
and no change if it's already Boot 3.

Slack discussion [here](https://moderneinc.slack.com/archives/C017J8U6ZGC/p1679331496438579).