### PR TITLE
Removed ConditionalOnBeanAnyNestedCondition from Spring Boot Best Pra…

### DIFF
--- a/src/main/resources/META-INF/rewrite/spring-boot-20.yml
+++ b/src/main/resources/META-INF/rewrite/spring-boot-20.yml
@@ -672,6 +672,5 @@ recipeList:
   - org.openrewrite.java.spring.ImplicitWebAnnotationNames
   - org.openrewrite.java.spring.boot2.UnnecessarySpringExtension
   - org.openrewrite.java.spring.NoAutowiredOnConstructor
-  - org.openrewrite.java.spring.boot2.ConditionalOnBeanAnyNestedCondition
   - org.openrewrite.java.spring.boot2.RestTemplateBuilderRequestFactory
   - org.openrewrite.java.spring.boot2.ReplaceDeprecatedEnvironmentTestUtils


### PR DESCRIPTION
…ctices

As far as I can tell, replacing `ConditionalOnBean` with this `AnyNestedCondition` construct is actually a semantically meaningful change. The former is an `and`, and the latter is an `or`. So, this recipe should likely be used not as a best practice but instead as a targeted transformation.

https://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/autoconfigure/condition/ConditionalOnBean.html
https://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/autoconfigure/condition/AnyNestedCondition.html