### PR TITLE
[RFC] Decouple version-specific migration tasks from the previous versions' migrations

### DIFF
--- a/src/main/resources/META-INF/rewrite/spring-boot-25.yml
+++ b/src/main/resources/META-INF/rewrite/spring-boot-25.yml
@@ -23,6 +23,14 @@ displayName: Upgrade to Spring Boot 2.5
 description: 'Upgrade to Spring Boot 2.5 from any prior 2.x version.'
 recipeList:
   - org.openrewrite.java.spring.boot2.UpgradeSpringBoot_2_4
+  - org.openrewrite.java.spring.boot2.UpgradeSpringBoot_2_5_Isolated
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.spring.boot2.UpgradeSpringBoot_2_5_Isolated
+displayName: Upgrade to Spring Boot 2.5 from 2.4
+description: 'Upgrade to Spring Boot 2.5 from 2.4.'
+recipeList:
   - org.openrewrite.java.spring.data.UpgradeSpringData_2_5
   - org.openrewrite.maven.UpgradeDependencyVersion:
       groupId: org.springframework.boot


### PR DESCRIPTION
Currently, for our version upgrade recipes, we tend to follow a pattern where the first subrecipe is the previous version upgrade recipe, followed by the migrations for the new version.

I'm considering splitting those two concerns, such that you can call a specific version's set of migration tasks in isolation if desired. See diff.

### Why
This would mostly benefit organizations building recipes for private frameworks which wrap frameworks like spring. With the current pattern, you might have something like this:

```yml
---
type: specs.openrewrite.org/v1beta/recipe
name: com.private.UpgradePrivateSpringBoot_2_5
recipeList:
  - com.private.UpgradePrivateSpringBoot_2_4
  - org.openrewrite.java.spring.boot2.UpgradeSpringBoot_2_5
  # migration tasks specific to private-spring 2.5
  # ...

---
type: specs.openrewrite.org/v1beta/recipe
name: com.private.UpgradePrivateSpringBoot_2_6
recipeList:
  - com.private.UpgradePrivateSpringBoot_2_5
  - org.openrewrite.java.spring.boot2.UpgradeSpringBoot_2_6
  # migration tasks specific to private-spring 2.6
  # ...
```

With the above pattern, when you invoke `UpgradePrivateSpringBoot_2_6`, `UpgradeSpringBoot_2_5` gets called twice: once by `UpgradeSpringBoot_2_6`, and again by `UpgradePrivateSpringBoot_2_5`. After the first run of that recipe, the second one is an expensive no-op. And as you make the chain longer with additional framework versions, this grows multiplicatively.

With the pattern implied by this PR, you could instead have this:
```yml
---
type: specs.openrewrite.org/v1beta/recipe
name: com.private.UpgradePrivateSpringBoot_2_5
recipeList:
  - com.private.UpgradePrivateSpringBoot_2_4
  - org.openrewrite.java.spring.boot2.UpgradeSpringBoot_2_5_Isolated
  # migration tasks specific to private-spring 2.5
  # ...

---
type: specs.openrewrite.org/v1beta/recipe
name: com.private.UpgradePrivateSpringBoot_2_6
recipeList:
  - com.private.UpgradePrivateSpringBoot_2_5
  - org.openrewrite.java.spring.boot2.UpgradeSpringBoot_2_6_Isolated
  # migration tasks specific to private-spring 2.6
  # ...
```

Now, `UpgradeSpringBoot_2_5_Isolated` is called just once. Same result, less waste.

(For maximum consistency, the private recipe authors could also apply the same pattern to their own recipes, separating the migration task recipes from the recipes which handle calling the Spring recipe / the previous version recipe)

### If accepted

I would probably want to do this for the Migrate Java recipes, too, and we might want to adopt it as the default design for similar new recipes.

I'm open to suggestions on a naming convention. The "chained" recipe should keep the current name to preserve existing behavior, but the `_Isolated` suffix for the newly-split-off recipe probably isn't the most intuitive.