### PR TITLE
[Spring security 6 migration] Adds `UpdateEnableReactiveMethodSecurity` recipe

### DIFF
--- a/src/main/java/org/openrewrite/java/spring/security6/RequireExplicitSavingOfSecurityContextRepository.java
+++ b/src/main/java/org/openrewrite/java/spring/security6/RequireExplicitSavingOfSecurityContextRepository.java
@@ -124,7 +124,7 @@ public class RequireExplicitSavingOfSecurityContextRepository extends Recipe {
         }
     }
 
-    private boolean isTrue(Expression expression) {
+    public static boolean isTrue(Expression expression) {
         if (expression instanceof J.Literal) {
             return expression.getType() == JavaType.Primitive.Boolean && Boolean.TRUE.equals(((J.Literal) expression).getValue());
         }

--- a/src/main/java/org/openrewrite/java/spring/security6/UpdateEnableReactiveMethodSecurity.java
+++ b/src/main/java/org/openrewrite/java/spring/security6/UpdateEnableReactiveMethodSecurity.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.spring.security6;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.internal.ListUtils;
+import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.java.AnnotationMatcher;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.search.UsesType;
+import org.openrewrite.java.tree.Expression;
+import org.openrewrite.java.tree.J;
+
+import java.time.Duration;
+import java.util.List;
+
+public class UpdateEnableReactiveMethodSecurity extends Recipe {
+
+    private static final AnnotationMatcher ENABLE_REACTIVE_METHOD_SECURITY_MATCHER =
+        new AnnotationMatcher("@org.springframework.security.config.annotation.method.configuration.EnableReactiveMethodSecurity");
+
+    @Override
+    public String getDisplayName() {
+        return "Remove the `useAuthorizationManager=true` attribute from `@EnableReactiveMethodSecurity`";
+    }
+
+    @Override
+    public String getDescription() {
+        return "In Spring security 6.0, `@EnableReactiveMethodSecurity` defaults `useAuthorizationManager` to true. " +
+               "So, to complete migration, `@EnableReactiveMethodSecurity` remove the `useAuthorizationManager` attribute.";
+    }
+
+    @Override
+    public @Nullable Duration getEstimatedEffortPerOccurrence() {
+        return Duration.ofMinutes(2);
+    }
+
+    @Override
+    protected @Nullable TreeVisitor<?, ExecutionContext> getSingleSourceApplicableTest() {
+        return new UsesType<>(
+            "org.springframework.security.config.annotation.method.configuration.EnableReactiveMethodSecurity", false);
+    }
+
+    @Override
+    protected TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new JavaIsoVisitor<ExecutionContext>() {
+            @Override
+            public J.Annotation visitAnnotation(J.Annotation annotation, ExecutionContext ctx) {
+                annotation = super.visitAnnotation(annotation, ctx);
+                if (ENABLE_REACTIVE_METHOD_SECURITY_MATCHER.matches(annotation) &&
+                    annotation.getArguments() != null &&
+                    !annotation.getArguments().isEmpty()) {
+                    List<Expression> args = annotation.getArguments();
+                    args = ListUtils.map(args, arg -> isUseAuthorizationManagerArgSetToTrue(arg) ? null : arg);
+                    return autoFormat(annotation.withArguments(args), ctx);
+                }
+                return annotation;
+            }
+        };
+    }
+
+    private static boolean isUseAuthorizationManagerArgSetToTrue(Expression arg) {
+        if (arg instanceof J.Assignment) {
+            J.Assignment assignment = (J.Assignment) arg;
+            return assignment.getVariable().toString().equals("useAuthorizationManager") &&
+                   RequireExplicitSavingOfSecurityContextRepository.isTrue(assignment.getAssignment());
+        }
+        return false;
+    }
+}

--- a/src/main/resources/META-INF/rewrite/spring-security-60.yml
+++ b/src/main/resources/META-INF/rewrite/spring-security-60.yml
@@ -36,6 +36,7 @@ recipeList:
   - org.openrewrite.java.spring.security6.RemoveOauth2LoginConfig
   - org.openrewrite.java.spring.security6.UpdateRequestCache
   - org.openrewrite.java.spring.security6.RemoveUseAuthorizationManager
+  - org.openrewrite.java.spring.security6.UpdateEnableReactiveMethodSecurity
 ---
 ########################################################################################################################
 type: specs.openrewrite.org/v1beta/recipe

--- a/src/testWithSpringSecurity_5_8/java/org/openrewrite/spring/security5/UpdateEnableReactiveMethodSecurityTest.java
+++ b/src/testWithSpringSecurity_5_8/java/org/openrewrite/spring/security5/UpdateEnableReactiveMethodSecurityTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.spring.security5;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.InMemoryExecutionContext;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.java.spring.security6.UpdateEnableReactiveMethodSecurity;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+public class UpdateEnableReactiveMethodSecurityTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(new UpdateEnableReactiveMethodSecurity())
+          .parser(JavaParser.fromJavaVersion()
+            .logCompilationWarningsAndErrors(true)
+            .classpathFromResources(new InMemoryExecutionContext(), "spring-security-web-5.8.+",
+              "spring-security-config-5.8.+"));
+    }
+
+    @Test
+    void removeUseAuthorizationManager() {
+        rewriteRun(
+          java(
+            """
+              import org.springframework.security.config.annotation.method.configuration.EnableReactiveMethodSecurity;
+
+              @EnableReactiveMethodSecurity(useAuthorizationManager = true)
+              class SecurityConfig {
+              }
+              """,
+            """
+              import org.springframework.security.config.annotation.method.configuration.EnableReactiveMethodSecurity;
+
+              @EnableReactiveMethodSecurity
+              class SecurityConfig {
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void doNotRemoveIfUseAuthorizationManagerIsFalse() {
+        rewriteRun(
+          java(
+            """
+              import org.springframework.security.config.annotation.method.configuration.EnableReactiveMethodSecurity;
+
+              @EnableReactiveMethodSecurity(useAuthorizationManager = false)
+              class SecurityConfig {
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void multipleAttributes() {
+        rewriteRun(
+          java(
+            """
+              import org.springframework.security.config.annotation.method.configuration.EnableReactiveMethodSecurity;
+
+              @EnableReactiveMethodSecurity(useAuthorizationManager = true, order = 1)
+              class SecurityConfig {
+              }
+              """,
+              """
+              import org.springframework.security.config.annotation.method.configuration.EnableReactiveMethodSecurity;
+
+              @EnableReactiveMethodSecurity(order = 1)
+              class SecurityConfig {
+              }
+              """)
+        );
+    }
+}


### PR DESCRIPTION
This recipe is part of the [Spring Security 6.0 migration ](https://github.com/openrewrite/rewrite-spring/issues/256).
In Spring Security 6.0, `@EnableReactiveMethodSecurity` defaults `useAuthorizationManager` to true. So, to complete migration, `@EnableReactiveMethodSecurity` remove the `useAuthorizationManager` attribute. 

Reference : [here](https://docs.spring.io/spring-security/reference/6.0.0/migration/reactive.html)
Before
```java
@EnableReactiveMethodSecurity(useAuthorizationManager = true)
```
After
```java
@EnableReactiveMethodSecurity
```