### PR TITLE
Adds recipe `UpdateSmartLifecycleDefaultPhase` and `FlywayMigration`

### DIFF
--- a/src/main/java/org/openrewrite/java/spring/boot3/FlywayMigration.java
+++ b/src/main/java/org/openrewrite/java/spring/boot3/FlywayMigration.java
@@ -1,0 +1,29 @@
+package org.openrewrite.java.spring.boot3;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.JavaIsoVisitor;
+
+public class FlywayMigration extends Recipe {
+    @Override
+    public String getDisplayName() {
+        return "todo";
+    }
+
+
+    @Override
+    public String getDescription() {
+        return "FlywayConfigurationCustomizer beans are now called to customize the FluentConfiguration after any " +
+               "Callback and JavaMigration beans have been added to the configuration. An application that defines " +
+               "Callback and JavaMigration beans and adds callbacks and Java migrations using a customizer may have " +
+               "to be updated to ensure that the intended callbacks and Java migrations are used.\n";
+    }
+
+    @Override
+    protected TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new JavaIsoVisitor<ExecutionContext>(){
+            // todo
+        };
+    }
+}

--- a/src/main/java/org/openrewrite/java/spring/boot3/UpdateSmartLifecycleDefaultPhase.java
+++ b/src/main/java/org/openrewrite/java/spring/boot3/UpdateSmartLifecycleDefaultPhase.java
@@ -1,0 +1,84 @@
+package org.openrewrite.java.spring.boot3;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.JavaVisitor;
+import org.openrewrite.java.MethodMatcher;
+import org.openrewrite.java.PartProvider;
+import org.openrewrite.java.tree.J;
+
+public class UpdateSmartLifecycleDefaultPhase extends Recipe  {
+    private static final MethodMatcher GET_PHASE_MATCHER = new MethodMatcher(
+        "org.springframework.context.SmartLifecycle getPhase()", true
+    );
+
+    @Nullable
+    private static J.Identifier defaultPhaseIdentifier = null;
+
+    @Override
+    public String getDisplayName() {
+        return "Use `SmartLifecycle.DEFAULT_PHASE` instead of Integer.MAX_VALUE";
+    }
+
+    @Override
+    public String getDescription() {
+        return "The phases used by the SmartLifecycle implementations for graceful shutdown have been updated. " +
+               "Graceful shutdown now begins in phase SmartLifecycle.DEFAULT_PHASE - 2048 and the web server is " +
+               "stopped in phase SmartLifecycle.DEFAULT_PHASE - 1024. Any SmartLifecycle implementations that were " +
+               "participating in graceful shutdown should be updated accordingly.";
+    }
+
+
+    @Override
+    protected TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new JavaIsoVisitor<ExecutionContext>() {
+            @Override
+            public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration classDecl,
+                                                            ExecutionContext executionContext) {
+                return super.visitClassDeclaration(classDecl, executionContext);
+            }
+
+            @Override
+            public J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration method,
+                                                              ExecutionContext ctx) {
+                if (GET_PHASE_MATCHER.matches(method.getMethodType())) {
+                    return (J.MethodDeclaration) new JavaVisitor<ExecutionContext>() {
+
+                        @Override
+                        public J visitFieldAccess(J.FieldAccess fieldAccess, ExecutionContext executionContext) {
+                            if (fieldAccess.toString().equals("Integer.MAX_VALUE")) {
+                                // replace with `SmartLifecycle.DEFAULT_PHASE`
+                                return getDefaultPhaseIdentifier();
+                            }
+
+                            return fieldAccess;
+                        }
+                    }.visit(method, ctx);
+                }
+                return super.visitMethodDeclaration(method, ctx);
+            }
+
+        };
+    }
+
+    private static J.Identifier getDefaultPhaseIdentifier() {
+        if (defaultPhaseIdentifier == null) {
+            J.MethodInvocation m = PartProvider.buildPart("import org.springframework.context.SmartLifecycle;\n" +
+                                                            "class MyLifeCycle implements SmartLifecycle {\n" +
+                                                            "\t@Override public void start() {}\n" +
+                                                            "\t@Override public void stop() {}\n" +
+                                                            "\t@Override public boolean isRunning() { return false; " +
+                                                            "}\n" +
+                                                            "\t@Override public int getPhase() { return " +
+                                                            "DEFAULT_PHASE;}\n" +
+                                                            "\tvoid method(int i) {}\n" +
+                                                            "\tvoid methodCall() {method(DEFAULT_PHASE);}\n" +
+                                                            "}", J.MethodInvocation.class, "spring-context");
+            defaultPhaseIdentifier = (J.Identifier) m.getArguments().get(0);
+        }
+        return defaultPhaseIdentifier;
+    }
+}

--- a/src/testWithSpringBoot_2_7/java/org/openrewrite/java/spring/boot2/FlywayMigrationTest.java
+++ b/src/testWithSpringBoot_2_7/java/org/openrewrite/java/spring/boot2/FlywayMigrationTest.java
@@ -1,0 +1,106 @@
+package org.openrewrite.java.spring.boot2;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.java.spring.boot3.FlywayMigration;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+public class FlywayMigrationTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.parser(JavaParser.fromJavaVersion().classpath("spring-boot"))
+          .recipe(new FlywayMigration());
+    }
+
+    @Test
+    void sample() {
+        rewriteRun(
+          java(
+            """
+              import flyway.NotificationBeanMigration;
+              import org.flywaydb.core.api.configuration.FluentConfiguration;
+              import org.springframework.boot.autoconfigure.flyway.FlywayConfigurationCustomizer;
+              import org.springframework.context.annotation.Bean;
+              import org.springframework.context.annotation.Configuration;
+
+              @Configuration
+              public class MigrationConfiguration implements FlywayConfigurationCustomizer {
+                  @Bean
+                  public NotificationBeanMigration beanMigration() {
+                      return new NotificationBeanMigration(null);
+                  }
+
+                  @Override
+                  public void customize(FluentConfiguration configuration) {
+                      // add callback
+                      configuration.callbacks(new MyCallback());
+
+                      // add java migration
+                      configuration.javaMigrations(new MyJavaMigration());
+
+                      // others
+                      configuration.resolvers(new FlywayConfigurationResolver());
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void sample2() {
+        rewriteRun(
+          java(
+            """
+              import org.flywaydb.core.api.callback.Callback;
+              import org.flywaydb.core.api.callback.Context;
+              import org.flywaydb.core.api.callback.Event;
+              import org.springframework.boot.autoconfigure.flyway.FlywayConfigurationCustomizer;
+              import org.springframework.context.annotation.Bean;
+              import org.springframework.context.annotation.Configuration;
+              import org.springframework.context.annotation.Profile;
+
+
+              @Profile("dev")
+              @Configuration
+              public class DevDbDataInitFlywayConfig {
+
+                  @Bean
+                  public FlywayConfigurationCustomizer flywayConfigurationCustomizer() {
+                      return configuration -> {
+                          // add callbacks
+                          configuration.callbacks(new DevDbDataInitFlywayCallback());
+                      };
+                  }
+
+                  public class DevDbDataInitFlywayCallback implements Callback {
+                      @Override
+                      public boolean canHandleInTransaction(Event event, Context context) {
+                          return false;
+                      }
+
+                      @Override
+                      public void handle(Event arg0, Context arg1) {
+                      }
+
+                      @Override
+                      public String getCallbackName() {
+                          return "dev";
+                      }
+
+                      @Override
+                      public boolean supports(Event event, Context context) {
+                          return event == Event.AFTER_MIGRATE;
+                      }
+                  }
+              }
+              """
+          )
+        );
+    }
+
+}

--- a/src/testWithSpringBoot_2_7/java/org/openrewrite/java/spring/boot2/UpdateSmartLifecycleDefaultPhaseTest.java
+++ b/src/testWithSpringBoot_2_7/java/org/openrewrite/java/spring/boot2/UpdateSmartLifecycleDefaultPhaseTest.java
@@ -1,0 +1,65 @@
+package org.openrewrite.java.spring.boot2;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.java.spring.boot3.UpdateSmartLifecycleDefaultPhase;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+public class UpdateSmartLifecycleDefaultPhaseTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.parser(JavaParser.fromJavaVersion().classpath("spring-context"))
+          .recipe(new UpdateSmartLifecycleDefaultPhase());
+    }
+
+    @Test
+    void replace() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.springframework.context.SmartLifecycle;
+
+              class MyLifeCycle implements SmartLifecycle  {
+              	@Override
+              	public void start() {}
+
+              	@Override
+              	public void stop() {}
+
+              	@Override
+              	public boolean isRunning() { return false; }
+
+              	@Override
+              	public int getPhase() {
+              		return Integer.MAX_VALUE - 1;
+              	}
+              }
+              """,
+            """
+              import org.springframework.context.SmartLifecycle;
+
+              class MyLifeCycle implements SmartLifecycle  {
+              	@Override
+              	public void start() {}
+
+              	@Override
+              	public void stop() {}
+
+              	@Override
+              	public boolean isRunning() { return false; }
+
+              	@Override
+              	public int getPhase() {
+              		return DEFAULT_PHASE - 1;
+              	}
+              }
+              """
+          )
+        );
+    }
+}


### PR DESCRIPTION
## WIP (please review testing first only)

This PR is part of the migration of Spring Boot 3.0  https://github.com/openrewrite/rewrite-spring/issues/257.


Add tests per my understanding of the requirement.
1. For recipe `UpdateSmartLifecycleDefaultPhase`, the requirement is [Update phases for graceful shutdown](https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-3.0-Migration-Guide#updated-phases-for-graceful-shutdown),  it just replaces `Integer.MAX_VALUE` with `SmartLifecycle.DEFAULT_PHASE ` in method `SmartLifecycle getPhase() `.
Need some Spring boot expertise to confirm my understanding of the requirement is correct.
2. For recipe `FlywayMigration`. 
 I am not sure about the requirement for now. just added some code snippets in the test by following the description [Migrate to Flyway 9.0](https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-3.0-Migration-Guide#flyway).
