### PR TITLE
UpgradeSpringSecurity_5_8 is Spring Security's rule.

### DIFF
--- a/src/main/resources/META-INF/rewrite/spring-security-58.yml
+++ b/src/main/resources/META-INF/rewrite/spring-security-58.yml
@@ -16,7 +16,7 @@
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.spring.security5.UpgradeSpringSecurity_5_8
-displayName: Migrate to Spring Framework 5.8
+displayName: Migrate to Spring Security 5.8
 description: >
   Migrate applications to the latest Spring Security 5.8 release. This recipe will modify an
   application's build files, make changes to deprecated/preferred APIs, and migrate configuration settings that have


### PR DESCRIPTION
It's not a Spring Framework 5.8's.