### PR TITLE
ImplicitWebAnnotationNames - auto-format variable declaration when an argument is removed.

### DIFF
--- a/src/main/java/org/openrewrite/java/spring/ImplicitWebAnnotationNames.java
+++ b/src/main/java/org/openrewrite/java/spring/ImplicitWebAnnotationNames.java
@@ -77,6 +77,12 @@ public class ImplicitWebAnnotationNames extends Recipe {
         ).map(className -> "org.springframework.web.bind.annotation." + className).collect(toSet());
 
         @Override
+        public J.VariableDeclarations visitVariableDeclarations(J.VariableDeclarations multiVariable, ExecutionContext executionContext) {
+            J.VariableDeclarations varDecls = super.visitVariableDeclarations(multiVariable, executionContext);
+            return maybeAutoFormat(multiVariable, varDecls, executionContext);
+        }
+
+        @Override
         public J.Annotation visitAnnotation(J.Annotation annotation, ExecutionContext ctx) {
             J.Annotation a = super.visitAnnotation(annotation, ctx);
 

--- a/src/testWithSpringBoot_2_1/java/org/openrewrite/java/spring/ImplicitWebAnnotationNamesTest.java
+++ b/src/testWithSpringBoot_2_1/java/org/openrewrite/java/spring/ImplicitWebAnnotationNamesTest.java
@@ -85,7 +85,7 @@ class ImplicitWebAnnotationNamesTest implements RewriteTest {
               public class UsersController {
                   @GetMapping("/{id}")
                   public ResponseEntity<String> getUser(
-                      @RequestParam(name = "count", defaultValue = 3) int count) {
+                          @RequestParam(name = "count", defaultValue = 3) int count) {
                   }
               }
               """,
@@ -98,7 +98,41 @@ class ImplicitWebAnnotationNamesTest implements RewriteTest {
               public class UsersController {
                   @GetMapping("/{id}")
                   public ResponseEntity<String> getUser(
-                      @RequestParam(defaultValue = 3) int count) {
+                          @RequestParam(defaultValue = 3) int count) {
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite-spring/issues/340")
+    @Test
+    void autoFormatAfterRemovingArgument() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.springframework.http.ResponseEntity;
+              import org.springframework.web.bind.annotation.*;
+              
+              @RestController
+              @RequestMapping("/users")
+              public class UsersController {
+                  @GetMapping("/{id}")
+                  public ResponseEntity<String> getUser(@PathVariable("id")Long id) {
+                  }
+              }
+              """,
+            """
+              import org.springframework.http.ResponseEntity;
+              import org.springframework.web.bind.annotation.*;
+              
+              @RestController
+              @RequestMapping("/users")
+              public class UsersController {
+                  @GetMapping("/{id}")
+                  public ResponseEntity<String> getUser(@PathVariable Long id) {
                   }
               }
               """


### PR DESCRIPTION
Auto-format variable declaration when an argument is removed. Fixes #340