### PR TITLE
re-enabled the UpdateGradle recipes

### DIFF
--- a/src/main/resources/META-INF/rewrite/spring-boot-20.yml
+++ b/src/main/resources/META-INF/rewrite/spring-boot-20.yml
@@ -43,9 +43,9 @@ recipeList:
       pluginIdPattern: org.springframework.boot
       newVersion: 2.0.x
   - org.openrewrite.gradle.spring.AddSpringDependencyManagementPlugin
-#  - org.openrewrite.gradle.UpdateGradleWrapper:
-#      version: 4.x
-#      addIfMissing: false
+  - org.openrewrite.gradle.UpdateGradleWrapper:
+      version: 4.x
+      addIfMissing: false
   - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
       groupId: org.mockito
       artifactId: "*"

--- a/src/main/resources/META-INF/rewrite/spring-boot-21.yml
+++ b/src/main/resources/META-INF/rewrite/spring-boot-21.yml
@@ -45,9 +45,9 @@ recipeList:
   - org.openrewrite.gradle.plugins.UpgradePluginVersion:
       pluginIdPattern: io.spring.dependency-management
       newVersion: 1.0.10.RELEASE
-#  - org.openrewrite.gradle.UpdateGradleWrapper:
-#      version: ^4.4
-#      addIfMissing: false
+  - org.openrewrite.gradle.UpdateGradleWrapper:
+      version: ^4.4
+      addIfMissing: false
   # Use recommended replacements for deprecated APIs
   - org.openrewrite.java.spring.boot2.MigrateRestTemplateBuilderBasicAuthorization
   - org.openrewrite.java.spring.boot2.MigrateRestTemplateBuilderTimeoutByInt

--- a/src/main/resources/META-INF/rewrite/spring-boot-22.yml
+++ b/src/main/resources/META-INF/rewrite/spring-boot-22.yml
@@ -46,9 +46,9 @@ recipeList:
   - org.openrewrite.gradle.plugins.UpgradePluginVersion:
       pluginIdPattern: io.spring.dependency-management
       newVersion: 1.0.11.RELEASE
-#  - org.openrewrite.gradle.UpdateGradleWrapper:
-#      version: ^4.10
-#      addIfMissing: false
+  - org.openrewrite.gradle.UpdateGradleWrapper:
+      version: ^4.10
+      addIfMissing: false
 
   # Use recommended replacements for deprecated APIs
   - org.openrewrite.java.spring.boot2.MigrateApplicationHealthIndicatorToPingHealthIndicator

--- a/src/main/resources/META-INF/rewrite/spring-boot-23.yml
+++ b/src/main/resources/META-INF/rewrite/spring-boot-23.yml
@@ -43,9 +43,9 @@ recipeList:
   - org.openrewrite.gradle.plugins.UpgradePluginVersion:
       pluginIdPattern: org.springframework.boot
       newVersion: 2.3.x
-#  - org.openrewrite.gradle.UpdateGradleWrapper:
-#      version: ^6.3
-#      addIfMissing: false
+  - org.openrewrite.gradle.UpdateGradleWrapper:
+      version: ^6.3
+      addIfMissing: false
   # https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.3-Release-Notes#validation-starter-no-longer-included-in-web-starters
   - org.openrewrite.java.dependencies.AddDependency:
       groupId: org.springframework.boot

--- a/src/main/resources/META-INF/rewrite/spring-boot-25.yml
+++ b/src/main/resources/META-INF/rewrite/spring-boot-25.yml
@@ -39,9 +39,9 @@ recipeList:
   - org.openrewrite.gradle.plugins.UpgradePluginVersion:
       pluginIdPattern: io.spring.dependency-management
       newVersion: 1.0.15.RELEASE
-#  - org.openrewrite.gradle.UpdateGradleWrapper:
-#      version: ^6.8
-#      addIfMissing: false
+  - org.openrewrite.gradle.UpdateGradleWrapper:
+      version: ^6.8
+      addIfMissing: false
   - org.openrewrite.java.spring.boot2.MigrateDatabaseCredentials
 
   # Use recommended replacements for deprecated APIs

--- a/src/main/resources/META-INF/rewrite/spring-boot-30.yml
+++ b/src/main/resources/META-INF/rewrite/spring-boot-30.yml
@@ -50,9 +50,9 @@ recipeList:
   - org.openrewrite.gradle.plugins.UpgradePluginVersion:
       pluginIdPattern: io.spring.dependency-management
       newVersion: 1.1.0
-#  - org.openrewrite.gradle.UpdateGradleWrapper:
-#      version: ^7.4
-#      addIfMissing: false
+  - org.openrewrite.gradle.UpdateGradleWrapper:
+      version: ^7.4
+      addIfMissing: false
   - org.openrewrite.java.migrate.jakarta.JavaxMigrationToJakarta
   - org.openrewrite.java.spring.boot3.RemoveConstructorBindingAnnotation
   - org.openrewrite.java.spring.boot2.MoveAutoConfigurationToImportsFile

--- a/src/testWithSpringBoot_2_7/java/org/openrewrite/gradle/spring/UpdateGradleTest.java
+++ b/src/testWithSpringBoot_2_7/java/org/openrewrite/gradle/spring/UpdateGradleTest.java
@@ -30,7 +30,6 @@ import static org.openrewrite.properties.Assertions.properties;
 import static org.openrewrite.test.SourceSpecs.other;
 import static org.openrewrite.test.SourceSpecs.text;
 
-@Disabled
 class UpdateGradleTest implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
@@ -66,7 +65,7 @@ class UpdateGradleTest implements RewriteTest {
             """
               plugins {
                   id "java"
-                  id "org.springframework.boot" version "2.7.13"
+                  id "org.springframework.boot" version "2.7.14"
                   id "io.spring.dependency-management" version "1.0.15.RELEASE"
               }
               
@@ -149,7 +148,7 @@ class UpdateGradleTest implements RewriteTest {
             """
               plugins {
                   id "java"
-                  id "org.springframework.boot" version "2.7.13"
+                  id "org.springframework.boot" version "2.7.14"
               }
               
               repositories {
@@ -157,7 +156,7 @@ class UpdateGradleTest implements RewriteTest {
               }
               
               dependencies {
-                  implementation platform("org.springframework.boot:spring-boot-dependencies:2.7.13")
+                  implementation platform("org.springframework.boot:spring-boot-dependencies:2.7.14")
                   implementation "org.springframework.boot:spring-boot-starter-web"
               }
               """


### PR DESCRIPTION
## What's changed?
Re-enabled all UpdateGradle recipes on SpringBoot migration recipes and re-enabled and fixed the tests

## What's your motivation?
We can run this recipe in a reliable way in the SaaS again, so it makes sense to add again the recipe to the SpringBoot migration recipes.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
