### PR TITLE
[Spring Security6 migration] Add recipe UpdateRequestCacheTest

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -192,6 +192,19 @@ dependencies {
     "testWithSpringBoot_3_0RuntimeOnly"("org.springframework.security:spring-security-config:6.0.+")
     "testWithSpringBoot_3_0RuntimeOnly"("org.springframework.security:spring-security-web:6.0.+")
     "testWithSpringBoot_3_0RuntimeOnly"("org.springframework.security:spring-security-ldap:6.0.+")
+
+    "testWithSpringSecurity_5_8RuntimeOnly"("org.springframework:spring-context:5.3.+")
+    "testWithSpringSecurity_5_8RuntimeOnly"("org.springframework.boot:spring-boot-starter:2.7.+")
+    "testWithSpringSecurity_5_8RuntimeOnly"("org.springframework.boot:spring-boot:2.7.+")
+    "testWithSpringSecurity_5_8RuntimeOnly"("org.springframework.boot:spring-boot-starter-test:2.7.+")
+    "testWithSpringSecurity_5_8RuntimeOnly"("org.springframework:spring-web:5.3.+")
+    "testWithSpringSecurity_5_8RuntimeOnly"("org.springframework:spring-webmvc:5.3.+")
+    "testWithSpringSecurity_5_8RuntimeOnly"("org.springframework:spring-webflux:5.3.+")
+    "testWithSpringSecurity_5_8RuntimeOnly"("org.springframework.security:spring-security-core:5.8.+")
+    "testWithSpringSecurity_5_8RuntimeOnly"("org.springframework.security:spring-security-config:5.8.+")
+    "testWithSpringSecurity_5_8RuntimeOnly"("org.springframework.security:spring-security-web:5.8.+")
+    "testWithSpringSecurity_5_8RuntimeOnly"("org.springframework.security:spring-security-ldap:5.8.+")
+    "testWithSpringSecurity_5_8RuntimeOnly"("org.apache.tomcat.embed:tomcat-embed-core:9.0.+")
 }
 
 

--- a/src/main/java/org/openrewrite/java/spring/security6/UpdateRequestCache.java
+++ b/src/main/java/org/openrewrite/java/spring/security6/UpdateRequestCache.java
@@ -16,14 +16,18 @@
 package org.openrewrite.java.spring.security6;
 
 import org.openrewrite.*;
+import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.java.JavaTemplate;
 import org.openrewrite.java.MethodMatcher;
+import org.openrewrite.java.search.UsesMethod;
 import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.Statement;
 import org.openrewrite.java.tree.TypeUtils;
+
+import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
 
@@ -50,6 +54,16 @@ public class UpdateRequestCache extends Recipe {
                "request if the HTTP parameter \"continue\" is defined. To maintain the same default behavior as " +
                "Spring Security 5, either explicitly add the HTTP parameter \"continue\" to every request or use " +
                "NullRequestCache to override the default behavior.";
+    }
+
+    @Override
+    public @Nullable Duration getEstimatedEffortPerOccurrence() {
+        return Duration.ofMinutes(5);
+    }
+
+    @Override
+    protected @Nullable TreeVisitor<?, ExecutionContext> getSingleSourceApplicableTest() {
+        return new UsesMethod<>(REQUEST_CACHE_MATCHER);
     }
 
     @Override

--- a/src/main/java/org/openrewrite/java/spring/security6/UpdateRequestCache.java
+++ b/src/main/java/org/openrewrite/java/spring/security6/UpdateRequestCache.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openrewrite.java.spring.security6;
 
 import org.openrewrite.*;

--- a/src/main/java/org/openrewrite/java/spring/security6/UpdateRequestCache.java
+++ b/src/main/java/org/openrewrite/java/spring/security6/UpdateRequestCache.java
@@ -1,0 +1,148 @@
+package org.openrewrite.java.spring.security6;
+
+import org.openrewrite.*;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.java.JavaTemplate;
+import org.openrewrite.java.MethodMatcher;
+import org.openrewrite.java.tree.Expression;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.Statement;
+import org.openrewrite.java.tree.TypeUtils;
+import java.util.Collections;
+import java.util.List;
+
+public class UpdateRequestCache extends Recipe {
+
+    private static final MethodMatcher CONTINUE_PARAMETER_MATCHER = new MethodMatcher(
+        "org.springframework.security.web.savedrequest.HttpSessionRequestCache setMatchingRequestParameterName(java.lang.String)"
+    );
+
+    private static final MethodMatcher REQUEST_CACHE_MATCHER = new MethodMatcher(
+        "org.springframework.security.config.annotation.web.configurers.RequestCacheConfigurer requestCache(org.springframework.security.web.savedrequest.RequestCache)"
+    );
+
+    @Override
+    public String getDisplayName() {
+        return "Keep the default RequestCache querying behavior in Spring Security 5";
+    }
+
+    @Override
+    public String getDescription() {
+        return "By default, Spring Security 5 queries the saved request on every request, which means that in a " +
+               "typical setup, the HttpSession is queried on every request to use the RequestCache. In Spring " +
+               "Security 6, the default behavior has changed, and RequestCache will only be queried for a cached " +
+               "request if the HTTP parameter \"continue\" is defined. To maintain the same default behavior as " +
+               "Spring Security 5, either explicitly add the HTTP parameter \"continue\" to every request or use " +
+               "NullRequestCache to override the default behavior.";
+    }
+
+    @Override
+    protected TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new JavaIsoVisitor<ExecutionContext>() {
+
+            @Override
+            public J.Block visitBlock(J.Block block, ExecutionContext executionContext) {
+                block = super.visitBlock(block, executionContext);
+                List<Statement> statements = block.getStatements();
+
+                boolean hasContinueParameterStatement = findContinueParameterStatement(statements);
+                if (hasContinueParameterStatement) {
+                    return block;
+                }
+
+                for (int i = 0; i < statements.size(); i++) {
+                    Statement statement = statements.get(i);
+                    if (isNewHttpSessionRequestCacheStatement(statement)) {
+                        JavaTemplate template = JavaTemplate.builder(this::getCursor,
+                                "#{any()}.setMatchingRequestParameterName(\"continue\");")
+                            .javaParser(JavaParser.fromJavaVersion()
+                                .classpath("spring-security-web"))
+                            .imports(
+                                "org.springframework.security.web.savedrequest.HttpSessionRequestCache")
+                            .build();
+
+                        statement = statement.withTemplate(template, statement.getCoordinates().replace(), getSelect(statement));
+                        statements.add(i + 1, statement);
+
+                        return block.withStatements(statements);
+                    }
+                }
+                return block;
+            }
+
+            @Override
+            public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method,
+                                                            ExecutionContext executionContext) {
+                if (REQUEST_CACHE_MATCHER.matches(method)) {
+                    Expression arg = method.getArguments().get(0);
+                    if (isNewHttpSessionRequestCacheExpression(arg)) {
+                        JavaTemplate template = JavaTemplate.builder(this::getCursor,
+                                "new NullRequestCache()")
+                            .javaParser(JavaParser.fromJavaVersion()
+                                .classpath("spring-security-web"))
+                            .imports(
+                                "org.springframework.security.web.savedrequest.NullRequestCache")
+                            .build();
+
+                        maybeAddImport("org.springframework.security.web.savedrequest.NullRequestCache");
+                        maybeRemoveImport("org.springframework.security.web.savedrequest.HttpSessionRequestCache");
+                        arg = arg.withTemplate(template, arg.getCoordinates().replace());
+                        return method.withArguments(Collections.singletonList(arg));
+                    }
+
+                    return method;
+                }
+
+                return super.visitMethodInvocation(method, executionContext);
+            }
+        };
+    }
+
+    private static J.Identifier getSelect(Statement statement) {
+        return ((J.VariableDeclarations) statement).getVariables().get(0).getName();
+    }
+
+    private static boolean isNewHttpSessionRequestCacheStatement(Statement statement) {
+        if (statement instanceof J.VariableDeclarations) {
+            J.VariableDeclarations mv = (J.VariableDeclarations) statement;
+            if (mv.getVariables().size() == 1) {
+                J.VariableDeclarations.NamedVariable v = mv.getVariables().get(0);
+                return TypeUtils.isOfClassType(v.getType(),
+                    "org.springframework.security.web.savedrequest.HttpSessionRequestCache") &&
+                       v.getInitializer() != null && isNewHttpSessionRequestCacheExpression(v.getInitializer());
+            }
+        }
+        return false;
+    }
+
+    private static boolean isContinueParameterStatement(Statement statement) {
+        if (statement instanceof J.MethodInvocation) {
+            J.MethodInvocation m = (J.MethodInvocation) statement;
+
+            if (CONTINUE_PARAMETER_MATCHER.matches(m)) {
+                if (m.getArguments().get(0) instanceof J.Literal) {
+                    return ((J.Literal) m.getArguments().get(0)).getValue().equals("continue");
+                }
+            }
+        }
+        return false;
+    }
+
+    private static boolean findContinueParameterStatement(List<Statement> statements) {
+        return  statements.stream().anyMatch(UpdateRequestCache::isContinueParameterStatement);
+    }
+
+    private static boolean isNewHttpSessionRequestCacheExpression(Expression expression) {
+        if (!(expression instanceof J.NewClass)) {
+            return false;
+        }
+        J.NewClass newClass = (J.NewClass) expression;
+
+        if (TypeUtils.isOfClassType(newClass.getConstructorType().getReturnType(),
+            "org.springframework.security.web.savedrequest.HttpSessionRequestCache")) {
+            return true;
+        }
+        return false;
+    }
+}

--- a/src/main/java/org/openrewrite/java/spring/security6/UpdateRequestCache.java
+++ b/src/main/java/org/openrewrite/java/spring/security6/UpdateRequestCache.java
@@ -16,6 +16,7 @@
 package org.openrewrite.java.spring.security6;
 
 import org.openrewrite.*;
+import org.openrewrite.internal.ListUtils;
 import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.JavaParser;
@@ -92,7 +93,7 @@ public class UpdateRequestCache extends Recipe {
                             .build();
 
                         statement = statement.withTemplate(template, statement.getCoordinates().replace(), getSelect(statement));
-                        statements.add(i + 1, statement);
+                        statements = ListUtils.insert(statements, statement, i+1);
 
                         return block.withStatements(statements);
                     }

--- a/src/testWithSpringSecurity_5_8/java/org/openrewrite/spring/security5/UpdateRequestCacheTest.java
+++ b/src/testWithSpringSecurity_5_8/java/org/openrewrite/spring/security5/UpdateRequestCacheTest.java
@@ -1,0 +1,192 @@
+package org.openrewrite.spring.security5;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.InMemoryExecutionContext;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.java.spring.security6.UpdateRequestCache;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+public class UpdateRequestCacheTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(new UpdateRequestCache())
+          .parser(JavaParser.fromJavaVersion()
+            .logCompilationWarningsAndErrors(true)
+            .classpathFromResources(new InMemoryExecutionContext(),"spring-context-5.3.+", "spring-beans-5.3.+", "spring-web-5.3.+", "spring-security-web-5.8.+", "spring-security-config-5.8.+"));
+    }
+
+    @Test
+    void security5Default() {
+        rewriteRun(
+          java(
+            """
+              import org.springframework.context.annotation.Bean;
+              import org.springframework.context.annotation.Configuration;
+              import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+              import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+              import org.springframework.security.web.SecurityFilterChain;
+              import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
+              import org.springframework.security.web.savedrequest.HttpSessionRequestCache;
+
+              @Configuration
+              @EnableWebSecurity
+              public class SecurityConfig {
+
+                  @Bean
+                  public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+                      HttpSessionRequestCache requestCache = new HttpSessionRequestCache();
+
+                      http.authorizeHttpRequests(authorize -> authorize
+                              .requestMatchers("/public", "/public/*").permitAll()
+                              .requestMatchers("/login").permitAll()
+                              .anyRequest().authenticated())
+                          .oauth2Login(oauth2 -> oauth2
+                              .failureHandler(new SimpleUrlAuthenticationFailureHandler("/auth-error")))
+                          .requestCache((cache) -> cache
+                              .requestCache(requestCache));
+
+                      return http.build();
+                  }
+              }
+              """,
+            """
+              import org.springframework.context.annotation.Bean;
+              import org.springframework.context.annotation.Configuration;
+              import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+              import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+              import org.springframework.security.web.SecurityFilterChain;
+              import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
+              import org.springframework.security.web.savedrequest.HttpSessionRequestCache;
+                  
+              @Configuration
+              @EnableWebSecurity
+              public class SecurityConfig {
+
+                  @Bean
+                  public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+                      HttpSessionRequestCache requestCache = new HttpSessionRequestCache();
+                      requestCache.setMatchingRequestParameterName("continue");
+    
+                      http.authorizeHttpRequests(authorize -> authorize
+                              .requestMatchers("/public", "/public/*").permitAll()
+                              .requestMatchers("/login").permitAll()
+                              .anyRequest().authenticated())
+                          .oauth2Login(oauth2 -> oauth2
+                              .failureHandler(new SimpleUrlAuthenticationFailureHandler("/auth-error")))
+                          .requestCache((cache) -> cache
+                              .requestCache(requestCache));
+    
+                      return http.build();
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void NoChangeIfContinueParameterHasBeenSet() {
+        rewriteRun(
+          java(
+            """
+              import org.springframework.context.annotation.Bean;
+              import org.springframework.context.annotation.Configuration;
+              import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+              import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+              import org.springframework.security.web.SecurityFilterChain;
+              import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
+              import org.springframework.security.web.savedrequest.HttpSessionRequestCache;
+
+              @Configuration
+              @EnableWebSecurity
+              public class SecurityConfig {
+
+                  @Bean
+                  public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+                      HttpSessionRequestCache requestCache = new HttpSessionRequestCache();
+                      requestCache.setMatchingRequestParameterName("continue");
+
+                      http.authorizeHttpRequests(authorize -> authorize
+                              .requestMatchers("/public", "/public/*").permitAll()
+                              .requestMatchers("/login").permitAll()
+                              .anyRequest().authenticated())
+                          .oauth2Login(oauth2 -> oauth2
+                              .failureHandler(new SimpleUrlAuthenticationFailureHandler("/auth-error")))
+                          .requestCache((cache) -> cache
+                                  .requestCache(requestCache));
+
+                      return http.build();
+                  }
+              }
+              """)
+        );
+    }
+
+    @Test
+    void HttpSessionRequestCacheConstructorAsParameter() {
+        rewriteRun(
+          java(
+            """
+              import org.springframework.context.annotation.Bean;
+              import org.springframework.context.annotation.Configuration;
+              import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+              import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+              import org.springframework.security.web.SecurityFilterChain;
+              import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
+              import org.springframework.security.web.savedrequest.HttpSessionRequestCache;
+
+              @Configuration
+              @EnableWebSecurity
+              public class SecurityConfig {
+
+                  @Bean
+                  public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+                    http.authorizeHttpRequests(authorize -> authorize
+                            .requestMatchers("/public", "/public/*").permitAll()
+                            .requestMatchers("/login").permitAll()
+                            .anyRequest().authenticated())
+                        .oauth2Login(oauth2 -> oauth2
+                            .failureHandler(new SimpleUrlAuthenticationFailureHandler("/auth-error")))
+                        .requestCache((cache) -> cache
+                            .requestCache(new HttpSessionRequestCache()));
+                          
+                    return http.build();
+                  }
+              }
+              """,
+            """
+              import org.springframework.context.annotation.Bean;
+              import org.springframework.context.annotation.Configuration;
+              import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+              import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+              import org.springframework.security.web.SecurityFilterChain;
+              import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
+              import org.springframework.security.web.savedrequest.NullRequestCache;
+
+              @Configuration
+              @EnableWebSecurity
+              public class SecurityConfig {
+
+                  @Bean
+                  public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+                    http.authorizeHttpRequests(authorize -> authorize
+                            .requestMatchers("/public", "/public/*").permitAll()
+                            .requestMatchers("/login").permitAll()
+                            .anyRequest().authenticated())
+                        .oauth2Login(oauth2 -> oauth2
+                            .failureHandler(new SimpleUrlAuthenticationFailureHandler("/auth-error")))
+                        .requestCache((cache) -> cache
+                            .requestCache(new NullRequestCache()));
+                          
+                    return http.build();
+                  }
+              }
+              """
+          )
+        );
+    }
+}

--- a/src/testWithSpringSecurity_5_8/java/org/openrewrite/spring/security5/UpdateRequestCacheTest.java
+++ b/src/testWithSpringSecurity_5_8/java/org/openrewrite/spring/security5/UpdateRequestCacheTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openrewrite.spring.security5;
 
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
This recipe is part of  [Spring Security 6.0 migration ](https://github.com/openrewrite/rewrite-spring/issues/256) to [Optimize Querying of RequestCache](https://docs.spring.io/spring-security/reference/6.0.0/migration/servlet/session-management.html#requestcache-query-optimization)

By default, Spring Security 5 queries the saved request on every request, which means that in a typical setup, the HttpSession is queried on every request to use the RequestCache. In Spring Security 6, the default behavior has changed, and RequestCache will only be queried for a cached request if the HTTP parameter `continue` is defined. This helps Spring Security avoid unnecessary HttpSession queries with the RequestCache. To maintain the same default behavior as Spring Security 5, either explicitly add the HTTP parameter `continue` to every request or use NullRequestCache to override the default behavior.
