### PR TITLE
Revert "Add Spring Security 5.8 migration to Spring Framework 5.3 and…

### DIFF
--- a/src/main/resources/META-INF/rewrite/spring-boot-27.yml
+++ b/src/main/resources/META-INF/rewrite/spring-boot-27.yml
@@ -23,7 +23,6 @@ displayName: Migrate to Spring Boot 2.7
 description: 'Upgrade to Spring Boot 2.7'
 recipeList:
   - org.openrewrite.java.spring.boot2.UpgradeSpringBoot_2_6
-  - org.openrewrite.java.spring.security5.UpgradeSpringSecurity_5_8
   - org.openrewrite.maven.UpgradeDependencyVersion:
       groupId: org.springframework.boot
       artifactId: "*"

--- a/src/main/resources/META-INF/rewrite/spring-framework-53.yml
+++ b/src/main/resources/META-INF/rewrite/spring-framework-53.yml
@@ -25,7 +25,6 @@ recipeList:
   - org.openrewrite.java.spring.framework.UpgradeSpringFramework_5_2
   - org.openrewrite.java.spring.framework.UpgradeSpringFrameworkDependencies:
       newVersion: 5.3.x
-  - org.openrewrite.java.spring.security5.UpgradeSpringSecurity_5_8
   - org.openrewrite.java.spring.framework.UseObjectUtilsIsEmpty
   - org.openrewrite.java.spring.framework.MigrateInstantiationAwareBeanPostProcessorAdapter
   - org.openrewrite.java.spring.framework.JdbcTemplateObjectArrayArgToVarArgs

--- a/src/main/resources/META-INF/rewrite/spring-security-60.yml
+++ b/src/main/resources/META-INF/rewrite/spring-security-60.yml
@@ -25,6 +25,7 @@ tags:
   - spring
   - security
 recipeList:
+  - org.openrewrite.java.spring.security5.UpgradeSpringSecurity_5_8
   - org.openrewrite.maven.UpgradeDependencyVersion:
       groupId: org.springframework.security
       artifactId: "*"


### PR DESCRIPTION
… Spring Boot 2.7"

This reverts commit 6f91bde39a3d48ee5cd8253468770935d47a6972.

Hey @knutwannheden -- let me know if you have some context behind this commit?
AFAIK, no release line of Spring Boot uses Spring Security 5.8; SB 2.7 is on SS 5.7, and SB 3.0 is on SS 6.0. So, I wouldn't expect the SS 5.8 migration to get called until SB 3.0 calls SS 6.0. SB 2.7 seems too early.

And, by having SS 5.8 in the SF 5.3 recipe, it actually gets called all the way back in the SB *2.4* recipe, which would normally be using SS 5.4. Way early.