### PR TITLE
Feature/isolate upgrades

### DIFF
--- a/src/main/resources/META-INF/rewrite/spring-boot-21.yml
+++ b/src/main/resources/META-INF/rewrite/spring-boot-21.yml
@@ -41,6 +41,7 @@ description: >
 tags:
   - spring
   - boot
+  - hidden
 recipeList:
   - org.openrewrite.java.spring.framework.UpgradeSpringFramework_5_1_Only
   - org.openrewrite.maven.UpgradeDependencyVersion:

--- a/src/main/resources/META-INF/rewrite/spring-boot-21.yml
+++ b/src/main/resources/META-INF/rewrite/spring-boot-21.yml
@@ -30,6 +30,19 @@ tags:
   - boot
 recipeList:
   - org.openrewrite.java.spring.boot2.UpgradeSpringBoot_2_0
+  - org.openrewrite.java.spring.boot2.UpgradeSpringBoot_2_1_Only
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.spring.boot2.UpgradeSpringBoot_2_1_Only
+displayName: Migrate to Spring Boot 2.1 from 2.0
+description: >
+  Applies any migrations specific to the Spring Boot 2.1 release, without any migrations from older releases.
+tags:
+  - spring
+  - boot
+recipeList:
+  - org.openrewrite.java.spring.framework.UpgradeSpringFramework_5_1_Only
   - org.openrewrite.maven.UpgradeDependencyVersion:
       groupId: org.springframework.boot
       artifactId: "*"

--- a/src/main/resources/META-INF/rewrite/spring-boot-22.yml
+++ b/src/main/resources/META-INF/rewrite/spring-boot-22.yml
@@ -30,7 +30,19 @@ tags:
   - boot
 recipeList:
   - org.openrewrite.java.spring.boot2.UpgradeSpringBoot_2_1
-  - org.openrewrite.java.spring.framework.UpgradeSpringFramework_5_2
+  - org.openrewrite.java.spring.boot2.UpgradeSpringBoot_2_2_Only
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.spring.boot2.UpgradeSpringBoot_2_2_Only
+displayName: Migrate to Spring Boot 2.2 from 2.1
+description: >
+  Applies any migrations specific to the Spring Boot 2.2 release, without any migrations from older releases.
+tags:
+  - spring
+  - boot
+recipeList:
+  - org.openrewrite.java.spring.framework.UpgradeSpringFramework_5_2_Only
   - org.openrewrite.maven.UpgradeDependencyVersion:
       groupId: org.springframework.boot
       artifactId: "*"

--- a/src/main/resources/META-INF/rewrite/spring-boot-22.yml
+++ b/src/main/resources/META-INF/rewrite/spring-boot-22.yml
@@ -41,6 +41,7 @@ description: >
 tags:
   - spring
   - boot
+  - hidden
 recipeList:
   - org.openrewrite.java.spring.framework.UpgradeSpringFramework_5_2_Only
   - org.openrewrite.maven.UpgradeDependencyVersion:

--- a/src/main/resources/META-INF/rewrite/spring-boot-23.yml
+++ b/src/main/resources/META-INF/rewrite/spring-boot-23.yml
@@ -41,6 +41,7 @@ description: >
 tags:
   - spring
   - boot
+  - hidden
 recipeList:
   - org.openrewrite.java.spring.data.UpgradeSpringData_2_3
   - org.openrewrite.maven.UpgradeDependencyVersion:

--- a/src/main/resources/META-INF/rewrite/spring-boot-23.yml
+++ b/src/main/resources/META-INF/rewrite/spring-boot-23.yml
@@ -30,6 +30,18 @@ tags:
   - boot
 recipeList:
   - org.openrewrite.java.spring.boot2.UpgradeSpringBoot_2_2
+  - org.openrewrite.java.spring.boot2.UpgradeSpringBoot_2_3_Only
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.spring.boot2.UpgradeSpringBoot_2_3_Only
+displayName: Migrate to Spring Boot 2.3 from 2.2
+description: >
+  Applies any migrations specific to the Spring Boot 2.3 release, without any migrations from older releases.
+tags:
+  - spring
+  - boot
+recipeList:
   - org.openrewrite.java.spring.data.UpgradeSpringData_2_3
   - org.openrewrite.maven.UpgradeDependencyVersion:
       groupId: org.springframework.boot

--- a/src/main/resources/META-INF/rewrite/spring-boot-24.yml
+++ b/src/main/resources/META-INF/rewrite/spring-boot-24.yml
@@ -30,7 +30,19 @@ tags:
   - boot
 recipeList:
   - org.openrewrite.java.spring.boot2.UpgradeSpringBoot_2_3
-  - org.openrewrite.java.spring.framework.UpgradeSpringFramework_5_3
+  - org.openrewrite.java.spring.boot2.UpgradeSpringBoot_2_4_Only
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.spring.boot2.UpgradeSpringBoot_2_4_Only
+displayName: Migrate to Spring Boot 2.4
+description: >
+  Applies any migrations specific to the Spring Boot 2.4 release, without any migrations from older releases.
+tags:
+  - spring
+  - boot
+recipeList:
+  - org.openrewrite.java.spring.framework.UpgradeSpringFramework_5_3_Only
   - org.openrewrite.java.spring.boot2.SpringBoot2JUnit4to5Migration
   - org.openrewrite.maven.UpgradeDependencyVersion:
       groupId: org.springframework.boot

--- a/src/main/resources/META-INF/rewrite/spring-boot-24.yml
+++ b/src/main/resources/META-INF/rewrite/spring-boot-24.yml
@@ -41,6 +41,7 @@ description: >
 tags:
   - spring
   - boot
+  - hidden
 recipeList:
   - org.openrewrite.java.spring.framework.UpgradeSpringFramework_5_3_Only
   - org.openrewrite.java.spring.boot2.SpringBoot2JUnit4to5Migration

--- a/src/main/resources/META-INF/rewrite/spring-boot-25.yml
+++ b/src/main/resources/META-INF/rewrite/spring-boot-25.yml
@@ -23,7 +23,15 @@ displayName: Upgrade to Spring Boot 2.5
 description: 'Upgrade to Spring Boot 2.5 from any prior 2.x version.'
 recipeList:
   - org.openrewrite.java.spring.boot2.UpgradeSpringBoot_2_4
-  - org.openrewrite.java.spring.data.UpgradeSpringData_2_5
+  - org.openrewrite.java.spring.boot2.UpgradeSpringBoot_2_5_Only
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.spring.boot2.UpgradeSpringBoot_2_5_Only
+displayName: Upgrade to Spring Boot 2.5
+description: 'Upgrade to Spring Boot 2.5 from 2.4.'
+recipeList:
+  - org.openrewrite.java.spring.data.UpgradeSpringData_2_5_Only
   - org.openrewrite.maven.UpgradeDependencyVersion:
       groupId: org.springframework.boot
       artifactId: "*"

--- a/src/main/resources/META-INF/rewrite/spring-boot-25.yml
+++ b/src/main/resources/META-INF/rewrite/spring-boot-25.yml
@@ -21,6 +21,9 @@ type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.spring.boot2.UpgradeSpringBoot_2_5
 displayName: Upgrade to Spring Boot 2.5
 description: 'Upgrade to Spring Boot 2.5 from any prior 2.x version.'
+tags:
+  - spring
+  - boot
 recipeList:
   - org.openrewrite.java.spring.boot2.UpgradeSpringBoot_2_4
   - org.openrewrite.java.spring.boot2.UpgradeSpringBoot_2_5_Only
@@ -30,6 +33,10 @@ type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.spring.boot2.UpgradeSpringBoot_2_5_Only
 displayName: Upgrade to Spring Boot 2.5
 description: 'Upgrade to Spring Boot 2.5 from 2.4.'
+tags:
+  - spring
+  - boot
+  - hidden
 recipeList:
   - org.openrewrite.java.spring.data.UpgradeSpringData_2_5_Only
   - org.openrewrite.maven.UpgradeDependencyVersion:

--- a/src/main/resources/META-INF/rewrite/spring-boot-26.yml
+++ b/src/main/resources/META-INF/rewrite/spring-boot-26.yml
@@ -41,6 +41,7 @@ description: >
 tags:
   - spring
   - boot
+  - hidden
 recipeList:
   - org.openrewrite.maven.UpgradeDependencyVersion:
       groupId: org.springframework.boot

--- a/src/main/resources/META-INF/rewrite/spring-boot-26.yml
+++ b/src/main/resources/META-INF/rewrite/spring-boot-26.yml
@@ -30,6 +30,18 @@ tags:
   - boot
 recipeList:
   - org.openrewrite.java.spring.boot2.UpgradeSpringBoot_2_5
+  - org.openrewrite.java.spring.boot2.UpgradeSpringBoot_2_6_Only
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.spring.boot2.UpgradeSpringBoot_2_6_Only
+displayName: Migrate to Spring Boot 2.6 from 2.5
+description: >
+  Applies any migrations specific to the Spring Boot 2.6 release, without any migrations from older releases.
+tags:
+  - spring
+  - boot
+recipeList:
   - org.openrewrite.maven.UpgradeDependencyVersion:
       groupId: org.springframework.boot
       artifactId: "*"

--- a/src/main/resources/META-INF/rewrite/spring-boot-27.yml
+++ b/src/main/resources/META-INF/rewrite/spring-boot-27.yml
@@ -23,6 +23,14 @@ displayName: Migrate to Spring Boot 2.7
 description: 'Upgrade to Spring Boot 2.7'
 recipeList:
   - org.openrewrite.java.spring.boot2.UpgradeSpringBoot_2_6
+  - org.openrewrite.java.spring.boot2.UpgradeSpringBoot_2_7_Only
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.spring.boot2.UpgradeSpringBoot_2_7_Only
+displayName: Migrate to Spring Boot 2.7 from 2.6
+description: 'Upgrade to Spring Boot 2.7 from 2.6'
+recipeList:
   - org.openrewrite.maven.UpgradeDependencyVersion:
       groupId: org.springframework.boot
       artifactId: "*"

--- a/src/main/resources/META-INF/rewrite/spring-boot-27.yml
+++ b/src/main/resources/META-INF/rewrite/spring-boot-27.yml
@@ -21,6 +21,9 @@ type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.spring.boot2.UpgradeSpringBoot_2_7
 displayName: Migrate to Spring Boot 2.7
 description: 'Upgrade to Spring Boot 2.7'
+tags:
+  - spring
+  - boot
 recipeList:
   - org.openrewrite.java.spring.boot2.UpgradeSpringBoot_2_6
   - org.openrewrite.java.spring.boot2.UpgradeSpringBoot_2_7_Only
@@ -30,6 +33,10 @@ type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.spring.boot2.UpgradeSpringBoot_2_7_Only
 displayName: Migrate to Spring Boot 2.7 from 2.6
 description: 'Upgrade to Spring Boot 2.7 from 2.6'
+tags:
+  - spring
+  - boot
+  - hidden
 recipeList:
   - org.openrewrite.maven.UpgradeDependencyVersion:
       groupId: org.springframework.boot

--- a/src/main/resources/META-INF/rewrite/spring-boot-30.yml
+++ b/src/main/resources/META-INF/rewrite/spring-boot-30.yml
@@ -27,6 +27,18 @@ tags:
   - boot
 recipeList:
   - org.openrewrite.java.spring.boot2.UpgradeSpringBoot_2_7
+  - org.openrewrite.java.spring.boot2.UpgradeSpringBoot_3_0_Only
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.spring.boot3.UpgradeSpringBoot_3_0_Only
+displayName: Migrate to Spring Boot 3.0 from 2.7
+description: >
+  Applies any migrations specific to the Spring Boot 3.0 release, without any migrations from older releases.
+tags:
+  - spring
+  - boot
+recipeList:
   - org.openrewrite.java.spring.boot3.RemoveEnableBatchProcessing
   - org.openrewrite.java.spring.boot3.MavenPomUpgrade
   - org.openrewrite.java.migrate.UpgradeToJava17

--- a/src/main/resources/META-INF/rewrite/spring-boot-30.yml
+++ b/src/main/resources/META-INF/rewrite/spring-boot-30.yml
@@ -38,6 +38,7 @@ description: >
 tags:
   - spring
   - boot
+  - hidden
 recipeList:
   - org.openrewrite.java.spring.boot3.RemoveEnableBatchProcessing
   - org.openrewrite.java.spring.boot3.MavenPomUpgrade

--- a/src/main/resources/META-INF/rewrite/spring-data-25.yml
+++ b/src/main/resources/META-INF/rewrite/spring-data-25.yml
@@ -23,6 +23,14 @@ displayName: Migrate to Spring Data 2.5
 description: Migrate applications to the latest Spring Data 2.5 release.
 recipeList:
   - org.openrewrite.java.spring.data.UpgradeSpringData_2_3
+  - org.openrewrite.java.spring.data.UpgradeSpringData_2_5_Only
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.spring.data.UpgradeSpringData_2_5_Only
+displayName: Migrate to Spring Data 2.5 from 2.3
+description: Applies any migrations specific to the Spring Data 2.3 release, without any migrations from older releases.
+recipeList:
   - org.openrewrite.java.spring.data.UseJpaRepositoryGetById
   - org.openrewrite.java.spring.data.UseJpaRepositoryDeleteAllInBatch
 ---

--- a/src/main/resources/META-INF/rewrite/spring-data-25.yml
+++ b/src/main/resources/META-INF/rewrite/spring-data-25.yml
@@ -30,6 +30,8 @@ type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.spring.data.UpgradeSpringData_2_5_Only
 displayName: Migrate to Spring Data 2.5 from 2.3
 description: Applies any migrations specific to the Spring Data 2.3 release, without any migrations from older releases.
+tags:
+  - hidden
 recipeList:
   - org.openrewrite.java.spring.data.UseJpaRepositoryGetById
   - org.openrewrite.java.spring.data.UseJpaRepositoryDeleteAllInBatch

--- a/src/main/resources/META-INF/rewrite/spring-framework-51.yml
+++ b/src/main/resources/META-INF/rewrite/spring-framework-51.yml
@@ -13,15 +13,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
----
 ########################################################################################################################
 # Spring Framework 5.1
+---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.spring.framework.UpgradeSpringFramework_5_1
 displayName: Migrate to Spring Framework 5.1
 description: Migrate applications to the latest Spring Framework 5.1 release.
 recipeList:
   - org.openrewrite.java.spring.framework.UpgradeSpringFramework_5_0
+  - org.openrewrite.java.spring.framework.UpgradeSpringFramework_5_1_Only
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.spring.framework.UpgradeSpringFramework_5_1_Only
+displayName: Migrate to Spring Framework 5.1 from 5.0
+description: Applies any migrations specific to the Spring Framework 5.1 release, without any migrations from older releases.
+recipeList:
   - org.openrewrite.java.spring.framework.UpgradeSpringFrameworkDependencies:
       newVersion: 5.1.x
   - org.openrewrite.java.spring.framework.EnvironmentAcceptsProfiles

--- a/src/main/resources/META-INF/rewrite/spring-framework-51.yml
+++ b/src/main/resources/META-INF/rewrite/spring-framework-51.yml
@@ -29,6 +29,8 @@ type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.spring.framework.UpgradeSpringFramework_5_1_Only
 displayName: Migrate to Spring Framework 5.1 from 5.0
 description: Applies any migrations specific to the Spring Framework 5.1 release, without any migrations from older releases.
+tags:
+  - hidden
 recipeList:
   - org.openrewrite.java.spring.framework.UpgradeSpringFrameworkDependencies:
       newVersion: 5.1.x

--- a/src/main/resources/META-INF/rewrite/spring-framework-52.yml
+++ b/src/main/resources/META-INF/rewrite/spring-framework-52.yml
@@ -23,6 +23,14 @@ displayName: Migrate to Spring Framework 5.2
 description: Migrate applications to the latest Spring Framework 5.2 release.
 recipeList:
   - org.openrewrite.java.spring.framework.UpgradeSpringFramework_5_1
+  - org.openrewrite.java.spring.framework.UpgradeSpringFramework_5_2_Only
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.spring.framework.UpgradeSpringFramework_5_2_Only
+displayName: Migrate to Spring Framework 5.2 from 5.1
+description: Applies any migrations specific to the Spring Framework 5.2 release, without any migrations from older releases.
+recipeList:
   - org.openrewrite.java.spring.framework.UpgradeSpringFrameworkDependencies:
       newVersion: 5.2.x
   - org.openrewrite.java.spring.framework.MigrateUtf8MediaTypes

--- a/src/main/resources/META-INF/rewrite/spring-framework-52.yml
+++ b/src/main/resources/META-INF/rewrite/spring-framework-52.yml
@@ -30,6 +30,8 @@ type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.spring.framework.UpgradeSpringFramework_5_2_Only
 displayName: Migrate to Spring Framework 5.2 from 5.1
 description: Applies any migrations specific to the Spring Framework 5.2 release, without any migrations from older releases.
+tags:
+  - hidden
 recipeList:
   - org.openrewrite.java.spring.framework.UpgradeSpringFrameworkDependencies:
       newVersion: 5.2.x

--- a/src/main/resources/META-INF/rewrite/spring-framework-53.yml
+++ b/src/main/resources/META-INF/rewrite/spring-framework-53.yml
@@ -30,6 +30,8 @@ type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.spring.framework.UpgradeSpringFramework_5_3_Only
 displayName: Migrate to Spring Framework 5.3 from 5.2
 description: Applies any migrations specific to the Spring Framework 5.2 release, without any migrations from older releases.
+tags:
+  - hidden
 recipeList:
   - org.openrewrite.java.spring.framework.UpgradeSpringFrameworkDependencies:
       newVersion: 5.3.x

--- a/src/main/resources/META-INF/rewrite/spring-framework-53.yml
+++ b/src/main/resources/META-INF/rewrite/spring-framework-53.yml
@@ -23,6 +23,14 @@ displayName: Migrate to Spring Framework 5.3
 description: Migrate applications to the latest Spring Framework 5.3 release.
 recipeList:
   - org.openrewrite.java.spring.framework.UpgradeSpringFramework_5_2
+  - org.openrewrite.java.spring.framework.UpgradeSpringFramework_5_3_Only
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.spring.framework.UpgradeSpringFramework_5_3_Only
+displayName: Migrate to Spring Framework 5.3 from 5.2
+description: Applies any migrations specific to the Spring Framework 5.2 release, without any migrations from older releases.
+recipeList:
   - org.openrewrite.java.spring.framework.UpgradeSpringFrameworkDependencies:
       newVersion: 5.3.x
   - org.openrewrite.java.spring.framework.UseObjectUtilsIsEmpty

--- a/src/main/resources/META-INF/rewrite/spring-security-60.yml
+++ b/src/main/resources/META-INF/rewrite/spring-security-60.yml
@@ -26,7 +26,7 @@ tags:
   - security
 recipeList:
   - org.openrewrite.java.spring.security5.UpgradeSpringSecurity_5_8
-  - org.openrewrite.java.spring.security5.UpgradeSpringSecurity_6_0_Only
+  - org.openrewrite.java.spring.security6.UpgradeSpringSecurity_6_0_Only
 
 ---
 type: specs.openrewrite.org/v1beta/recipe

--- a/src/main/resources/META-INF/rewrite/spring-security-60.yml
+++ b/src/main/resources/META-INF/rewrite/spring-security-60.yml
@@ -37,6 +37,7 @@ description: >
 tags:
   - spring
   - security
+  - hidden
 recipeList:
   - org.openrewrite.maven.UpgradeDependencyVersion:
       groupId: org.springframework.security

--- a/src/main/resources/META-INF/rewrite/spring-security-60.yml
+++ b/src/main/resources/META-INF/rewrite/spring-security-60.yml
@@ -26,6 +26,18 @@ tags:
   - security
 recipeList:
   - org.openrewrite.java.spring.security5.UpgradeSpringSecurity_5_8
+  - org.openrewrite.java.spring.security5.UpgradeSpringSecurity_6_0_Only
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.spring.security6.UpgradeSpringSecurity_6_0_Only
+displayName: Migrate to Spring Security 6.0 from 5.8
+description: >
+  Applies any migrations specific to the Spring Security 6.0 release, without any migrations from older releases.
+tags:
+  - spring
+  - security
+recipeList:
   - org.openrewrite.maven.UpgradeDependencyVersion:
       groupId: org.springframework.security
       artifactId: "*"


### PR DESCRIPTION
implementation of #351

on a private project (using recipes for a private spring-boot-wrapper framework), I was able to reduce recipe execution time from 6m52s to 3m06s using a local snapshot of rewrite-spring with this change. The (private) recipe chain had just 4 calls to `UpgradeSpringBoot_###` recipes.

these changes should even bring some small performance improvements to the `UpgradeSpringBoot` recipes directly, as I was able to untangle some redundant execution of spring-data, spring-framework, spring-security, etc recipes across the chain,