### PR TITLE
Changed MigrateAbstractHealthIndicatorToPingHealthIndicator to target…

### DIFF
--- a/src/main/resources/META-INF/rewrite/spring-boot-22.yml
+++ b/src/main/resources/META-INF/rewrite/spring-boot-22.yml
@@ -42,7 +42,7 @@ recipeList:
       newVersion: 2.2.x
 
   # Use recommended replacements for deprecated APIs
-  - org.openrewrite.java.spring.boot2.MigrateAbstractHealthIndicatorToPingHealthIndicator
+  - org.openrewrite.java.spring.boot2.MigrateApplicationHealthIndicatorToPingHealthIndicator
   - org.openrewrite.java.spring.boot2.MigrateWebTestClientBuilderCustomizerPackageName
   - org.openrewrite.java.spring.boot2.MigrateConfigurationPropertiesBindingPostProcessorValidatorBeanName
 
@@ -53,12 +53,12 @@ recipeList:
 
 ---
 type: specs.openrewrite.org/v1beta/recipe
-name: org.openrewrite.java.spring.boot2.MigrateAbstractHealthIndicatorToPingHealthIndicator
+name: org.openrewrite.java.spring.boot2.MigrateApplicationHealthIndicatorToPingHealthIndicator
 displayName: Use `PingHealthIndicator`
-description: '`org.springframework.boot.actuate.health.AbstractHealthIndicator` was deprecated in 2.2.'
+description: '`org.springframework.boot.actuate.health.ApplicationHealthIndicator` was deprecated in 2.2.'
 recipeList:
   - org.openrewrite.java.ChangeType:
-      oldFullyQualifiedTypeName: org.springframework.boot.actuate.health.AbstractHealthIndicator
+      oldFullyQualifiedTypeName: org.springframework.boot.actuate.health.ApplicationHealthIndicator
       newFullyQualifiedTypeName: org.springframework.boot.actuate.health.PingHealthIndicator
 
 ---


### PR DESCRIPTION
… ApplicationHealthIndicator

I think this was simply a typo in the first place.

Ref:
2.2.1 Deprecations: https://javadoc.io/static/org.springframework.boot/spring-boot-actuator/2.2.1.RELEASE/deprecated-list.html
ApplicationHealthIndicator (deprecated): https://javadoc.io/static/org.springframework.boot/spring-boot-actuator/2.2.1.RELEASE/org/springframework/boot/actuate/health/ApplicationHealthIndicator.html
AbstractHealthIndicator (not deprecated, even now in 3.x): https://docs.spring.io/spring-boot/docs/2.2.0.RELEASE/api/org/springframework/boot/actuate/health/AbstractHealthIndicator.html