### PR TITLE
[Spring Security6 migration]Add recipe `RemoveOauth2LoginConfig`

### DIFF
--- a/src/main/java/org/openrewrite/java/spring/security6/RemoveOauth2LoginConfig.java
+++ b/src/main/java/org/openrewrite/java/spring/security6/RemoveOauth2LoginConfig.java
@@ -110,7 +110,7 @@ public class RemoveOauth2LoginConfig extends Recipe {
                         return method.getSelect().withPrefix(method.getPrefix());
                     }
                 }
-                return super.visitMethodInvocation(method, executionContext);
+                return method;
             }
         };
     }

--- a/src/main/java/org/openrewrite/java/spring/security6/RemoveOauth2LoginConfig.java
+++ b/src/main/java/org/openrewrite/java/spring/security6/RemoveOauth2LoginConfig.java
@@ -1,0 +1,77 @@
+package org.openrewrite.java.spring.security6;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.MethodMatcher;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.Statement;
+
+import java.time.Duration;
+import java.util.List;
+
+public class RemoveOauth2LoginConfig extends Recipe {
+    private static final MethodMatcher USER_AUTHORITIES_MAPPER_MATCHER = new MethodMatcher(
+        "org.springframework.security.config.annotation.web.configurers.oauth2.client.OAuth2LoginConfigurer userAuthoritiesMapper(org.springframework.security.core.authority.mapping.GrantedAuthoritiesMapper)"
+    );
+
+
+    @Override
+    public String getDisplayName() {
+        return "Remove unneeded `oauth2Login` config when upgrading to Spring Security 6";
+    }
+
+    @Override
+    public String getDescription() {
+        return "oauth2Login() is a Spring Security feature that allows users to authenticate with an OAuth2 or OpenID" +
+               " Connect 1.0 provider. When a user is authenticated using this feature, they are granted a set of " +
+               "authorities that determines what actions they are allowed to perform within the application.\n" +
+               "\n" +
+               "In Spring Security 5, the default authority given to a user authenticated with an OAuth2 or OpenID " +
+               "Connect 1.0 provider via oauth2Login() is ROLE_USER. This means that the user is allowed to access " +
+               "the application's resources as a regular user.\n" +
+               "\n" +
+               "However, in Spring Security 6, the default authority given to a user authenticated with an OAuth2 " +
+               "provider is OAUTH2_USER, and the default authority given to a user authenticated with an OpenID " +
+               "Connect 1.0 provider is OIDC_USER. These authorities are more specific and allow for better " +
+               "customization of the user's permissions within the application.\n" +
+               "\n" +
+               "If you are upgrading to Spring Security 6 and you have previously configured a " +
+               "GrantedAuthoritiesMapper to handle the authorities of users authenticated via oauth2Login(), you can " +
+               "remove it completely as the new default authorities should be sufficient.";
+    }
+
+    @Override
+    public @Nullable Duration getEstimatedEffortPerOccurrence() {
+        return Duration.ofMinutes(8);
+    }
+
+    @Override
+    protected TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new JavaIsoVisitor<ExecutionContext>() {
+
+            @Override
+            public J.Block visitBlock(J.Block block, ExecutionContext executionContext) {
+                block = super.visitBlock(block, executionContext);
+
+
+                List<Statement> statements = block.getStatements();
+
+
+                return block;
+            }
+
+            @Override
+            public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method,
+                                                            ExecutionContext executionContext) {
+
+                if (USER_AUTHORITIES_MAPPER_MATCHER.matches(method)) {
+                    return method;
+                }
+                return method;
+            }
+        };
+    }
+}

--- a/src/main/java/org/openrewrite/java/spring/security6/RemoveOauth2LoginConfig.java
+++ b/src/main/java/org/openrewrite/java/spring/security6/RemoveOauth2LoginConfig.java
@@ -92,17 +92,22 @@ public class RemoveOauth2LoginConfig extends Recipe {
 
                             if (m.getSelect() instanceof J.Identifier) {
                                 // remove this statement
-                                // todo, maybe add a method `listUtils.remove(int index)`
-                                statements.remove(i);
+                                int indexToRemove = i;
+                                statements = ListUtils.map(statements, (index, s) -> {
+                                    if (index == indexToRemove) {
+                                        return null;
+                                    }
+                                    return s;
+                                });
                                 return block.withStatements(statements);
                             } else if (m.getSelect() instanceof J.MethodInvocation) {
                                 // update the statement
                                 int indexToUpdate = i;
                                 statements = ListUtils.map(statements, (index, s) -> {
-                                    if (index != indexToUpdate) {
-                                        return s;
+                                    if (index == indexToUpdate) {
+                                        return m.getSelect().withPrefix(m.getPrefix());
                                     }
-                                    return m.getSelect().withPrefix(m.getPrefix());
+                                    return s;
                                 });
                                 return block.withStatements(statements);
                             }

--- a/src/main/java/org/openrewrite/java/spring/security6/RemoveOauth2LoginConfig.java
+++ b/src/main/java/org/openrewrite/java/spring/security6/RemoveOauth2LoginConfig.java
@@ -50,21 +50,22 @@ public class RemoveOauth2LoginConfig extends Recipe {
 
     @Override
     public String getDescription() {
+        //language=markdown
         return "oauth2Login() is a Spring Security feature that allows users to authenticate with an OAuth2 or OpenID" +
                " Connect 1.0 provider. When a user is authenticated using this feature, they are granted a set of " +
                "authorities that determines what actions they are allowed to perform within the application.\n" +
                "\n" +
                "In Spring Security 5, the default authority given to a user authenticated with an OAuth2 or OpenID " +
-               "Connect 1.0 provider via oauth2Login() is ROLE_USER. This means that the user is allowed to access " +
+               "Connect 1.0 provider via `oauth2Login()` is `ROLE_USER`. This means that the user is allowed to access " +
                "the application's resources as a regular user.\n" +
                "\n" +
                "However, in Spring Security 6, the default authority given to a user authenticated with an OAuth2 " +
-               "provider is OAUTH2_USER, and the default authority given to a user authenticated with an OpenID " +
-               "Connect 1.0 provider is OIDC_USER. These authorities are more specific and allow for better " +
+               "provider is `OAUTH2_USER`, and the default authority given to a user authenticated with an OpenID " +
+               "Connect 1.0 provider is `OIDC_USER`. These authorities are more specific and allow for better " +
                "customization of the user's permissions within the application.\n" +
                "\n" +
                "If you are upgrading to Spring Security 6 and you have previously configured a " +
-               "GrantedAuthoritiesMapper to handle the authorities of users authenticated via oauth2Login(), you can " +
+               "`GrantedAuthoritiesMapper` to handle the authorities of users authenticated via `oauth2Login()`, you can " +
                "remove it completely as the new default authorities should be sufficient.";
     }
 

--- a/src/main/java/org/openrewrite/java/spring/security6/RemoveOauth2LoginConfig.java
+++ b/src/main/java/org/openrewrite/java/spring/security6/RemoveOauth2LoginConfig.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openrewrite.java.spring.security6;
 
 import org.openrewrite.ExecutionContext;

--- a/src/testWithSpringSecurity_5_8/java/org/openrewrite/spring/security5/RemoveOauth2LoginConfigTest.java
+++ b/src/testWithSpringSecurity_5_8/java/org/openrewrite/spring/security5/RemoveOauth2LoginConfigTest.java
@@ -21,12 +21,14 @@ public class RemoveOauth2LoginConfigTest implements RewriteTest {
     @Test
     void removeUnneededConfigFromACallChain() {
         rewriteRun(
+          spec -> spec.cycles(3).expectedCyclesThatMakeChanges(3),
           java(
             """
               import org.springframework.context.annotation.Bean;
               import org.springframework.context.annotation.Configuration;
               import org.springframework.security.config.annotation.web.builders.HttpSecurity;
               import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+              import org.springframework.security.config.annotation.web.configurers.oauth2.client.OAuth2LoginConfigurer;
               import org.springframework.security.core.GrantedAuthority;
               import org.springframework.security.core.authority.SimpleGrantedAuthority;
               import org.springframework.security.core.authority.mapping.GrantedAuthoritiesMapper;
@@ -46,16 +48,8 @@ public class RemoveOauth2LoginConfigTest implements RewriteTest {
                               .anyRequest().authenticated())
                           .oauth2Login()
                           .userInfoEndpoint()
-                              .userAuthoritiesMapper(userAuthoritiesMapper());
+                              .userAuthoritiesMapper(null);
                       return http.build();
-                  }
-
-                  private GrantedAuthoritiesMapper userAuthoritiesMapper() {
-                      return (authorities) -> {
-                          Set<GrantedAuthority> mappedAuthorities = new HashSet<>();
-                          mappedAuthorities.add(new SimpleGrantedAuthority("ROLE_CUSTOM"));
-                          return mappedAuthorities;
-                      };
                   }
               }
               """,
@@ -64,6 +58,7 @@ public class RemoveOauth2LoginConfigTest implements RewriteTest {
               import org.springframework.context.annotation.Configuration;
               import org.springframework.security.config.annotation.web.builders.HttpSecurity;
               import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+              import org.springframework.security.config.annotation.web.configurers.oauth2.client.OAuth2LoginConfigurer;
               import org.springframework.security.core.GrantedAuthority;
               import org.springframework.security.core.authority.SimpleGrantedAuthority;
               import org.springframework.security.core.authority.mapping.GrantedAuthoritiesMapper;
@@ -76,20 +71,12 @@ public class RemoveOauth2LoginConfigTest implements RewriteTest {
               @EnableWebSecurity
               public class SecurityConfig {
                   @Bean
-                  public SecurityFilterChain filterChain_after(HttpSecurity http) throws Exception {
+                  public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
                       http.authorizeHttpRequests(authorize -> authorize
                               .requestMatchers("/public", "/public/*").permitAll()
                               .requestMatchers("/login").permitAll()
                               .anyRequest().authenticated());
                       return http.build();
-                  }
-
-                  private GrantedAuthoritiesMapper userAuthoritiesMapper() {
-                      return (authorities) -> {
-                          Set<GrantedAuthority> mappedAuthorities = new HashSet<>();
-                          mappedAuthorities.add(new SimpleGrantedAuthority("ROLE_CUSTOM"));
-                          return mappedAuthorities;
-                      };
                   }
               }
               """
@@ -100,6 +87,7 @@ public class RemoveOauth2LoginConfigTest implements RewriteTest {
     @Test
     void removeUserInfoEndpointStatement() {
         rewriteRun(
+          spec -> spec.cycles(2).expectedCyclesThatMakeChanges(2),
           java(
             """
               import org.springframework.context.annotation.Bean;
@@ -122,16 +110,8 @@ public class RemoveOauth2LoginConfigTest implements RewriteTest {
                   public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
                       OAuth2LoginConfigurer<HttpSecurity> auth2 = http.oauth2Login();
                       auth2.userInfoEndpoint()
-                          .userAuthoritiesMapper(userAuthoritiesMapper());
+                          .userAuthoritiesMapper(null);
                       return http.build();
-                  }
-
-                  private GrantedAuthoritiesMapper userAuthoritiesMapper() {
-                      return (authorities) -> {
-                          Set<GrantedAuthority> mappedAuthorities = new HashSet<>();
-                          mappedAuthorities.add(new SimpleGrantedAuthority("ROLE_CUSTOM"));
-                          return mappedAuthorities;
-                      };
                   }
               }
               """,
@@ -157,14 +137,6 @@ public class RemoveOauth2LoginConfigTest implements RewriteTest {
                   public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
                       OAuth2LoginConfigurer<HttpSecurity> auth2 = http.oauth2Login();
                       return http.build();
-                  }
-
-                  private GrantedAuthoritiesMapper userAuthoritiesMapper() {
-                      return (authorities) -> {
-                          Set<GrantedAuthority> mappedAuthorities = new HashSet<>();
-                          mappedAuthorities.add(new SimpleGrantedAuthority("ROLE_CUSTOM"));
-                          return mappedAuthorities;
-                      };
                   }
               }
               """
@@ -201,16 +173,8 @@ public class RemoveOauth2LoginConfigTest implements RewriteTest {
                               .anyRequest().authenticated())
                           .oauth2Login()
                           .userInfoEndpoint();
-                      x.userAuthoritiesMapper(userAuthoritiesMapper());
+                      x.userAuthoritiesMapper(null);
                       return http.build();
-                  }
-
-                  private GrantedAuthoritiesMapper userAuthoritiesMapper() {
-                      return (authorities) -> {
-                          Set<GrantedAuthority> mappedAuthorities = new HashSet<>();
-                          mappedAuthorities.add(new SimpleGrantedAuthority("ROLE_CUSTOM"));
-                          return mappedAuthorities;
-                      };
                   }
               }
               """,
@@ -240,14 +204,6 @@ public class RemoveOauth2LoginConfigTest implements RewriteTest {
                           .oauth2Login()
                           .userInfoEndpoint();
                       return http.build();
-                  }
-
-                  private GrantedAuthoritiesMapper userAuthoritiesMapper() {
-                      return (authorities) -> {
-                          Set<GrantedAuthority> mappedAuthorities = new HashSet<>();
-                          mappedAuthorities.add(new SimpleGrantedAuthority("ROLE_CUSTOM"));
-                          return mappedAuthorities;
-                      };
                   }
               }
               """

--- a/src/testWithSpringSecurity_5_8/java/org/openrewrite/spring/security5/RemoveOauth2LoginConfigTest.java
+++ b/src/testWithSpringSecurity_5_8/java/org/openrewrite/spring/security5/RemoveOauth2LoginConfigTest.java
@@ -36,7 +36,7 @@ public class RemoveOauth2LoginConfigTest implements RewriteTest {
     @Test
     void removeUnneededConfigFromACallChain() {
         rewriteRun(
-          spec -> spec.cycles(3).expectedCyclesThatMakeChanges(3),
+          spec -> spec.expectedCyclesThatMakeChanges(2),
           java(
             """
               import org.springframework.context.annotation.Bean;
@@ -102,7 +102,7 @@ public class RemoveOauth2LoginConfigTest implements RewriteTest {
     @Test
     void removeUserInfoEndpointStatement() {
         rewriteRun(
-          spec -> spec.cycles(2).expectedCyclesThatMakeChanges(2),
+          // spec -> spec.cycles(2).expectedCyclesThatMakeChanges(2),
           java(
             """
               import org.springframework.context.annotation.Bean;
@@ -126,6 +126,7 @@ public class RemoveOauth2LoginConfigTest implements RewriteTest {
                       OAuth2LoginConfigurer<HttpSecurity> auth2 = http.oauth2Login();
                       auth2.userInfoEndpoint()
                           .userAuthoritiesMapper(null);
+                      auth2.init(null);
                       return http.build();
                   }
               }
@@ -151,6 +152,7 @@ public class RemoveOauth2LoginConfigTest implements RewriteTest {
                   @Bean
                   public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
                       OAuth2LoginConfigurer<HttpSecurity> auth2 = http.oauth2Login();
+                      auth2.init(null);
                       return http.build();
                   }
               }
@@ -219,6 +221,24 @@ public class RemoveOauth2LoginConfigTest implements RewriteTest {
                           .oauth2Login()
                           .userInfoEndpoint();
                       return http.build();
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void noChangeForReturn() {
+        rewriteRun(
+          java(
+            """
+              import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+              import org.springframework.security.config.annotation.web.configurers.oauth2.client.OAuth2LoginConfigurer;
+
+              public class config2 {
+                  OAuth2LoginConfigurer<HttpSecurity> get(HttpSecurity http) throws Exception {
+                      return http.oauth2Login();
                   }
               }
               """

--- a/src/testWithSpringSecurity_5_8/java/org/openrewrite/spring/security5/RemoveOauth2LoginConfigTest.java
+++ b/src/testWithSpringSecurity_5_8/java/org/openrewrite/spring/security5/RemoveOauth2LoginConfigTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openrewrite.spring.security5;
 
 import org.junit.jupiter.api.Test;

--- a/src/testWithSpringSecurity_5_8/java/org/openrewrite/spring/security5/RemoveOauth2LoginConfigTest.java
+++ b/src/testWithSpringSecurity_5_8/java/org/openrewrite/spring/security5/RemoveOauth2LoginConfigTest.java
@@ -1,0 +1,257 @@
+package org.openrewrite.spring.security5;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.InMemoryExecutionContext;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.java.spring.security6.RemoveOauth2LoginConfig;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+public class RemoveOauth2LoginConfigTest implements RewriteTest {
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(new RemoveOauth2LoginConfig())
+          .parser(JavaParser.fromJavaVersion()
+            .logCompilationWarningsAndErrors(true)
+            .classpathFromResources(new InMemoryExecutionContext(),"spring-context-5.3.+", "spring-beans-5.3.+", "spring-web-5.3.+", "spring-security-web-5.8.+", "spring-security-config-5.8.+"));
+    }
+
+    @Test
+    void removeUnneededConfigFromACallChain() {
+        rewriteRun(
+          java(
+            """
+              import org.springframework.context.annotation.Bean;
+              import org.springframework.context.annotation.Configuration;
+              import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+              import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+              import org.springframework.security.core.GrantedAuthority;
+              import org.springframework.security.core.authority.SimpleGrantedAuthority;
+              import org.springframework.security.core.authority.mapping.GrantedAuthoritiesMapper;
+              import org.springframework.security.web.SecurityFilterChain;
+
+              import java.util.HashSet;
+              import java.util.Set;
+
+              @Configuration
+              @EnableWebSecurity
+              public class SecurityConfig {
+                  @Bean
+                  public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+                      http.authorizeHttpRequests(authorize -> authorize
+                              .requestMatchers("/public", "/public/*").permitAll()
+                              .requestMatchers("/login").permitAll()
+                              .anyRequest().authenticated())
+                          .oauth2Login()
+                          .userInfoEndpoint()
+                              .userAuthoritiesMapper(userAuthoritiesMapper());
+                      return http.build();
+                  }
+
+                  private GrantedAuthoritiesMapper userAuthoritiesMapper() {
+                      return (authorities) -> {
+                          Set<GrantedAuthority> mappedAuthorities = new HashSet<>();
+                          mappedAuthorities.add(new SimpleGrantedAuthority("ROLE_CUSTOM"));
+                          return mappedAuthorities;
+                      };
+                  }
+              }
+              """,
+            """
+              import org.springframework.context.annotation.Bean;
+              import org.springframework.context.annotation.Configuration;
+              import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+              import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+              import org.springframework.security.core.GrantedAuthority;
+              import org.springframework.security.core.authority.SimpleGrantedAuthority;
+              import org.springframework.security.core.authority.mapping.GrantedAuthoritiesMapper;
+              import org.springframework.security.web.SecurityFilterChain;
+
+              import java.util.HashSet;
+              import java.util.Set;
+
+              @Configuration
+              @EnableWebSecurity
+              public class SecurityConfig {
+                  @Bean
+                  public SecurityFilterChain filterChain_after(HttpSecurity http) throws Exception {
+                      http.authorizeHttpRequests(authorize -> authorize
+                              .requestMatchers("/public", "/public/*").permitAll()
+                              .requestMatchers("/login").permitAll()
+                              .anyRequest().authenticated());
+                      return http.build();
+                  }
+
+                  private GrantedAuthoritiesMapper userAuthoritiesMapper() {
+                      return (authorities) -> {
+                          Set<GrantedAuthority> mappedAuthorities = new HashSet<>();
+                          mappedAuthorities.add(new SimpleGrantedAuthority("ROLE_CUSTOM"));
+                          return mappedAuthorities;
+                      };
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void removeUserInfoEndpointStatement() {
+        rewriteRun(
+          java(
+            """
+              import org.springframework.context.annotation.Bean;
+              import org.springframework.context.annotation.Configuration;
+              import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+              import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+              import org.springframework.security.config.annotation.web.configurers.oauth2.client.OAuth2LoginConfigurer;
+              import org.springframework.security.core.GrantedAuthority;
+              import org.springframework.security.core.authority.SimpleGrantedAuthority;
+              import org.springframework.security.core.authority.mapping.GrantedAuthoritiesMapper;
+              import org.springframework.security.web.SecurityFilterChain;
+
+              import java.util.HashSet;
+              import java.util.Set;
+
+              @Configuration
+              @EnableWebSecurity
+              public class SecurityConfig {
+                  @Bean
+                  public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+                      OAuth2LoginConfigurer<HttpSecurity> auth2 = http.oauth2Login();
+                      auth2.userInfoEndpoint()
+                          .userAuthoritiesMapper(userAuthoritiesMapper());
+                      return http.build();
+                  }
+
+                  private GrantedAuthoritiesMapper userAuthoritiesMapper() {
+                      return (authorities) -> {
+                          Set<GrantedAuthority> mappedAuthorities = new HashSet<>();
+                          mappedAuthorities.add(new SimpleGrantedAuthority("ROLE_CUSTOM"));
+                          return mappedAuthorities;
+                      };
+                  }
+              }
+              """,
+            """
+
+              import org.springframework.context.annotation.Bean;
+              import org.springframework.context.annotation.Configuration;
+              import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+              import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+              import org.springframework.security.config.annotation.web.configurers.oauth2.client.OAuth2LoginConfigurer;
+              import org.springframework.security.core.GrantedAuthority;
+              import org.springframework.security.core.authority.SimpleGrantedAuthority;
+              import org.springframework.security.core.authority.mapping.GrantedAuthoritiesMapper;
+              import org.springframework.security.web.SecurityFilterChain;
+
+              import java.util.HashSet;
+              import java.util.Set;
+
+              @Configuration
+              @EnableWebSecurity
+              public class SecurityConfig {
+                  @Bean
+                  public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+                      OAuth2LoginConfigurer<HttpSecurity> auth2 = http.oauth2Login();
+                      return http.build();
+                  }
+
+                  private GrantedAuthoritiesMapper userAuthoritiesMapper() {
+                      return (authorities) -> {
+                          Set<GrantedAuthority> mappedAuthorities = new HashSet<>();
+                          mappedAuthorities.add(new SimpleGrantedAuthority("ROLE_CUSTOM"));
+                          return mappedAuthorities;
+                      };
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void removeUserAuthoritiesMapperStatement() {
+        rewriteRun(
+          java(
+            """
+              import org.springframework.context.annotation.Bean;
+              import org.springframework.context.annotation.Configuration;
+              import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+              import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+              import org.springframework.security.config.annotation.web.configurers.oauth2.client.OAuth2LoginConfigurer;
+              import org.springframework.security.core.GrantedAuthority;
+              import org.springframework.security.core.authority.SimpleGrantedAuthority;
+              import org.springframework.security.core.authority.mapping.GrantedAuthoritiesMapper;
+              import org.springframework.security.web.SecurityFilterChain;
+
+              import java.util.HashSet;
+              import java.util.Set;
+
+              @Configuration
+              @EnableWebSecurity
+              public class SecurityConfig {
+                  @Bean
+                  public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+                      OAuth2LoginConfigurer<HttpSecurity>.UserInfoEndpointConfig x = http.authorizeHttpRequests(authorize -> authorize
+                              .requestMatchers("/public", "/public/*").permitAll()
+                              .requestMatchers("/login").permitAll()
+                              .anyRequest().authenticated())
+                          .oauth2Login()
+                          .userInfoEndpoint();
+                      x.userAuthoritiesMapper(userAuthoritiesMapper());
+                      return http.build();
+                  }
+
+                  private GrantedAuthoritiesMapper userAuthoritiesMapper() {
+                      return (authorities) -> {
+                          Set<GrantedAuthority> mappedAuthorities = new HashSet<>();
+                          mappedAuthorities.add(new SimpleGrantedAuthority("ROLE_CUSTOM"));
+                          return mappedAuthorities;
+                      };
+                  }
+              }
+              """,
+            """
+              import org.springframework.context.annotation.Bean;
+              import org.springframework.context.annotation.Configuration;
+              import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+              import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+              import org.springframework.security.config.annotation.web.configurers.oauth2.client.OAuth2LoginConfigurer;
+              import org.springframework.security.core.GrantedAuthority;
+              import org.springframework.security.core.authority.SimpleGrantedAuthority;
+              import org.springframework.security.core.authority.mapping.GrantedAuthoritiesMapper;
+              import org.springframework.security.web.SecurityFilterChain;
+
+              import java.util.HashSet;
+              import java.util.Set;
+
+              @Configuration
+              @EnableWebSecurity
+              public class SecurityConfig {
+                  @Bean
+                  public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+                      OAuth2LoginConfigurer<HttpSecurity>.UserInfoEndpointConfig x = http.authorizeHttpRequests(authorize -> authorize
+                              .requestMatchers("/public", "/public/*").permitAll()
+                              .requestMatchers("/login").permitAll()
+                              .anyRequest().authenticated())
+                          .oauth2Login()
+                          .userInfoEndpoint();
+                      return http.build();
+                  }
+
+                  private GrantedAuthoritiesMapper userAuthoritiesMapper() {
+                      return (authorities) -> {
+                          Set<GrantedAuthority> mappedAuthorities = new HashSet<>();
+                          mappedAuthorities.add(new SimpleGrantedAuthority("ROLE_CUSTOM"));
+                          return mappedAuthorities;
+                      };
+                  }
+              }
+              """
+          )
+        );
+    }
+}

--- a/src/testWithSpringSecurity_5_8/java/org/openrewrite/spring/security5/RemoveOauth2LoginConfigTest.java
+++ b/src/testWithSpringSecurity_5_8/java/org/openrewrite/spring/security5/RemoveOauth2LoginConfigTest.java
@@ -34,7 +34,7 @@ public class RemoveOauth2LoginConfigTest implements RewriteTest {
     }
 
     @Test
-    void removeUnneededConfigFromACallChain() {
+    void removeUnneededConfigFromEndOfCallChain() {
         rewriteRun(
           spec -> spec.expectedCyclesThatMakeChanges(2),
           java(
@@ -43,10 +43,6 @@ public class RemoveOauth2LoginConfigTest implements RewriteTest {
               import org.springframework.context.annotation.Configuration;
               import org.springframework.security.config.annotation.web.builders.HttpSecurity;
               import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-              import org.springframework.security.config.annotation.web.configurers.oauth2.client.OAuth2LoginConfigurer;
-              import org.springframework.security.core.GrantedAuthority;
-              import org.springframework.security.core.authority.SimpleGrantedAuthority;
-              import org.springframework.security.core.authority.mapping.GrantedAuthoritiesMapper;
               import org.springframework.security.web.SecurityFilterChain;
 
               import java.util.HashSet;
@@ -73,10 +69,6 @@ public class RemoveOauth2LoginConfigTest implements RewriteTest {
               import org.springframework.context.annotation.Configuration;
               import org.springframework.security.config.annotation.web.builders.HttpSecurity;
               import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-              import org.springframework.security.config.annotation.web.configurers.oauth2.client.OAuth2LoginConfigurer;
-              import org.springframework.security.core.GrantedAuthority;
-              import org.springframework.security.core.authority.SimpleGrantedAuthority;
-              import org.springframework.security.core.authority.mapping.GrantedAuthoritiesMapper;
               import org.springframework.security.web.SecurityFilterChain;
 
               import java.util.HashSet;
@@ -100,6 +92,41 @@ public class RemoveOauth2LoginConfigTest implements RewriteTest {
     }
 
     @Test
+    void noChangeIfMethodsAreInTheMiddleOfChain() {
+        rewriteRun(
+          java(
+            """
+              import org.springframework.context.annotation.Bean;
+              import org.springframework.context.annotation.Configuration;
+              import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+              import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+              import org.springframework.security.web.SecurityFilterChain;
+
+              import java.util.HashSet;
+              import java.util.Set;
+
+              @Configuration
+              @EnableWebSecurity
+              public class SecurityConfig {
+                  @Bean
+                  public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+                      http.authorizeHttpRequests(authorize -> authorize
+                              .requestMatchers("/public", "/public/*").permitAll()
+                              .requestMatchers("/login").permitAll()
+                              .anyRequest().authenticated())
+                          .oauth2Login()
+                          .userInfoEndpoint()
+                              .userAuthoritiesMapper(null)
+                              .oidcUserService(null);
+                      return http.build();
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void removeUserInfoEndpointStatement() {
         rewriteRun(
           // spec -> spec.cycles(2).expectedCyclesThatMakeChanges(2),
@@ -110,13 +137,7 @@ public class RemoveOauth2LoginConfigTest implements RewriteTest {
               import org.springframework.security.config.annotation.web.builders.HttpSecurity;
               import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
               import org.springframework.security.config.annotation.web.configurers.oauth2.client.OAuth2LoginConfigurer;
-              import org.springframework.security.core.GrantedAuthority;
-              import org.springframework.security.core.authority.SimpleGrantedAuthority;
-              import org.springframework.security.core.authority.mapping.GrantedAuthoritiesMapper;
               import org.springframework.security.web.SecurityFilterChain;
-
-              import java.util.HashSet;
-              import java.util.Set;
 
               @Configuration
               @EnableWebSecurity
@@ -132,19 +153,12 @@ public class RemoveOauth2LoginConfigTest implements RewriteTest {
               }
               """,
             """
-
               import org.springframework.context.annotation.Bean;
               import org.springframework.context.annotation.Configuration;
               import org.springframework.security.config.annotation.web.builders.HttpSecurity;
               import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
               import org.springframework.security.config.annotation.web.configurers.oauth2.client.OAuth2LoginConfigurer;
-              import org.springframework.security.core.GrantedAuthority;
-              import org.springframework.security.core.authority.SimpleGrantedAuthority;
-              import org.springframework.security.core.authority.mapping.GrantedAuthoritiesMapper;
               import org.springframework.security.web.SecurityFilterChain;
-
-              import java.util.HashSet;
-              import java.util.Set;
 
               @Configuration
               @EnableWebSecurity
@@ -171,13 +185,7 @@ public class RemoveOauth2LoginConfigTest implements RewriteTest {
               import org.springframework.security.config.annotation.web.builders.HttpSecurity;
               import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
               import org.springframework.security.config.annotation.web.configurers.oauth2.client.OAuth2LoginConfigurer;
-              import org.springframework.security.core.GrantedAuthority;
-              import org.springframework.security.core.authority.SimpleGrantedAuthority;
-              import org.springframework.security.core.authority.mapping.GrantedAuthoritiesMapper;
               import org.springframework.security.web.SecurityFilterChain;
-
-              import java.util.HashSet;
-              import java.util.Set;
 
               @Configuration
               @EnableWebSecurity
@@ -201,13 +209,7 @@ public class RemoveOauth2LoginConfigTest implements RewriteTest {
               import org.springframework.security.config.annotation.web.builders.HttpSecurity;
               import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
               import org.springframework.security.config.annotation.web.configurers.oauth2.client.OAuth2LoginConfigurer;
-              import org.springframework.security.core.GrantedAuthority;
-              import org.springframework.security.core.authority.SimpleGrantedAuthority;
-              import org.springframework.security.core.authority.mapping.GrantedAuthoritiesMapper;
               import org.springframework.security.web.SecurityFilterChain;
-
-              import java.util.HashSet;
-              import java.util.Set;
 
               @Configuration
               @EnableWebSecurity


### PR DESCRIPTION
This recipe is part of the [Spring Security6 migration](https://github.com/openrewrite/rewrite-spring/issues/256) to implement to keep [Default authorities for oauth2Login()](https://docs.spring.io/spring-security/reference/6.0.0/migration/servlet/authentication.html#_default_authorities_for_oauth2login).


