### PR TITLE
Ony selectively apply NoRequestMappingAnnotation

### DIFF
--- a/src/testWithSpringBoot_2_1/java/org/openrewrite/java/spring/NoRequestMappingAnnotationTest.java
+++ b/src/testWithSpringBoot_2_1/java/org/openrewrite/java/spring/NoRequestMappingAnnotationTest.java
@@ -97,7 +97,7 @@ class NoRequestMappingAnnotationTest implements RewriteTest {
                       return null;
                   }
 
-                  @GetMapping
+                  @RequestMapping
                   public ResponseEntity<List<String>> getUsersNoRequestMethod() {
                       return null;
                   }
@@ -117,6 +117,7 @@ class NoRequestMappingAnnotationTest implements RewriteTest {
               import org.springframework.http.ResponseEntity;
               import org.springframework.web.bind.annotation.RequestMapping;
               import org.springframework.web.bind.annotation.RestController;
+              import static org.springframework.web.bind.annotation.RequestMethod.POST;
               
               @RestController
               @RequestMapping("/users")
@@ -157,6 +158,7 @@ class NoRequestMappingAnnotationTest implements RewriteTest {
               import org.springframework.http.ResponseEntity;
               import org.springframework.web.bind.annotation.RequestMapping;
               import org.springframework.web.bind.annotation.RestController;
+              import static org.springframework.web.bind.annotation.RequestMethod.POST;
               
               @RestController
               public class UsersController {
@@ -194,6 +196,7 @@ class NoRequestMappingAnnotationTest implements RewriteTest {
               import java.util.*;
               import org.springframework.http.ResponseEntity;
               import org.springframework.web.bind.annotation.RequestMapping;
+              import org.springframework.web.bind.annotation.RequestMethod;
               
               @RestController
               @RequestMapping("/users")
@@ -296,10 +299,11 @@ class NoRequestMappingAnnotationTest implements RewriteTest {
           java(
             """
               import org.springframework.web.bind.annotation.RequestMapping;
+              import org.springframework.web.bind.annotation.RequestMethod;
               
               class Test {
                   class Inner {
-                      @RequestMapping("/api")
+                      @RequestMapping(method = RequestMethod.GET, value = "/api")
                       void test() {
                       }
                   }


### PR DESCRIPTION
## What's changed?
Only apply NoRequestMappingAnnotation if there's a `method` argument with a target mapping annotation replacement.

## What's your motivation?
`@RequestMapping` without `method` matches all methods, so it's not safe to convert.

## Have you considered any alternatives or workarounds?
We could add a comment to the `@RequestMapping("/foo")` annotations that these require work, but that produce a lot of such messages.

## Any additional context
Previously we matched all, or even missing methods; that's a bug.