### PR TITLE
chore: pull Spring Boot 2.7 type changes into a separate recipe

### DIFF
--- a/src/main/resources/META-INF/rewrite/spring-boot-27.yml
+++ b/src/main/resources/META-INF/rewrite/spring-boot-27.yml
@@ -39,19 +39,7 @@ recipeList:
   - org.openrewrite.gradle.plugins.UpgradePluginVersion:
       pluginIdPattern: org.springframework.boot
       newVersion: 2.7.x
-  # Use recommended replacements for deprecated APIs
-  - org.openrewrite.java.ChangeType:
-      oldFullyQualifiedTypeName: org.springframework.boot.web.server.LocalServerPort
-      newFullyQualifiedTypeName: org.springframework.boot.test.web.server.LocalServerPort
-  - org.openrewrite.java.ChangeType:
-      oldFullyQualifiedTypeName: org.springframework.boot.actuate.autoconfigure.web.server.LocalManagementPort
-      newFullyQualifiedTypeName: org.springframework.boot.test.web.server.LocalManagementPort
-  - org.openrewrite.java.ChangeType:
-      oldFullyQualifiedTypeName: org.springframework.boot.rsocket.context.LocalRSocketServerPort
-      newFullyQualifiedTypeName: org.springframework.boot.test.rsocket.server.LocalRSocketServerPort
-  - org.openrewrite.java.ChangeType:
-      oldFullyQualifiedTypeName: org.springframework.boot.orm.jpa.hibernate.SpringPhysicalNamingStrategy
-      newFullyQualifiedTypeName: org.hibernate.boot.model.naming.CamelCaseToUnderscoresNamingStrategy
+  - org.openrewrite.java.spring.boot2.SpringBootTypeChanges_2_7
   - org.openrewrite.java.spring.boot2.SpringBootProperties_2_7
   # Switch MySQL driver artifactId
   - org.openrewrite.java.dependencies.ChangeDependency:
@@ -138,3 +126,27 @@ recipeList:
       propertyKey: spring.jpa.hibernate.naming.physical-strategy
       oldValue: org.springframework.boot.orm.jpa.hibernate.SpringPhysicalNamingStrategy
       newValue: org.hibernate.boot.model.naming.CamelCaseToUnderscoresNamingStrategy
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.spring.boot2.SpringBootTypeChanges_2_7
+displayName: Migrate deprecated APIs to the recommended replacements for Spring Boot 2.7
+description: >
+  Migrate applications to the latest Spring Boot 2.7 release. This recipe will replace APIs deprecated in the previous 
+  version with the recommended replacement for Spring Boot 2.7
+tags:
+  - spring
+  - boot
+recipeList:
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.springframework.boot.web.server.LocalServerPort
+      newFullyQualifiedTypeName: org.springframework.boot.test.web.server.LocalServerPort
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.springframework.boot.actuate.autoconfigure.web.server.LocalManagementPort
+      newFullyQualifiedTypeName: org.springframework.boot.test.web.server.LocalManagementPort
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.springframework.boot.rsocket.context.LocalRSocketServerPort
+      newFullyQualifiedTypeName: org.springframework.boot.test.rsocket.server.LocalRSocketServerPort
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.springframework.boot.orm.jpa.hibernate.SpringPhysicalNamingStrategy
+      newFullyQualifiedTypeName: org.hibernate.boot.model.naming.CamelCaseToUnderscoresNamingStrategy


### PR DESCRIPTION
## What's changed?
Functionally nothing. Trivial refactoring.

## What's your motivation?
I would like to have the possibility to run a recipe for migrating deprecated APIs to the recommended replacements separately from the main `org.openrewrite.java.spring.boot2.UpgradeSpringBoot_2_7`. 

Generally speaking, the more granular OpenRewrite recipes are the most useful they are for our needs (since we cherry-pick only what we need).

## Have you considered any alternatives or workarounds?
The alternative is to just invoke `org.openrewrite.java.spring.boot2.UpgradeSpringBoot_2_7` but we are already on Spring Boot 2.7 and only have a couple of dozens of usages of deprecated types and nothing else from the recipe seems to apply.

### Checklist
- [x] I've used the IntelliJ auto-formatter on affected files
