### PR TITLE
move `WebSecurityConfigurerAdapter` recipe to security5

### DIFF
--- a/src/main/java/org/openrewrite/java/spring/security5/WebSecurityConfigurerAdapter.java
+++ b/src/main/java/org/openrewrite/java/spring/security5/WebSecurityConfigurerAdapter.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.openrewrite.java.spring.boot2;
+package org.openrewrite.java.spring.security5;
 
 import org.openrewrite.*;
 import org.openrewrite.internal.ListUtils;

--- a/src/main/resources/META-INF/rewrite/spring-boot-27.yml
+++ b/src/main/resources/META-INF/rewrite/spring-boot-27.yml
@@ -37,7 +37,6 @@ recipeList:
       retainVersions:
         - mysql:mysql-connector-java
   # Use recommended replacements for deprecated APIs
-  - org.openrewrite.java.spring.boot2.WebSecurityConfigurerAdapter
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: org.springframework.boot.web.server.LocalServerPort
       newFullyQualifiedTypeName: org.springframework.boot.test.web.server.LocalServerPort

--- a/src/main/resources/META-INF/rewrite/spring-security-58.yml
+++ b/src/main/resources/META-INF/rewrite/spring-security-58.yml
@@ -37,6 +37,7 @@ recipeList:
   - org.openrewrite.java.spring.security5.UpdateArgon2PasswordEncoder
   - org.openrewrite.java.spring.security5.ReplaceGlobalMethodSecurityWithMethodSecurity
   - org.openrewrite.java.spring.security5.ReplaceGlobalMethodSecurityWithMethodSecurityXml
+  - org.openrewrite.java.spring.security5.WebSecurityConfigurerAdapter
 
 ---
 type: specs.openrewrite.org/v1beta/recipe

--- a/src/testWithSpringSecurity_5_7/java/org/openrewrite/spring/security5/WebSecurityConfigurerAdapterTest.java
+++ b/src/testWithSpringSecurity_5_7/java/org/openrewrite/spring/security5/WebSecurityConfigurerAdapterTest.java
@@ -13,11 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.openrewrite.java.spring.boot2;
+package org.openrewrite.spring.security5;
 
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.java.JavaParser;
+import org.openrewrite.java.spring.security5.WebSecurityConfigurerAdapter;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 


### PR DESCRIPTION
Move `WebSecurityConfigurerAdapter` recipe from `boot2` to `security5`.
And add it to the security5.8 migration recipe list.
As it's part of security5.8 migration ([doc](https://docs.spring.io/spring-security/reference/5.8/migration/servlet/config.html#_publish_a_securityfilterchain_bean)), so should be in `security5`.