### PR TITLE
fix: use default values for propertyKey and tlsPropertyKey when empty string.

### DIFF
--- a/src/main/java/org/openrewrite/java/spring/amqp/UseTlsAmqpConnectionString.java
+++ b/src/main/java/org/openrewrite/java/spring/amqp/UseTlsAmqpConnectionString.java
@@ -79,7 +79,7 @@ public class UseTlsAmqpConnectionString extends Recipe {
     @Option(displayName = "Optional list of file path matcher",
             description = "Each value in this list represents a glob expression that is used to match which files will " +
                     "be modified. If this value is not present, this recipe will query the execution context for " +
-                    "reasonable defaults. (\"**/application.yml\", \"**/application.yml\", and \"**/application.properties\".",
+                    "reasonable defaults. (\"**/application.yml\", \"**/application.yaml\", and \"**/application.properties\".",
             example = "**/application.yml",
             required = false)
     @Nullable
@@ -97,8 +97,8 @@ public class UseTlsAmqpConnectionString extends Recipe {
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
-        String actualPropertyKey = propertyKey == null ? "spring.rabbitmq.addresses" : propertyKey;
-        String actualTlsPropertyKey = tlsPropertyKey == null ? "spring.rabbitmq.ssl.enabled" : tlsPropertyKey;
+        String actualPropertyKey = propertyKey == null || propertyKey.isEmpty() ? "spring.rabbitmq.addresses" : propertyKey;
+        String actualTlsPropertyKey = tlsPropertyKey == null || tlsPropertyKey.isEmpty() ? "spring.rabbitmq.ssl.enabled" : tlsPropertyKey;
         return new TreeVisitor<Tree, ExecutionContext>() {
             @Override
             public boolean isAcceptable(SourceFile sourceFile, ExecutionContext ctx) {

--- a/src/test/java/org/openrewrite/java/spring/amqp/UseTlsAmqpConnectionStringTest.java
+++ b/src/test/java/org/openrewrite/java/spring/amqp/UseTlsAmqpConnectionStringTest.java
@@ -62,6 +62,38 @@ class UseTlsAmqpConnectionStringTest implements RewriteTest {
     }
 
     @Test
+    void useTlsEmptyProperties() {
+        rewriteRun(
+          spec ->  spec.recipe(new UseTlsAmqpConnectionString("", 5672, 5671, null, null)),
+          yaml(
+            """
+              spring:
+                rabbitmq:
+                  addresses: host1:5672
+              """,
+            """
+              spring:
+                rabbitmq:
+                  addresses: host1:5671
+                  ssl:
+                    enabled: true
+              """,
+            spec -> spec.path("application.yml")
+          ),
+          properties(
+            """
+              spring.rabbitmq.addresses=host1:5672
+              """,
+            """
+              spring.rabbitmq.addresses=host1:5671
+              spring.rabbitmq.ssl.enabled=true
+              """,
+            spec -> spec.path("application.properties")
+          )
+        );
+    }
+
+    @Test
     void multipleAddresses() {
         rewriteRun(
           yaml(


### PR DESCRIPTION
## What's changed?
src/main/java/org/openrewrite/java/spring/amqp/UseTlsAmqpConnectionString.java recipe will now use default values for `propertyKey` and `tlsPropertyKey` when these options are supplied as empty strings. 

## What's your motivation?
The recipe does not default options when an empty string is supplied and an empty string is not a valid key. 

## Anyone you would like to review specifically?
@shanman190 

## Have you considered any alternatives or workarounds?
For the Moderne SaaS the alternative is to not default strings to "" which may happen from this PR: https://github.com/openrewrite/rewrite/pull/3404/files.


### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've added the license header to any new files through `./gradlew licenseFormat`
- [x] I've used the IntelliJ auto-formatter on affected files
- [x] I've updated the documentation (if applicable)
