### PR TITLE
Make concrete visitor accessible for Security DSL recipes

### DIFF
--- a/src/main/java/org/openrewrite/java/spring/boot2/ConvertToSecurityDslVisitor.java
+++ b/src/main/java/org/openrewrite/java/spring/boot2/ConvertToSecurityDslVisitor.java
@@ -16,9 +16,11 @@
 package org.openrewrite.java.spring.boot2;
 
 import org.openrewrite.Cursor;
+import org.openrewrite.SourceFile;
 import org.openrewrite.Tree;
 import org.openrewrite.internal.StringUtils;
 import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.search.UsesType;
 import org.openrewrite.java.tree.*;
 import org.openrewrite.marker.Markers;
 import org.openrewrite.marker.Markup;
@@ -38,6 +40,11 @@ public class ConvertToSecurityDslVisitor<P> extends JavaIsoVisitor<P> {
     public ConvertToSecurityDslVisitor(String securityFqn, Collection<String> convertableMethods) {
         this.securityFqn = securityFqn;
         this.convertableMethods = convertableMethods;
+    }
+
+    @Override
+    public boolean isAcceptable(SourceFile sourceFile, P p) {
+        return new UsesType<>(securityFqn, true).isAcceptable(sourceFile, p);
     }
 
     @Override

--- a/src/main/java/org/openrewrite/java/spring/boot2/HttpSecurityLambdaDsl.java
+++ b/src/main/java/org/openrewrite/java/spring/boot2/HttpSecurityLambdaDsl.java
@@ -16,10 +16,7 @@
 package org.openrewrite.java.spring.boot2;
 
 import org.openrewrite.ExecutionContext;
-import org.openrewrite.Preconditions;
 import org.openrewrite.Recipe;
-import org.openrewrite.TreeVisitor;
-import org.openrewrite.java.search.UsesType;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -45,8 +42,8 @@ public final class HttpSecurityLambdaDsl extends Recipe {
     }
 
     @Override
-    public TreeVisitor<?, ExecutionContext> getVisitor() {
-        return Preconditions.check(new UsesType<>(FQN_HTTP_SECURITY, true), new ConvertToSecurityDslVisitor<>(FQN_HTTP_SECURITY, APPLICABLE_METHOD_NAMES));
+    public ConvertToSecurityDslVisitor<ExecutionContext> getVisitor() {
+        return new ConvertToSecurityDslVisitor<>(FQN_HTTP_SECURITY, APPLICABLE_METHOD_NAMES);
     }
 
 }

--- a/src/main/java/org/openrewrite/java/spring/boot2/ServerHttpSecurityLambdaDsl.java
+++ b/src/main/java/org/openrewrite/java/spring/boot2/ServerHttpSecurityLambdaDsl.java
@@ -16,10 +16,7 @@
 package org.openrewrite.java.spring.boot2;
 
 import org.openrewrite.ExecutionContext;
-import org.openrewrite.Preconditions;
 import org.openrewrite.Recipe;
-import org.openrewrite.TreeVisitor;
-import org.openrewrite.java.search.UsesType;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -44,9 +41,8 @@ public final class ServerHttpSecurityLambdaDsl extends Recipe {
     }
 
     @Override
-    public TreeVisitor<?, ExecutionContext> getVisitor() {
-        return Preconditions.check(new UsesType<>(FQN_SERVER_HTTP_SECURITY, true),
-                new ConvertToSecurityDslVisitor<>(FQN_SERVER_HTTP_SECURITY, APPLICABLE_METHOD_NAMES));
+    public ConvertToSecurityDslVisitor<ExecutionContext> getVisitor() {
+        return new ConvertToSecurityDslVisitor<>(FQN_SERVER_HTTP_SECURITY, APPLICABLE_METHOD_NAMES);
     }
 
 }


### PR DESCRIPTION
The Security DSL recipes are re-used in IDE to mark problems. Need to get a hold of a visitor to call `isApplicableTopLevelMethodInvocation(...)`