### PR TITLE
Adapted the maven specific mysql dependency update to the generic one to include gradle

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -124,6 +124,7 @@ dependencies {
     runtimeOnly("org.openrewrite:rewrite-java-17:$rewriteVersion")
 
     testRuntimeOnly("ch.qos.logback:logback-classic:1.+")
+    testRuntimeOnly(gradleApi())
 
     testImplementation("com.github.marschall:memoryfilesystem:latest.release")
 

--- a/src/main/resources/META-INF/rewrite/spring-boot-27.yml
+++ b/src/main/resources/META-INF/rewrite/spring-boot-27.yml
@@ -51,7 +51,7 @@ recipeList:
       newFullyQualifiedTypeName: org.hibernate.boot.model.naming.CamelCaseToUnderscoresNamingStrategy
   - org.openrewrite.java.spring.boot2.SpringBootProperties_2_7
   # Switch MySQL driver artifactId
-  - org.openrewrite.maven.ChangeDependencyGroupIdAndArtifactId:
+  - org.openrewrite.java.dependencies.ChangeDependency:
       oldGroupId: mysql
       oldArtifactId: mysql-connector-java
       newGroupId: com.mysql

--- a/src/testWithSpringBoot_2_7/java/org/openrewrite/java/spring/boot2/UpdateMysqlDriverArtifactIdTest.java
+++ b/src/testWithSpringBoot_2_7/java/org/openrewrite/java/spring/boot2/UpdateMysqlDriverArtifactIdTest.java
@@ -15,78 +15,77 @@
  */
 package org.openrewrite.java.spring.boot2;
 
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
 import org.openrewrite.Issue;
 import org.openrewrite.config.Environment;
-import org.openrewrite.DocumentExample;
+import org.openrewrite.gradle.Assertions;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
-
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.openrewrite.gradle.Assertions.withToolingApi;
 import static org.openrewrite.maven.Assertions.pomXml;
 
-@Issue("https://github.com/openrewrite/rewrite-spring/issues/274")
+@Issue("https://github.com/openrewrite/rewrite-spring/issues/274 & https://github.com/openrewrite/rewrite-spring/issues/375")
 public class UpdateMysqlDriverArtifactIdTest implements RewriteTest {
 
     @Override
     public void defaults(RecipeSpec spec) {
         spec.recipe(Environment.builder()
-          .scanRuntimeClasspath("org.openrewrite.java.spring.boot2")
-          .build()
-          .activateRecipes("org.openrewrite.java.spring.boot2.UpgradeSpringBoot_2_7"));
+                               .scanRuntimeClasspath("org.openrewrite.java.spring.boot2")
+                               .build()
+                               .activateRecipes("org.openrewrite.java.spring.boot2.UpgradeSpringBoot_2_7"));
     }
 
-    @DocumentExample
-    @Test
-    void switchArtifactIdAndUpdateVersionNumber() {
-        rewriteRun(
-          //language=xml
-          pomXml(
-            """
-              <project>
-                <modelVersion>4.0.0</modelVersion>
-                <groupId>com.example</groupId>
-                <artifactId>demo</artifactId>
-                <version>0.0.1-SNAPSHOT</version>
-                <dependencies>
-                  <dependency>
-                    <groupId>mysql</groupId>
-                    <artifactId>mysql-connector-java</artifactId>
-                    <version>8.0.30</version>
-                    <scope>runtime</scope>
-                  </dependency>
-                </dependencies>
-              </project>
-              """,
-            """
-              <project>
-                <modelVersion>4.0.0</modelVersion>
-                <groupId>com.example</groupId>
-                <artifactId>demo</artifactId>
-                <version>0.0.1-SNAPSHOT</version>
-                <dependencies>
-                  <dependency>
-                    <groupId>com.mysql</groupId>
-                    <artifactId>mysql-connector-j</artifactId>
-                    <version>8.0.33</version>
-                    <scope>runtime</scope>
-                  </dependency>
-                </dependencies>
-              </project>
+    @Nested
+    class Maven {
+        @DocumentExample
+        @Test
+        void switchArtifactIdAndUpdateVersionNumber() {
+            rewriteRun(
+              //language=xml
+              pomXml("""
+                     <project>
+                       <modelVersion>4.0.0</modelVersion>
+                       <groupId>com.example</groupId>
+                       <artifactId>demo</artifactId>
+                       <version>0.0.1-SNAPSHOT</version>
+                       <dependencies>
+                         <dependency>
+                           <groupId>mysql</groupId>
+                           <artifactId>mysql-connector-java</artifactId>
+                           <version>8.0.30</version>
+                           <scope>runtime</scope>
+                         </dependency>
+                       </dependencies>
+                     </project>
+                     """, """
+                          <project>
+                            <modelVersion>4.0.0</modelVersion>
+                            <groupId>com.example</groupId>
+                            <artifactId>demo</artifactId>
+                            <version>0.0.1-SNAPSHOT</version>
+                            <dependencies>
+                              <dependency>
+                                <groupId>com.mysql</groupId>
+                                <artifactId>mysql-connector-j</artifactId>
+                                <version>8.0.33</version>
+                                <scope>runtime</scope>
+                              </dependency>
+                            </dependencies>
+                          </project>
+                          """));
+        }
+
+        @Test
+        void doNotPinWhenNotVersioned() {
+            rewriteRun(pomXml(
+              //language=xml
               """
-          )
-        );
-    }
-
-    @Test
-    void doNotPinWhenNotVersioned() {
-        rewriteRun(
-          pomXml(
-            //language=xml
-            """
               <project>
                 <modelVersion>4.0.0</modelVersion>
                 <groupId>com.example</groupId>
@@ -106,34 +105,103 @@ public class UpdateMysqlDriverArtifactIdTest implements RewriteTest {
                   </dependency>
                 </dependencies>
               </project>
-              """,
-            spec -> spec.after(pom -> {
-                Matcher version = Pattern.compile("2.7.\\d+").matcher(pom);
-                assertThat(version.find()).describedAs("Expected 2.7.x in %s", pom).isTrue();
-                //language=xml
-                return String.format("""
-                  <project>
-                    <modelVersion>4.0.0</modelVersion>
-                    <groupId>com.example</groupId>
-                    <artifactId>demo</artifactId>
-                    <version>0.0.1-SNAPSHOT</version>
-                    <parent>
-                      <groupId>org.springframework.boot</groupId>
-                      <artifactId>spring-boot-starter-parent</artifactId>
-                      <version>%s</version>
-                      <relativePath/> <!-- lookup parent from repository -->
-                    </parent>
-                    <dependencies>
-                      <dependency>
-                        <groupId>com.mysql</groupId>
-                        <artifactId>mysql-connector-j</artifactId>
-                        <scope>runtime</scope>
-                      </dependency>
-                    </dependencies>
-                  </project>
-                  """, version.group(0));
-            })
-          )
-        );
+              """, spec -> spec.after(pom -> {
+                  Matcher version = Pattern.compile("2.7.\\d+").matcher(pom);
+                  assertThat(version.find()).describedAs("Expected 2.7.x in %s", pom).isTrue();
+                  //language=xml
+                  return String.format("""
+                                       <project>
+                                         <modelVersion>4.0.0</modelVersion>
+                                         <groupId>com.example</groupId>
+                                         <artifactId>demo</artifactId>
+                                         <version>0.0.1-SNAPSHOT</version>
+                                         <parent>
+                                           <groupId>org.springframework.boot</groupId>
+                                           <artifactId>spring-boot-starter-parent</artifactId>
+                                           <version>%s</version>
+                                           <relativePath/> <!-- lookup parent from repository -->
+                                         </parent>
+                                         <dependencies>
+                                           <dependency>
+                                             <groupId>com.mysql</groupId>
+                                             <artifactId>mysql-connector-j</artifactId>
+                                             <scope>runtime</scope>
+                                           </dependency>
+                                         </dependencies>
+                                       </project>
+                                       """, version.group(0));
+              })));
+        }
+    }
+
+    @Nested
+    class Gradle {
+
+        @DocumentExample
+        @Test
+        void gradleSwitchArtifactIdAndUpdateVersionNumber() {
+            rewriteRun(spec -> spec.beforeRecipe(withToolingApi()),
+                       //language=groovy
+                       Assertions.buildGradle("""
+                                              plugins {
+                                                id 'java'
+                                              }
+                                                                   
+                                              repositories {
+                                                 mavenCentral()
+                                              }
+                                                                   
+                                              dependencies {
+                                                  runtimeOnly 'mysql:mysql-connector-java:8.0.30'
+                                              }
+                                              """, """
+                                                   plugins {
+                                                     id 'java'
+                                                   }
+                                                                        
+                                                   repositories {
+                                                      mavenCentral()
+                                                   }
+                                                                        
+                                                   dependencies {
+                                                       runtimeOnly 'com.mysql:mysql-connector-j:8.0.33'
+                                                   }
+                                                   """));
+        }
+
+        @Test
+        void gradleDoNotPinWhenNotVersioned() {
+            rewriteRun(spec -> spec.beforeRecipe(withToolingApi()),
+                       //language=groovy
+                       Assertions.buildGradle("""
+                                              plugins {
+                                                id 'java'
+                                                id 'org.springframework.boot' version '2.6.1'
+                                                id 'io.spring.dependency-management' version '1.0.11.RELEASE'
+                                              }
+                                                                                        
+                                              repositories {
+                                                 mavenCentral()
+                                              }
+                                                                   
+                                              dependencies {
+                                                  runtimeOnly 'mysql:mysql-connector-java'
+                                              }
+                                              """, """
+                                                   plugins {
+                                                     id 'java'
+                                                     id 'org.springframework.boot' version '2.6.1'
+                                                     id 'io.spring.dependency-management' version '1.0.11.RELEASE'
+                                                   }
+                                                                        
+                                                   repositories {
+                                                      mavenCentral()
+                                                   }
+                                                                        
+                                                   dependencies {
+                                                       runtimeOnly 'com.mysql:mysql-connector-j'
+                                                   }
+                                                   """));
+        }
     }
 }

--- a/src/testWithSpringBoot_2_7/java/org/openrewrite/java/spring/boot2/UpdateMysqlDriverArtifactIdTest.java
+++ b/src/testWithSpringBoot_2_7/java/org/openrewrite/java/spring/boot2/UpdateMysqlDriverArtifactIdTest.java
@@ -23,6 +23,7 @@ import org.openrewrite.config.Environment;
 import org.openrewrite.gradle.Assertions;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
+
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -30,15 +31,15 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.openrewrite.gradle.Assertions.withToolingApi;
 import static org.openrewrite.maven.Assertions.pomXml;
 
-@Issue("https://github.com/openrewrite/rewrite-spring/issues/274 & https://github.com/openrewrite/rewrite-spring/issues/375")
+@Issue("https://github.com/openrewrite/rewrite-spring/issues/274")
 public class UpdateMysqlDriverArtifactIdTest implements RewriteTest {
 
     @Override
     public void defaults(RecipeSpec spec) {
         spec.recipe(Environment.builder()
-                               .scanRuntimeClasspath("org.openrewrite.java.spring.boot2")
-                               .build()
-                               .activateRecipes("org.openrewrite.java.spring.boot2.UpgradeSpringBoot_2_7"));
+          .scanRuntimeClasspath("org.openrewrite.java.spring.boot2")
+          .build()
+          .activateRecipes("org.openrewrite.java.spring.boot2.UpgradeSpringBoot_2_7"));
     }
 
     @Nested
@@ -48,160 +49,174 @@ public class UpdateMysqlDriverArtifactIdTest implements RewriteTest {
         void switchArtifactIdAndUpdateVersionNumber() {
             rewriteRun(
               //language=xml
-              pomXml("""
-                     <project>
-                       <modelVersion>4.0.0</modelVersion>
-                       <groupId>com.example</groupId>
-                       <artifactId>demo</artifactId>
-                       <version>0.0.1-SNAPSHOT</version>
-                       <dependencies>
-                         <dependency>
-                           <groupId>mysql</groupId>
-                           <artifactId>mysql-connector-java</artifactId>
-                           <version>8.0.30</version>
-                           <scope>runtime</scope>
-                         </dependency>
-                       </dependencies>
-                     </project>
-                     """, """
-                          <project>
-                            <modelVersion>4.0.0</modelVersion>
-                            <groupId>com.example</groupId>
-                            <artifactId>demo</artifactId>
-                            <version>0.0.1-SNAPSHOT</version>
-                            <dependencies>
-                              <dependency>
-                                <groupId>com.mysql</groupId>
-                                <artifactId>mysql-connector-j</artifactId>
-                                <version>8.0.33</version>
-                                <scope>runtime</scope>
-                              </dependency>
-                            </dependencies>
-                          </project>
-                          """));
+              pomXml(
+                """
+                  <project>
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>com.example</groupId>
+                    <artifactId>demo</artifactId>
+                    <version>0.0.1-SNAPSHOT</version>
+                    <dependencies>
+                      <dependency>
+                        <groupId>mysql</groupId>
+                        <artifactId>mysql-connector-java</artifactId>
+                        <version>8.0.30</version>
+                        <scope>runtime</scope>
+                      </dependency>
+                    </dependencies>
+                  </project>
+                  """,
+                """
+                  <project>
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>com.example</groupId>
+                    <artifactId>demo</artifactId>
+                    <version>0.0.1-SNAPSHOT</version>
+                    <dependencies>
+                      <dependency>
+                        <groupId>com.mysql</groupId>
+                        <artifactId>mysql-connector-j</artifactId>
+                        <version>8.0.33</version>
+                        <scope>runtime</scope>
+                      </dependency>
+                    </dependencies>
+                  </project>
+                  """));
         }
 
         @Test
         void doNotPinWhenNotVersioned() {
-            rewriteRun(pomXml(
-              //language=xml
-              """
-              <project>
-                <modelVersion>4.0.0</modelVersion>
-                <groupId>com.example</groupId>
-                <artifactId>demo</artifactId>
-                <version>0.0.1-SNAPSHOT</version>
-                <parent>
-                  <groupId>org.springframework.boot</groupId>
-                  <artifactId>spring-boot-starter-parent</artifactId>
-                  <version>2.7.7</version>
-                  <relativePath/> <!-- lookup parent from repository -->
-                </parent>
-                <dependencies>
-                  <dependency>
-                    <groupId>mysql</groupId>
-                    <artifactId>mysql-connector-java</artifactId>
-                    <scope>runtime</scope>
-                  </dependency>
-                </dependencies>
-              </project>
-              """, spec -> spec.after(pom -> {
-                  Matcher version = Pattern.compile("2.7.\\d+").matcher(pom);
-                  assertThat(version.find()).describedAs("Expected 2.7.x in %s", pom).isTrue();
-                  //language=xml
-                  return String.format("""
-                                       <project>
-                                         <modelVersion>4.0.0</modelVersion>
-                                         <groupId>com.example</groupId>
-                                         <artifactId>demo</artifactId>
-                                         <version>0.0.1-SNAPSHOT</version>
-                                         <parent>
-                                           <groupId>org.springframework.boot</groupId>
-                                           <artifactId>spring-boot-starter-parent</artifactId>
-                                           <version>%s</version>
-                                           <relativePath/> <!-- lookup parent from repository -->
-                                         </parent>
-                                         <dependencies>
-                                           <dependency>
-                                             <groupId>com.mysql</groupId>
-                                             <artifactId>mysql-connector-j</artifactId>
-                                             <scope>runtime</scope>
-                                           </dependency>
-                                         </dependencies>
-                                       </project>
-                                       """, version.group(0));
-              })));
+            rewriteRun(
+              pomXml(
+                //language=xml
+                """
+                  <project>
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>com.example</groupId>
+                    <artifactId>demo</artifactId>
+                    <version>0.0.1-SNAPSHOT</version>
+                    <parent>
+                      <groupId>org.springframework.boot</groupId>
+                      <artifactId>spring-boot-starter-parent</artifactId>
+                      <version>2.7.7</version>
+                      <relativePath/> <!-- lookup parent from repository -->
+                    </parent>
+                    <dependencies>
+                      <dependency>
+                        <groupId>mysql</groupId>
+                        <artifactId>mysql-connector-java</artifactId>
+                        <scope>runtime</scope>
+                      </dependency>
+                    </dependencies>
+                  </project>
+                  """,
+                spec -> spec.after(pom -> {
+                    Matcher version = Pattern.compile("2.7.\\d+").matcher(pom);
+                    assertThat(version.find()).describedAs("Expected 2.7.x in %s", pom).isTrue();
+                    //language=xml
+                    return String.format(
+                      """
+                        <project>
+                          <modelVersion>4.0.0</modelVersion>
+                          <groupId>com.example</groupId>
+                          <artifactId>demo</artifactId>
+                          <version>0.0.1-SNAPSHOT</version>
+                          <parent>
+                            <groupId>org.springframework.boot</groupId>
+                            <artifactId>spring-boot-starter-parent</artifactId>
+                            <version>%s</version>
+                            <relativePath/> <!-- lookup parent from repository -->
+                          </parent>
+                          <dependencies>
+                            <dependency>
+                              <groupId>com.mysql</groupId>
+                              <artifactId>mysql-connector-j</artifactId>
+                              <scope>runtime</scope>
+                            </dependency>
+                          </dependencies>
+                        </project>
+                        """, version.group(0));
+                })
+              )
+            );
         }
     }
 
     @Nested
+    @Issue("https://github.com/openrewrite/rewrite-spring/issues/375")
     class Gradle {
 
         @DocumentExample
         @Test
-        void gradleSwitchArtifactIdAndUpdateVersionNumber() {
+        void switchArtifactIdAndUpdateVersionNumber() {
             rewriteRun(spec -> spec.beforeRecipe(withToolingApi()),
-                       //language=groovy
-                       Assertions.buildGradle("""
-                                              plugins {
-                                                id 'java'
-                                              }
-                                                                   
-                                              repositories {
-                                                 mavenCentral()
-                                              }
-                                                                   
-                                              dependencies {
-                                                  runtimeOnly 'mysql:mysql-connector-java:8.0.30'
-                                              }
-                                              """, """
-                                                   plugins {
-                                                     id 'java'
-                                                   }
-                                                                        
-                                                   repositories {
-                                                      mavenCentral()
-                                                   }
-                                                                        
-                                                   dependencies {
-                                                       runtimeOnly 'com.mysql:mysql-connector-j:8.0.33'
-                                                   }
-                                                   """));
+              //language=groovy
+              Assertions.buildGradle(
+                """
+                  plugins {
+                    id 'java'
+                  }
+                                       
+                  repositories {
+                     mavenCentral()
+                  }
+                                       
+                  dependencies {
+                      runtimeOnly 'mysql:mysql-connector-java:8.0.30'
+                  }
+                  """,
+                """
+                  plugins {
+                    id 'java'
+                  }
+                                       
+                  repositories {
+                     mavenCentral()
+                  }
+                                       
+                  dependencies {
+                      runtimeOnly 'com.mysql:mysql-connector-j:8.0.33'
+                  }
+                  """)
+            );
         }
 
         @Test
-        void gradleDoNotPinWhenNotVersioned() {
+        void doNotPinWhenNotVersioned() {
             rewriteRun(spec -> spec.beforeRecipe(withToolingApi()),
-                       //language=groovy
-                       Assertions.buildGradle("""
-                                              plugins {
-                                                id 'java'
-                                                id 'org.springframework.boot' version '2.6.1'
-                                                id 'io.spring.dependency-management' version '1.0.11.RELEASE'
-                                              }
-                                                                                        
-                                              repositories {
-                                                 mavenCentral()
-                                              }
-                                                                   
-                                              dependencies {
-                                                  runtimeOnly 'mysql:mysql-connector-java'
-                                              }
-                                              """, """
-                                                   plugins {
-                                                     id 'java'
-                                                     id 'org.springframework.boot' version '2.6.1'
-                                                     id 'io.spring.dependency-management' version '1.0.11.RELEASE'
-                                                   }
-                                                                        
-                                                   repositories {
-                                                      mavenCentral()
-                                                   }
-                                                                        
-                                                   dependencies {
-                                                       runtimeOnly 'com.mysql:mysql-connector-j'
-                                                   }
-                                                   """));
+              //language=groovy
+              Assertions.buildGradle(
+                """
+                  plugins {
+                    id 'java'
+                    id 'org.springframework.boot' version '2.6.1'
+                    id 'io.spring.dependency-management' version '1.0.11.RELEASE'
+                  }
+                                                            
+                  repositories {
+                     mavenCentral()
+                  }
+                                       
+                  dependencies {
+                      runtimeOnly 'mysql:mysql-connector-java'
+                  }
+                  """,
+                """
+                  plugins {
+                    id 'java'
+                    id 'org.springframework.boot' version '2.6.1'
+                    id 'io.spring.dependency-management' version '1.0.11.RELEASE'
+                  }
+                                       
+                  repositories {
+                     mavenCentral()
+                  }
+                                       
+                  dependencies {
+                      runtimeOnly 'com.mysql:mysql-connector-j'
+                  }
+                  """)
+            );
         }
     }
 }


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?

Adapted the maven specific mysql dependency update to the generic one to include gradle

## What's your motivation?

Fixes #375 

### Checklist
- [X] I've added unit tests to cover both positive and negative cases
- [X] I've added the license header to any new files through `./gradlew licenseFormat`
- [X] I've used the IntelliJ auto-formatter on affected files
- [X] I've updated the documentation (if applicable)
