### PR TITLE
Upgrade Maven parent only; Gradle should work with BOM already

### DIFF
--- a/src/main/resources/META-INF/rewrite/spring-boot-20.yml
+++ b/src/main/resources/META-INF/rewrite/spring-boot-20.yml
@@ -35,7 +35,7 @@ recipeList:
       artifactId: "*"
       newVersion: 2.0.x
       overrideManagedVersion: false
-  - org.openrewrite.java.dependencies.UpgradeParentVersion:
+  - org.openrewrite.maven.UpgradeParentVersion:
       groupId: org.springframework.boot
       artifactId: spring-boot-starter-parent
       newVersion: 2.0.x


### PR DESCRIPTION
## What's changed?
Switch `org.openrewrite.java.dependencies.UpgradeParentVersion` back to `org.openrewrite.maven.UpgradeParentVersion`

## What's your motivation?
Fixes #371

## Any additional context
Introduced in https://github.com/openrewrite/rewrite-spring/commit/5e90a83ebedf970800cdb4719f46852bb132a40d , likely as an oversight there, as there is [no equivalent UpgradeParentVersion in rewrite-java-dependencies](https://github.com/openrewrite/rewrite-java-dependencies/tree/main/src/main/java/org/openrewrite/java/dependencies). The Gradle UpgradeDependencyVersion [handles platform dependencies as well](https://github.com/openrewrite/rewrite/blob/fdced008df89f861e33e73e39457db154adcc4a0/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpgradeDependencyVersionTest.java#L233-L246), which is already covered in the recipe just above the one changed here.. 
