### PR TITLE
first approach of HttpClient5 migration

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -126,6 +126,8 @@ dependencies {
 
     testRuntimeOnly("ch.qos.logback:logback-classic:1.+")
     testRuntimeOnly(gradleApi())
+    testRuntimeOnly("org.apache.httpcomponents:httpclient:4.5.14")
+    testRuntimeOnly("org.apache.httpcomponents.client5:httpclient5:5.1.+")
 
     testImplementation("com.github.marschall:memoryfilesystem:latest.release")
 

--- a/src/main/resources/META-INF/rewrite/apache-httpclient-5.yml
+++ b/src/main/resources/META-INF/rewrite/apache-httpclient-5.yml
@@ -123,10 +123,6 @@ recipeList:
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: org.apache.hc.client5.http.impl.classic.BasicCredentialsProvider
       newFullyQualifiedTypeName: org.apache.hc.client5.http.impl.auth.BasicCredentialsProvider
-  # Fixing Depreacted
-  - org.openrewrite.java.ChangeType:
-      oldFullyQualifiedTypeName: org.apache.hc.client5.http.impl.classic.DefaultHttpClient
-      newFullyQualifiedTypeName: org.apache.hc.client5.http.impl.classic.CloseableHttpClient
 
   - org.openrewrite.java.ChangePackage:
       oldPackageName: org.apache.http.auth
@@ -377,10 +373,6 @@ recipeList:
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: org.apache.hc.client5.http.HttpConnectionFactory
       newFullyQualifiedTypeName: org.apache.hc.core5.http.io.HttpConnectionFactory
-  # Fixing Deprecated
-  - org.openrewrite.java.ChangeType:
-      oldFullyQualifiedTypeName: org.apache.hc.client5.http.ClientConnectionManager
-      newFullyQualifiedTypeName: org.apache.hc.client5.http.io.HttpClientConnectionManager
 
   - org.openrewrite.java.ChangePackage:
       oldPackageName: org.apache.http

--- a/src/main/resources/META-INF/rewrite/apache-httpclient-5.yml
+++ b/src/main/resources/META-INF/rewrite/apache-httpclient-5.yml
@@ -42,18 +42,9 @@ name: org.openrewrite.java.apache.httpclient5.UpgradeApacheHttpClient_5_ClassMap
 displayName: Migrate to ApacheHttpClient 5.x Classes Namespace from 4.x
 description: Mapping of all the compatible classes of ApacheHttpClient 5.x from 4.x.
 recipeList:
-  - org.openrewrite.java.dependencies.ChangeDependency:
-      oldGroupId: org.apache.httpcomponents
-      oldArtifactId: httpclient
-      newGroupId: org.apache.httpcomponents.client5
-      newArtifactId: httpclient5
-      newVersion: 5.1.x
-      overrideManagedVersion: true
-
   - org.openrewrite.java.ChangePackage:
       oldPackageName: org.apache.http.client.methods
       newPackageName: org.apache.hc.client5.http.classic.methods
-      recursive: "False"
   # Fixing specific mappings
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: org.apache.hc.client5.http.classic.methods.CloseableHttpResponse
@@ -62,32 +53,25 @@ recipeList:
   - org.openrewrite.java.ChangePackage:
       oldPackageName: org.apache.http.client.entity
       newPackageName: org.apache.hc.client5.http.entity
-      recursive: "False"
   - org.openrewrite.java.ChangePackage:
       oldPackageName: org.apache.http.client.protocol
       newPackageName: org.apache.hc.client5.http.protocol
-      recursive: "False"
   - org.openrewrite.java.ChangePackage:
       oldPackageName: org.apache.http.conn.socket
       newPackageName: org.apache.hc.client5.http.socket
-      recursive: "False"
   - org.openrewrite.java.ChangePackage:
       oldPackageName: org.apache.http.ssl
       newPackageName: org.apache.hc.core5.ssl
-      recursive: "False"
   - org.openrewrite.java.ChangePackage:
       oldPackageName: org.apache.http.concurrent
       newPackageName: org.apache.hc.core5.concurrent
-      recursive: "False"
   - org.openrewrite.java.ChangePackage:
       oldPackageName: org.apache.http.impl.auth
       newPackageName: org.apache.hc.client5.http.impl.auth
-      recursive: "False"
 
   - org.openrewrite.java.ChangePackage:
       oldPackageName: org.apache.http.impl.cookie
       newPackageName: org.apache.hc.client5.http.impl.cookie
-      recursive: "False"
   # Fixing specific mappings
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: org.apache.hc.client5.http.impl.cookie.PublicSuffixListParser
@@ -99,7 +83,6 @@ recipeList:
   - org.openrewrite.java.ChangePackage:
       oldPackageName: org.apache.http.impl.client
       newPackageName: org.apache.hc.client5.http.impl.classic
-      recursive: "False"
   # Fixing specific mappings
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: org.apache.hc.client5.http.impl.classic.BasicAuthCache
@@ -148,33 +131,26 @@ recipeList:
   - org.openrewrite.java.ChangePackage:
       oldPackageName: org.apache.http.auth
       newPackageName: org.apache.hc.client5.http.auth
-      recursive: "False"
   - org.openrewrite.java.ChangePackage:
       oldPackageName: org.apache.http.cookie
       newPackageName: org.apache.hc.client5.http.cookie
-      recursive: "False"
   - org.openrewrite.java.ChangePackage:
       oldPackageName: org.apache.http.cookie
       newPackageName: org.apache.hc.client5.http.cookie
-      recursive: "False"
 
   - org.openrewrite.java.ChangePackage:
       oldPackageName: org.apache.http.annotation
       newPackageName: org.apache.hc.core5.annotation
-      recursive: "False"
   - org.openrewrite.java.ChangePackage:
       oldPackageName: org.apache.http.client.config
       newPackageName: org.apache.hc.client5.http.config
-      recursive: "False"
   - org.openrewrite.java.ChangePackage:
       oldPackageName: org.apache.http.annotation
       newPackageName: org.apache.hc.core5.annotation
-      recursive: "False"
 
   - org.openrewrite.java.ChangePackage:
       oldPackageName: org.apache.http.entity
       newPackageName: org.apache.hc.core5.http.io.entity
-      recursive: "False"
   # Fixing specific mappings
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: org.apache.hc.core5.http.io.entity.ContentLengthStrategy
@@ -186,12 +162,10 @@ recipeList:
   - org.openrewrite.java.ChangePackage:
       oldPackageName: org.apache.http.impl.bootstrap
       newPackageName: org.apache.hc.core5.http.impl.bootstrap
-      recursive: "False"
 
   - org.openrewrite.java.ChangePackage:
       oldPackageName: org.apache.http.impl.execchain
       newPackageName: org.apache.hc.client5.http.impl.classic
-      recursive: "False"
   # Fixing specific mappings
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: org.apache.hc.client5.http.impl.classic.TunnelRefusedException
@@ -200,7 +174,6 @@ recipeList:
   - org.openrewrite.java.ChangePackage:
       oldPackageName: org.apache.http.impl.io
       newPackageName: org.apache.hc.core5.http.impl.io
-      recursive: "False"
   # Fixing specific mappings
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: org.apache.hc.core5.http.impl.io.DefaultHttpResponseParserFactory
@@ -209,20 +182,16 @@ recipeList:
   - org.openrewrite.java.ChangePackage:
       oldPackageName: org.apache.http.io
       newPackageName: org.apache.hc.core5.http.io
-      recursive: "False"
   - org.openrewrite.java.ChangePackage:
       oldPackageName: org.apache.http.message
       newPackageName: org.apache.hc.core5.http.message
-      recursive: "False"
   - org.openrewrite.java.ChangePackage:
       oldPackageName: org.apache.http.pool
       newPackageName: org.apache.hc.core5.pool
-      recursive: "False"
 
   - org.openrewrite.java.ChangePackage:
       oldPackageName: org.apache.http.protocol
       newPackageName: org.apache.hc.core5.http.protocol
-      recursive: "False"
   # Fixing specific mappings
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: org.apache.hc.core5.http.protocol.HttpService
@@ -237,7 +206,6 @@ recipeList:
   - org.openrewrite.java.ChangePackage:
       oldPackageName: org.apache.http.util
       newPackageName: org.apache.hc.core5.util
-      recursive: "False"
   # Fixing specific mappings
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: org.apache.hc.core5.util.EntityUtils
@@ -260,7 +228,6 @@ recipeList:
   - org.openrewrite.java.ChangePackage:
       oldPackageName: org.apache.http.client
       newPackageName: org.apache.hc.client5.http
-      recursive: "False"
   # Fixing specific mappings
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: org.apache.hc.client5.http.CredentialsProvider
@@ -287,7 +254,6 @@ recipeList:
   - org.openrewrite.java.ChangePackage:
       oldPackageName: org.apache.http.config
       newPackageName: org.apache.hc.core5.http.config
-      recursive: "False"
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: org.apache.http.config.SocketConfig
       newFullyQualifiedTypeName: org.apache.hc.core5.http.io.SocketConfig
@@ -295,7 +261,6 @@ recipeList:
   - org.openrewrite.java.ChangePackage:
       oldPackageName: org.apache.http.impl
       newPackageName: org.apache.hc.core5.http.impl.io
-      recursive: "False"
   # Fixing specific mappings
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: org.apache.hc.core5.http.impl.io.EnglishReasonPhraseCatalog
@@ -313,7 +278,6 @@ recipeList:
   - org.openrewrite.java.ChangePackage:
       oldPackageName: org.apache.http.conn
       newPackageName: org.apache.hc.client5.http
-      recursive: "False"
   # Fixing specific mappings
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: org.apache.hc.client5.http.ManagedHttpClientConnection
@@ -337,17 +301,10 @@ recipeList:
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: org.apache.hc.client5.http.ClientConnectionManager
       newFullyQualifiedTypeName: org.apache.hc.client5.http.io.HttpClientConnectionManager
-  - org.openrewrite.java.ChangeType:
-      oldFullyQualifiedTypeName: org.apache.hc.client5.http.HttpRoutedConnection
-      newFullyQualifiedTypeName: org.apache.hc.client5.http.io.HttpClientConnectionManager
-  - org.openrewrite.java.ChangeType:
-      oldFullyQualifiedTypeName: org.apache.hc.client5.http.ManagedClientConnection
-      newFullyQualifiedTypeName: org.apache.hc.client5.http.io.HttpClientConnectionManager
 
   - org.openrewrite.java.ChangePackage:
       oldPackageName: org.apache.http.conn.util
       newPackageName: org.apache.hc.client5.http.psl
-      recursive: "False"
   # Fixing specific mappings
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: org.apache.hc.client5.http.psl.DnsUtils
@@ -359,7 +316,6 @@ recipeList:
   - org.openrewrite.java.ChangePackage:
       oldPackageName: org.apache.http.conn.routing
       newPackageName: org.apache.hc.client5.http
-      recursive: "False"
   # Fixing specific mappings
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: org.apache.hc.client5.http.BasicRouteDirector
@@ -374,7 +330,6 @@ recipeList:
   - org.openrewrite.java.ChangePackage:
       oldPackageName: org.apache.http.conn.ssl
       newPackageName: org.apache.hc.core5.ssl
-      recursive: "False"
   # Fixing specific mappings
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: org.apache.hc.core5.ssl.SSLConnectionSocketFactory
@@ -398,7 +353,6 @@ recipeList:
   - org.openrewrite.java.ChangePackage:
       oldPackageName: org.apache.http.impl.conn
       newPackageName: org.apache.hc.client5.http.impl.io
-      recursive: "False"
   # Fixing specific mappings
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: org.apache.hc.client5.http.impl.io.SystemDefaultDnsResolver
@@ -431,7 +385,6 @@ recipeList:
   - org.openrewrite.java.ChangePackage:
       oldPackageName: org.apache.http
       newPackageName: org.apache.hc.core5.http
-      recursive: "False"
   # Fixing specific mappings
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: org.apache.hc.core5.http.RequestLine

--- a/src/main/resources/META-INF/rewrite/apache-httpclient-5.yml
+++ b/src/main/resources/META-INF/rewrite/apache-httpclient-5.yml
@@ -276,33 +276,6 @@ recipeList:
       newFullyQualifiedTypeName: org.apache.hc.core5.http.impl.nio.DefaultHttpResponseFactory
 
   - org.openrewrite.java.ChangePackage:
-      oldPackageName: org.apache.http.conn
-      newPackageName: org.apache.hc.client5.http
-  # Fixing specific mappings
-  - org.openrewrite.java.ChangeType:
-      oldFullyQualifiedTypeName: org.apache.hc.client5.http.ManagedHttpClientConnection
-      newFullyQualifiedTypeName: org.apache.hc.client5.http.io.ManagedHttpClientConnection
-  - org.openrewrite.java.ChangeType:
-      oldFullyQualifiedTypeName: org.apache.hc.client5.http.HttpClientConnectionManager
-      newFullyQualifiedTypeName: org.apache.hc.client5.http.io.HttpClientConnectionManager
-  - org.openrewrite.java.ChangeType:
-      oldFullyQualifiedTypeName: org.apache.hc.client5.http.HttpClientConnectionOperator
-      newFullyQualifiedTypeName: org.apache.hc.client5.http.io.HttpClientConnectionOperator
-  - org.openrewrite.java.ChangeType:
-      oldFullyQualifiedTypeName: org.apache.hc.client5.http.EofSensorWatcher
-      newFullyQualifiedTypeName: org.apache.hc.core5.http.io.EofSensorWatcher
-  - org.openrewrite.java.ChangeType:
-      oldFullyQualifiedTypeName: org.apache.hc.client5.http.EofSensorInputStream
-      newFullyQualifiedTypeName: org.apache.hc.core5.http.io.EofSensorInputStream
-  - org.openrewrite.java.ChangeType:
-      oldFullyQualifiedTypeName: org.apache.hc.client5.http.HttpConnectionFactory
-      newFullyQualifiedTypeName: org.apache.hc.core5.http.io.HttpConnectionFactory
-  # Fixing Deprecated
-  - org.openrewrite.java.ChangeType:
-      oldFullyQualifiedTypeName: org.apache.hc.client5.http.ClientConnectionManager
-      newFullyQualifiedTypeName: org.apache.hc.client5.http.io.HttpClientConnectionManager
-
-  - org.openrewrite.java.ChangePackage:
       oldPackageName: org.apache.http.conn.util
       newPackageName: org.apache.hc.client5.http.psl
   # Fixing specific mappings
@@ -381,6 +354,33 @@ recipeList:
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: org.apache.hc.client5.http.impl.io.DefaultHttpResponseParser
       newFullyQualifiedTypeName: org.apache.hc.core5.http.impl.io.DefaultHttpResponseParser
+
+  - org.openrewrite.java.ChangePackage:
+      oldPackageName: org.apache.http.conn
+      newPackageName: org.apache.hc.client5.http
+  # Fixing specific mappings
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.hc.client5.http.ManagedHttpClientConnection
+      newFullyQualifiedTypeName: org.apache.hc.client5.http.io.ManagedHttpClientConnection
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.hc.client5.http.HttpClientConnectionManager
+      newFullyQualifiedTypeName: org.apache.hc.client5.http.io.HttpClientConnectionManager
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.hc.client5.http.HttpClientConnectionOperator
+      newFullyQualifiedTypeName: org.apache.hc.client5.http.io.HttpClientConnectionOperator
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.hc.client5.http.EofSensorWatcher
+      newFullyQualifiedTypeName: org.apache.hc.core5.http.io.EofSensorWatcher
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.hc.client5.http.EofSensorInputStream
+      newFullyQualifiedTypeName: org.apache.hc.core5.http.io.EofSensorInputStream
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.hc.client5.http.HttpConnectionFactory
+      newFullyQualifiedTypeName: org.apache.hc.core5.http.io.HttpConnectionFactory
+  # Fixing Deprecated
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.hc.client5.http.ClientConnectionManager
+      newFullyQualifiedTypeName: org.apache.hc.client5.http.io.HttpClientConnectionManager
 
   - org.openrewrite.java.ChangePackage:
       oldPackageName: org.apache.http

--- a/src/main/resources/META-INF/rewrite/apache-httpclient-5.yml
+++ b/src/main/resources/META-INF/rewrite/apache-httpclient-5.yml
@@ -1,0 +1,437 @@
+########################################################################################################################
+# Apache HttpClient 5.x
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.apache.httpclient5.UpgradeApacheHttpClient_5
+displayName: Migrate to ApacheHttpClient 5.x
+description: >
+  Migrate applications to the latest Apache HttpClient 5.x release. This recipe will modify an
+  application's build files, make changes to deprecated/preferred APIs, and migrate configuration settings that have
+  changes between versions.
+tags:
+  - apache
+  - httpclient
+recipeList:
+  - org.openrewrite.java.dependencies.ChangeDependency:
+      oldGroupId: org.apache.httpcomponents
+      oldArtifactId: httpclient
+      newGroupId: org.apache.httpcomponents.client5
+      newArtifactId: httpclient5
+      newVersion: 5.1.x
+      overrideManagedVersion: true
+  - org.openrewrite.java.apache.httpclient5.UpgradeApacheHttpClient_5_ClassMapping
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.apache.httpclient5.UpgradeApacheHttpClient_5_ClassMapping
+displayName: Migrate to ApacheHttpClient 5.x Classes Namespace from 4.x
+description: Mapping of all the compatible classes of ApacheHttpClient 5.x from 4.x.
+recipeList:
+  - org.openrewrite.java.dependencies.ChangeDependency:
+      oldGroupId: org.apache.httpcomponents
+      oldArtifactId: httpclient
+      newGroupId: org.apache.httpcomponents.client5
+      newArtifactId: httpclient5
+      newVersion: 5.1.x
+      overrideManagedVersion: true
+
+  - org.openrewrite.java.ChangePackage:
+      oldPackageName: org.apache.http.client.methods
+      newPackageName: org.apache.hc.client5.http.classic.methods
+      recursive: "False"
+  # Fixing specific mappings
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.hc.client5.http.classic.methods.CloseableHttpResponse
+      newFullyQualifiedTypeName: org.apache.hc.client5.http.impl.classic.CloseableHttpResponse
+
+  - org.openrewrite.java.ChangePackage:
+      oldPackageName: org.apache.http.client.entity
+      newPackageName: org.apache.hc.client5.http.entity
+      recursive: "False"
+  - org.openrewrite.java.ChangePackage:
+      oldPackageName: org.apache.http.client.protocol
+      newPackageName: org.apache.hc.client5.http.protocol
+      recursive: "False"
+  - org.openrewrite.java.ChangePackage:
+      oldPackageName: org.apache.http.conn.socket
+      newPackageName: org.apache.hc.client5.http.socket
+      recursive: "False"
+  - org.openrewrite.java.ChangePackage:
+      oldPackageName: org.apache.http.ssl
+      newPackageName: org.apache.hc.core5.ssl
+      recursive: "False"
+  - org.openrewrite.java.ChangePackage:
+      oldPackageName: org.apache.http.concurrent
+      newPackageName: org.apache.hc.core5.concurrent
+      recursive: "False"
+  - org.openrewrite.java.ChangePackage:
+      oldPackageName: org.apache.http.impl.auth
+      newPackageName: org.apache.hc.client5.http.impl.auth
+      recursive: "False"
+
+  - org.openrewrite.java.ChangePackage:
+      oldPackageName: org.apache.http.impl.cookie
+      newPackageName: org.apache.hc.client5.http.impl.cookie
+      recursive: "False"
+  # Fixing specific mappings
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.hc.client5.http.impl.cookie.PublicSuffixListParser
+      newFullyQualifiedTypeName: org.apache.hc.client5.http.psl.PublicSuffixListParser
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.hc.client5.http.impl.cookie.DateUtils
+      newFullyQualifiedTypeName: org.apache.hc.client5.http.utils.DateUtils
+
+  - org.openrewrite.java.ChangePackage:
+      oldPackageName: org.apache.http.impl.client
+      newPackageName: org.apache.hc.client5.http.impl.classic
+      recursive: "False"
+  # Fixing specific mappings
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.hc.client5.http.impl.classic.BasicAuthCache
+      newFullyQualifiedTypeName: org.apache.hc.client5.http.impl.auth.BasicAuthCache
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.hc.client5.http.impl.classic.HttpAuthenticator
+      newFullyQualifiedTypeName: org.apache.hc.client5.http.impl.auth.HttpAuthenticator
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.hc.client5.http.impl.classic.SystemDefaultCredentialsProvider
+      newFullyQualifiedTypeName: org.apache.hc.client5.http.impl.auth.SystemDefaultCredentialsProvider
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.hc.client5.http.impl.classic.DefaultClientConnectionReuseStrategy
+      newFullyQualifiedTypeName: org.apache.hc.client5.http.impl.DefaultClientConnectionReuseStrategy
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.hc.client5.http.impl.classic.DefaultRedirectStrategy
+      newFullyQualifiedTypeName: org.apache.hc.client5.http.impl.DefaultRedirectStrategy
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.hc.client5.http.impl.classic.RedirectLocations
+      newFullyQualifiedTypeName: org.apache.hc.client5.http.protocol.RedirectLocations
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.hc.client5.http.impl.classic.BasicCookieStore
+      newFullyQualifiedTypeName: org.apache.hc.client5.http.cookie.BasicCookieStore
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.hc.client5.http.impl.classic.DefaultConnectionKeepAliveStrategy
+      newFullyQualifiedTypeName: org.apache.hc.client5.http.impl.DefaultConnectionKeepAliveStrategy
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.hc.client5.http.impl.classic.IdleConnectionEvictor
+      newFullyQualifiedTypeName: org.apache.hc.client5.http.impl.IdleConnectionEvictor
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.hc.client5.http.impl.classic.TunnelRefusedException
+      newFullyQualifiedTypeName: org.apache.hc.client5.http.impl.TunnelRefusedException
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.hc.client5.http.impl.classic.NoopUserTokenHandler
+      newFullyQualifiedTypeName: org.apache.hc.client5.http.impl.NoopUserTokenHandler
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.hc.client5.http.impl.classic.DefaultUserTokenHandler
+      newFullyQualifiedTypeName: org.apache.hc.client5.http.impl.DefaultUserTokenHandler
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.hc.client5.http.impl.classic.BasicCredentialsProvider
+      newFullyQualifiedTypeName: org.apache.hc.client5.http.impl.auth.BasicCredentialsProvider
+  # Fixing Depreacted
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.hc.client5.http.impl.classic.DefaultHttpClient
+      newFullyQualifiedTypeName: org.apache.hc.client5.http.impl.classic.CloseableHttpClient
+
+  - org.openrewrite.java.ChangePackage:
+      oldPackageName: org.apache.http.auth
+      newPackageName: org.apache.hc.client5.http.auth
+      recursive: "False"
+  - org.openrewrite.java.ChangePackage:
+      oldPackageName: org.apache.http.cookie
+      newPackageName: org.apache.hc.client5.http.cookie
+      recursive: "False"
+  - org.openrewrite.java.ChangePackage:
+      oldPackageName: org.apache.http.cookie
+      newPackageName: org.apache.hc.client5.http.cookie
+      recursive: "False"
+
+  - org.openrewrite.java.ChangePackage:
+      oldPackageName: org.apache.http.annotation
+      newPackageName: org.apache.hc.core5.annotation
+      recursive: "False"
+  - org.openrewrite.java.ChangePackage:
+      oldPackageName: org.apache.http.client.config
+      newPackageName: org.apache.hc.client5.http.config
+      recursive: "False"
+  - org.openrewrite.java.ChangePackage:
+      oldPackageName: org.apache.http.annotation
+      newPackageName: org.apache.hc.core5.annotation
+      recursive: "False"
+
+  - org.openrewrite.java.ChangePackage:
+      oldPackageName: org.apache.http.entity
+      newPackageName: org.apache.hc.core5.http.io.entity
+      recursive: "False"
+  # Fixing specific mappings
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.hc.core5.http.io.entity.ContentLengthStrategy
+      newFullyQualifiedTypeName: org.apache.hc.core5.http.ContentLengthStrategy
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.hc.core5.http.io.entity.ContentType
+      newFullyQualifiedTypeName: org.apache.hc.core5.http.ContentType
+
+  - org.openrewrite.java.ChangePackage:
+      oldPackageName: org.apache.http.impl.bootstrap
+      newPackageName: org.apache.hc.core5.http.impl.bootstrap
+      recursive: "False"
+
+  - org.openrewrite.java.ChangePackage:
+      oldPackageName: org.apache.http.impl.execchain
+      newPackageName: org.apache.hc.client5.http.impl.classic
+      recursive: "False"
+  # Fixing specific mappings
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.hc.client5.http.impl.classic.TunnelRefusedException
+      newFullyQualifiedTypeName: org.apache.hc.client5.http.impl.TunnelRefusedException
+
+  - org.openrewrite.java.ChangePackage:
+      oldPackageName: org.apache.http.impl.io
+      newPackageName: org.apache.hc.core5.http.impl.io
+      recursive: "False"
+  # Fixing specific mappings
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.hc.core5.http.impl.io.DefaultHttpResponseParserFactory
+      newFullyQualifiedTypeName: org.apache.hc.client5.http.impl.io.DefaultHttpResponseParserFactory
+
+  - org.openrewrite.java.ChangePackage:
+      oldPackageName: org.apache.http.io
+      newPackageName: org.apache.hc.core5.http.io
+      recursive: "False"
+  - org.openrewrite.java.ChangePackage:
+      oldPackageName: org.apache.http.message
+      newPackageName: org.apache.hc.core5.http.message
+      recursive: "False"
+  - org.openrewrite.java.ChangePackage:
+      oldPackageName: org.apache.http.pool
+      newPackageName: org.apache.hc.core5.pool
+      recursive: "False"
+
+  - org.openrewrite.java.ChangePackage:
+      oldPackageName: org.apache.http.protocol
+      newPackageName: org.apache.hc.core5.http.protocol
+      recursive: "False"
+  # Fixing specific mappings
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.hc.core5.http.protocol.HttpService
+      newFullyQualifiedTypeName: org.apache.hc.core5.http.impl.io.HttpService
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.hc.core5.http.protocol.HttpRequestExecutor
+      newFullyQualifiedTypeName: org.apache.hc.core5.http.impl.io.HttpRequestExecutor
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.hc.core5.http.protocol.HttpRequestHandler
+      newFullyQualifiedTypeName: org.apache.hc.core5.http.io.HttpRequestHandler
+
+  - org.openrewrite.java.ChangePackage:
+      oldPackageName: org.apache.http.util
+      newPackageName: org.apache.hc.core5.util
+      recursive: "False"
+  # Fixing specific mappings
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.hc.core5.util.EntityUtils
+      newFullyQualifiedTypeName: org.apache.hc.core5.http.io.entity.EntityUtils
+
+  # Not worth do a ChangePackage here
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.http.client.utils.URIBuilder
+      newFullyQualifiedTypeName: org.apache.hc.core5.net.URIBuilder
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.http.client.utils.URLEncodedUtils
+      newFullyQualifiedTypeName: org.apache.hc.core5.net.URLEncodedUtils
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.http.client.utils.URIUtils
+      newFullyQualifiedTypeName: org.apache.hc.client5.http.utils.URIUtils
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.http.client.utils.DateUtils
+      newFullyQualifiedTypeName: org.apache.hc.client5.http.utils.DateUtils
+
+  - org.openrewrite.java.ChangePackage:
+      oldPackageName: org.apache.http.client
+      newPackageName: org.apache.hc.client5.http
+      recursive: "False"
+  # Fixing specific mappings
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.hc.client5.http.CredentialsProvider
+      newFullyQualifiedTypeName: org.apache.hc.client5.http.auth.CredentialsProvider
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.hc.client5.http.AuthCache
+      newFullyQualifiedTypeName: org.apache.hc.client5.http.auth.AuthCache
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.hc.client5.http.BackoffManager
+      newFullyQualifiedTypeName: org.apache.hc.client5.http.classic.BackoffManager
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.hc.client5.http.HttpClient
+      newFullyQualifiedTypeName: org.apache.hc.client5.http.classic.HttpClient
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.hc.client5.http.ConnectionBackoffStrategy
+      newFullyQualifiedTypeName: org.apache.hc.client5.http.classic.ConnectionBackoffStrategy
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.hc.client5.http.CookieStore
+      newFullyQualifiedTypeName: org.apache.hc.client5.http.cookie.CookieStore
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.hc.client5.http.RedirectStrategy
+      newFullyQualifiedTypeName: org.apache.hc.client5.http.protocol.RedirectStrategy
+
+  - org.openrewrite.java.ChangePackage:
+      oldPackageName: org.apache.http.config
+      newPackageName: org.apache.hc.core5.http.config
+      recursive: "False"
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.http.config.SocketConfig
+      newFullyQualifiedTypeName: org.apache.hc.core5.http.io.SocketConfig
+
+  - org.openrewrite.java.ChangePackage:
+      oldPackageName: org.apache.http.impl
+      newPackageName: org.apache.hc.core5.http.impl.io
+      recursive: "False"
+  # Fixing specific mappings
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.hc.core5.http.impl.io.EnglishReasonPhraseCatalog
+      newFullyQualifiedTypeName: org.apache.hc.core5.http.impl.EnglishReasonPhraseCatalog
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.hc.core5.http.impl.io.DefaultConnectionReuseStrategy
+      newFullyQualifiedTypeName: org.apache.hc.core5.http.impl.DefaultConnectionReuseStrategy
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.hc.core5.http.impl.io.DefaultHttpRequestFactory
+      newFullyQualifiedTypeName: org.apache.hc.core5.http.impl.nio.DefaultHttpRequestFactory
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.hc.core5.http.impl.io.DefaultHttpResponseFactory
+      newFullyQualifiedTypeName: org.apache.hc.core5.http.impl.nio.DefaultHttpResponseFactory
+
+  - org.openrewrite.java.ChangePackage:
+      oldPackageName: org.apache.http.conn
+      newPackageName: org.apache.hc.client5.http
+      recursive: "False"
+  # Fixing specific mappings
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.hc.client5.http.ManagedHttpClientConnection
+      newFullyQualifiedTypeName: org.apache.hc.client5.http.io.ManagedHttpClientConnection
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.hc.client5.http.HttpClientConnectionManager
+      newFullyQualifiedTypeName: org.apache.hc.client5.http.io.HttpClientConnectionManager
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.hc.client5.http.HttpClientConnectionOperator
+      newFullyQualifiedTypeName: org.apache.hc.client5.http.io.HttpClientConnectionOperator
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.hc.client5.http.EofSensorWatcher
+      newFullyQualifiedTypeName: org.apache.hc.core5.http.io.EofSensorWatcher
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.hc.client5.http.EofSensorInputStream
+      newFullyQualifiedTypeName: org.apache.hc.core5.http.io.EofSensorInputStream
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.hc.client5.http.HttpConnectionFactory
+      newFullyQualifiedTypeName: org.apache.hc.core5.http.io.HttpConnectionFactory
+  # Fixing Deprecated
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.hc.client5.http.ClientConnectionManager
+      newFullyQualifiedTypeName: org.apache.hc.client5.http.io.HttpClientConnectionManager
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.hc.client5.http.HttpRoutedConnection
+      newFullyQualifiedTypeName: org.apache.hc.client5.http.io.HttpClientConnectionManager
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.hc.client5.http.ManagedClientConnection
+      newFullyQualifiedTypeName: org.apache.hc.client5.http.io.HttpClientConnectionManager
+
+  - org.openrewrite.java.ChangePackage:
+      oldPackageName: org.apache.http.conn.util
+      newPackageName: org.apache.hc.client5.http.psl
+      recursive: "False"
+  # Fixing specific mappings
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.hc.client5.http.psl.DnsUtils
+      newFullyQualifiedTypeName: org.apache.hc.client5.http.utils.DnsUtils
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.hc.client5.http.psl.InetAddressUtils
+      newFullyQualifiedTypeName: org.apache.hc.core5.net.InetAddressUtils
+
+  - org.openrewrite.java.ChangePackage:
+      oldPackageName: org.apache.http.conn.routing
+      newPackageName: org.apache.hc.client5.http
+      recursive: "False"
+  # Fixing specific mappings
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.hc.client5.http.BasicRouteDirector
+      newFullyQualifiedTypeName: org.apache.hc.client5.http.impl.routing.BasicRouteDirector
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.hc.client5.http.HttpRouteDirector
+      newFullyQualifiedTypeName: org.apache.hc.client5.http.routing.HttpRouteDirector
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.hc.client5.http.HttpRoutePlanner
+      newFullyQualifiedTypeName: org.apache.hc.client5.http.routing.HttpRoutePlanner
+
+  - org.openrewrite.java.ChangePackage:
+      oldPackageName: org.apache.http.conn.ssl
+      newPackageName: org.apache.hc.core5.ssl
+      recursive: "False"
+  # Fixing specific mappings
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.hc.core5.ssl.SSLConnectionSocketFactory
+      newFullyQualifiedTypeName: org.apache.hc.client5.http.ssl.SSLConnectionSocketFactory
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.hc.core5.ssl.NoopHostnameVerifier
+      newFullyQualifiedTypeName: org.apache.hc.client5.http.ssl.NoopHostnameVerifier
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.hc.core5.ssl.DefaultHostnameVerifier
+      newFullyQualifiedTypeName: org.apache.hc.client5.http.ssl.DefaultHostnameVerifier
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.hc.core5.ssl.TrustSelfSignedStrategy
+      newFullyQualifiedTypeName: org.apache.hc.client5.http.ssl.TrustSelfSignedStrategy
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.hc.core5.ssl.TrustAllStrategy
+      newFullyQualifiedTypeName: org.apache.hc.client5.http.ssl.TrustAllStrategy
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.hc.core5.ssl.SubjectName
+      newFullyQualifiedTypeName: org.apache.hc.client5.http.ssl.SubjectName
+
+  - org.openrewrite.java.ChangePackage:
+      oldPackageName: org.apache.http.impl.conn
+      newPackageName: org.apache.hc.client5.http.impl.io
+      recursive: "False"
+  # Fixing specific mappings
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.hc.client5.http.impl.io.SystemDefaultDnsResolver
+      newFullyQualifiedTypeName: org.apache.hc.client5.http.SystemDefaultDnsResolver
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.hc.client5.http.impl.io.Wire
+      newFullyQualifiedTypeName: org.apache.hc.client5.http.impl.Wire
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.hc.client5.http.impl.io.InMemoryDnsResolver
+      newFullyQualifiedTypeName: org.apache.hc.client5.http.impl.InMemoryDnsResolver
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.hc.client5.http.impl.io.ConnectionShutdownException
+      newFullyQualifiedTypeName: org.apache.hc.client5.http.impl.ConnectionShutdownException
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.hc.client5.http.impl.io.DefaultSchemePortResolver
+      newFullyQualifiedTypeName: org.apache.hc.client5.http.impl.DefaultSchemePortResolver
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.hc.client5.http.impl.io.DefaultProxyRoutePlanner
+      newFullyQualifiedTypeName: org.apache.hc.client5.http.impl.routing.DefaultProxyRoutePlanner
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.hc.client5.http.impl.io.DefaultRoutePlanner
+      newFullyQualifiedTypeName: org.apache.hc.client5.http.impl.routing.DefaultRoutePlanner
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.hc.client5.http.impl.io.SystemDefaultRoutePlanner
+      newFullyQualifiedTypeName: org.apache.hc.client5.http.impl.routing.SystemDefaultRoutePlanner
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.hc.client5.http.impl.io.DefaultHttpResponseParser
+      newFullyQualifiedTypeName: org.apache.hc.core5.http.impl.io.DefaultHttpResponseParser
+
+  - org.openrewrite.java.ChangePackage:
+      oldPackageName: org.apache.http
+      newPackageName: org.apache.hc.core5.http
+      recursive: "False"
+  # Fixing specific mappings
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.hc.core5.http.RequestLine
+      newFullyQualifiedTypeName: org.apache.hc.core5.http.message.RequestLine
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.hc.core5.http.RequestLine
+      newFullyQualifiedTypeName: org.apache.hc.core5.http.message.RequestLine
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.hc.core5.http.HttpClientConnection
+      newFullyQualifiedTypeName: org.apache.hc.core5.http.io.HttpClientConnection
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.hc.core5.http.StatusLine
+      newFullyQualifiedTypeName: org.apache.hc.core5.http.message.StatusLine
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.hc.core5.http.HttpServerConnection
+      newFullyQualifiedTypeName: org.apache.hc.core5.http.io.HttpServerConnection
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.hc.core5.http.HttpConnectionFactory
+      newFullyQualifiedTypeName: org.apache.hc.core5.http.io.HttpConnectionFactory

--- a/src/main/resources/META-INF/rewrite/apache-httpclient-5.yml
+++ b/src/main/resources/META-INF/rewrite/apache-httpclient-5.yml
@@ -1,3 +1,19 @@
+#
+# Copyright 2023 the original author or authors.
+# <p>
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# <p>
+# https://www.apache.org/licenses/LICENSE-2.0
+# <p>
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 ########################################################################################################################
 # Apache HttpClient 5.x
 ---

--- a/src/test/java/org/openrewrite/java/apache/httpclient5/NamespaceChangesTest.java
+++ b/src/test/java/org/openrewrite/java/apache/httpclient5/NamespaceChangesTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.apache.httpclient5;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.config.Environment;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+public class NamespaceChangesTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec
+          .parser(JavaParser.fromJavaVersion()
+            .classpath("httpclient", "httpcore", "httpclient5", "httpcore5")
+          )
+          .recipe(Environment.builder()
+            .scanRuntimeClasspath("org.openrewrite", "org.openrewrite.java", "org.openrewrite.java.dependencies")
+            .build()
+            .activateRecipes("org.openrewrite.java.apache.httpclient5.UpgradeApacheHttpClient_5_ClassMapping")
+          );
+    }
+
+    @Test
+    void testSomeImports() {
+        rewriteRun(
+            //language=java
+            java("""
+                import org.apache.http.HttpEntity;
+                import org.apache.http.client.methods.HttpGet;
+                import org.apache.http.client.methods.HttpUriRequest;
+                import org.apache.http.util.EntityUtils;
+                
+                class A {
+                    void method(HttpEntity entity, String urlStr) {
+                        HttpUriRequest getRequest = new HttpGet(urlStr);
+                        EntityUtils.consume(entity);
+                    }
+                }
+              ""","""
+                import org.apache.hc.core5.http.io.entity.EntityUtils;
+                import org.apache.hc.core5.http.HttpEntity;
+                import org.apache.hc.client5.http.classic.methods.HttpGet;
+                import org.apache.hc.client5.http.classic.methods.HttpUriRequest;
+                
+                class A {
+                    void method(HttpEntity entity, String urlStr) {
+                        HttpUriRequest getRequest = new HttpGet(urlStr);
+                        EntityUtils.consume(entity);
+                    }
+                }
+              """)
+        );
+    }
+}

--- a/src/test/java/org/openrewrite/java/apache/httpclient5/UpgradeApacheHttpClient5Test.java
+++ b/src/test/java/org/openrewrite/java/apache/httpclient5/UpgradeApacheHttpClient5Test.java
@@ -28,7 +28,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.openrewrite.java.Assertions.java;
 import static org.openrewrite.maven.Assertions.pomXml;
 
-class NamespaceChangesTest implements RewriteTest {
+class UpgradeApacheHttpClient5Test implements RewriteTest {
 
     @Override
     public void defaults(RecipeSpec spec) {


### PR DESCRIPTION
## What's changed?
Added a first approach of Apache Http Client 5 migration. Right now it adds the new dependency coordinates and performs all the obvious mappings between compatible classes changing the namespace.
Some attempts on some Deprecated classes have been done, but probably with some breaking changes right now. Will need more iteration.

## What's your motivation?
Spring boot 3 migration requires HttpClient upgrade.
Issue: #300 

## Anyone you would like to review specifically?
@timtebeek 
