### PR TITLE
UseNewRequestMatchers should also replace with 5.7 on classpath

### DIFF
--- a/src/main/java/org/openrewrite/java/spring/security5/UseNewRequestMatchers.java
+++ b/src/main/java/org/openrewrite/java/spring/security5/UseNewRequestMatchers.java
@@ -72,7 +72,8 @@ public class UseNewRequestMatchers extends Recipe {
                                     .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "spring-security-config-5.8"))
                                     .build();
                             J.MethodInvocation apply = template.apply(getCursor(), mi.getCoordinates().replaceMethod(), mi.getArguments().toArray());
-                            return apply.withSelect(mi.getSelect());
+                            return apply.withSelect(mi.getSelect())
+                                    .withName(mi.getName().withSimpleName(replacementMethodName));
                         }
                         return mi;
                     }

--- a/src/testWithSpringSecurity_5_7/java/org/openrewrite/spring/security5/UseNewSecurityMatchersTest.java
+++ b/src/testWithSpringSecurity_5_7/java/org/openrewrite/spring/security5/UseNewSecurityMatchersTest.java
@@ -28,6 +28,7 @@ import org.openrewrite.java.spring.security5.UseNewSecurityMatchers;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
+import org.openrewrite.test.TypeValidation;
 
 import static org.openrewrite.java.Assertions.java;
 import static org.openrewrite.test.RewriteTest.toRecipe;
@@ -110,7 +111,8 @@ class UseNewSecurityMatchersTest implements RewriteTest {
                   tree = new UseNewSecurityMatchers().getVisitor().visit(tree, ctx);
                   return (J) tree;
               }
-          })),
+          }))
+            .typeValidationOptions(TypeValidation.builder().methodInvocations(false).build()),
           java(
             """
               package com.example;

--- a/src/testWithSpringSecurity_5_7/java/org/openrewrite/spring/security5/UseNewSecurityMatchersTest.java
+++ b/src/testWithSpringSecurity_5_7/java/org/openrewrite/spring/security5/UseNewSecurityMatchersTest.java
@@ -161,8 +161,7 @@ class UseNewSecurityMatchersTest implements RewriteTest {
                     tree = new UseNewSecurityMatchers().getVisitor().visit(tree, ctx);
                     return (J) tree;
                 }
-            }))
-            .typeValidationOptions(TypeValidation.builder().methodInvocations(false).build()),
+            })),
           java(
             """
               package com.example;

--- a/src/testWithSpringSecurity_5_7/java/org/openrewrite/spring/security5/UseNewSecurityMatchersTest.java
+++ b/src/testWithSpringSecurity_5_7/java/org/openrewrite/spring/security5/UseNewSecurityMatchersTest.java
@@ -28,7 +28,6 @@ import org.openrewrite.java.spring.security5.UseNewSecurityMatchers;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
-import org.openrewrite.test.TypeValidation;
 
 import static org.openrewrite.java.Assertions.java;
 import static org.openrewrite.test.RewriteTest.toRecipe;

--- a/src/testWithSpringSecurity_5_7/java/org/openrewrite/spring/security5/UseNewSecurityMatchersTest.java
+++ b/src/testWithSpringSecurity_5_7/java/org/openrewrite/spring/security5/UseNewSecurityMatchersTest.java
@@ -16,10 +16,10 @@
 package org.openrewrite.spring.security5;
 
 import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.InMemoryExecutionContext;
 import org.openrewrite.Tree;
-import org.openrewrite.DocumentExample;
 import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.java.JavaVisitor;
@@ -40,7 +40,7 @@ class UseNewSecurityMatchersTest implements RewriteTest {
         spec.recipe(new UseNewSecurityMatchers())
           .parser(JavaParser.fromJavaVersion()
             .logCompilationWarningsAndErrors(true)
-            .classpathFromResources(new InMemoryExecutionContext(),"spring-context-5.3.+", "spring-beans-5.3.+", "spring-web-5.3.+", "spring-security-web-5.8.+", "spring-security-config-5.8.+"));
+            .classpathFromResources(new InMemoryExecutionContext(), "spring-context-5.3.+", "spring-beans-5.3.+", "spring-web-5.3.+", "spring-security-web-5.8.+", "spring-security-config-5.8.+"));
     }
 
     @DocumentExample
@@ -101,17 +101,67 @@ class UseNewSecurityMatchersTest implements RewriteTest {
     }
 
     @Test
+    void chainedCalls() {
+        rewriteRun(
+          //language=java
+          java("""
+            package com.example.demo;
+                        
+            import org.springframework.context.annotation.Bean;
+            import org.springframework.context.annotation.Configuration;
+            import org.springframework.http.HttpMethod;
+            import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+            import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+            import org.springframework.security.web.SecurityFilterChain;
+                        
+            @Configuration
+            @EnableWebSecurity
+            class SecurityConfig {
+                @Bean
+                SecurityFilterChain securityFilterChain(HttpSecurity http) {
+                    http.antMatcher("/**").authorizeRequests()
+                            .antMatchers(HttpMethod.POST, "/verify").access("hasRole('ROLE_USER')")
+                            .anyRequest().authenticated();
+                    return http.build();
+                }
+            }
+            ""","""
+            package com.example.demo;
+                        
+            import org.springframework.context.annotation.Bean;
+            import org.springframework.context.annotation.Configuration;
+            import org.springframework.http.HttpMethod;
+            import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+            import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+            import org.springframework.security.web.SecurityFilterChain;
+                        
+            @Configuration
+            @EnableWebSecurity
+            class SecurityConfig {
+                @Bean
+                SecurityFilterChain securityFilterChain(HttpSecurity http) {
+                    http.securityMatcher("/**").authorizeRequests()
+                            .antMatchers(HttpMethod.POST, "/verify").access("hasRole('ROLE_USER')")
+                            .anyRequest().authenticated();
+                    return http.build();
+                }
+            }
+            """)
+        );
+    }
+
+    @Test
     void togetherWithRequestMatchers() {
         //language=java
         rewriteRun(
           spec -> spec.recipe(toRecipe(() -> new JavaVisitor<>() {
-              @Override
-              public @Nullable J visit(@Nullable Tree tree, ExecutionContext ctx) {
-                  tree = new UseNewRequestMatchers().getVisitor().visit(tree, ctx);
-                  tree = new UseNewSecurityMatchers().getVisitor().visit(tree, ctx);
-                  return (J) tree;
-              }
-          }))
+                @Override
+                public @Nullable J visit(@Nullable Tree tree, ExecutionContext ctx) {
+                    tree = new UseNewRequestMatchers().getVisitor().visit(tree, ctx);
+                    tree = new UseNewSecurityMatchers().getVisitor().visit(tree, ctx);
+                    return (J) tree;
+                }
+            }))
             .typeValidationOptions(TypeValidation.builder().methodInvocations(false).build()),
           java(
             """

--- a/src/testWithSpringSecurity_5_8/java/org/openrewrite/spring/security5/UseNewRequestMatchersTest.java
+++ b/src/testWithSpringSecurity_5_8/java/org/openrewrite/spring/security5/UseNewRequestMatchersTest.java
@@ -413,8 +413,8 @@ class UseNewRequestMatchersTest implements RewriteTest {
                               .authorizeHttpRequests(authz -> authz.regexMatchers("/api/admin/**").hasRole("ADMIN")
                                       .antMatchers(HttpMethod.GET, "/api/user/**").hasRole("USER")
                                       .mvcMatchers(HttpMethod.PATCH).denyAll()
-                                      .anyRequest().authenticated()
-                              );
+                                      .anyRequest().authenticated())
+                              .csrf().ignoringAntMatchers("/admin/**");
                       return http.build();
                   }
               }
@@ -440,8 +440,9 @@ class UseNewRequestMatchersTest implements RewriteTest {
                                       .requestMatchers("/api/admin/**").hasRole("ADMIN")
                                       .requestMatchers(HttpMethod.GET, "/api/user/**").hasRole("USER")
                                       .requestMatchers(HttpMethod.PATCH).denyAll()
-                                      .anyRequest().authenticated()
-                              );
+                                      .anyRequest().authenticated())
+                              .csrf()
+                              .ignoringRequestMatchers("/admin/**");
                       return http.build();
                   }
               }

--- a/src/testWithSpringSecurity_5_8/java/org/openrewrite/spring/security5/UseNewRequestMatchersTest.java
+++ b/src/testWithSpringSecurity_5_8/java/org/openrewrite/spring/security5/UseNewRequestMatchersTest.java
@@ -22,7 +22,6 @@ import org.openrewrite.java.JavaParser;
 import org.openrewrite.java.spring.security5.UseNewRequestMatchers;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
-import org.openrewrite.test.TypeValidation;
 
 import static org.openrewrite.java.Assertions.java;
 

--- a/src/testWithSpringSecurity_5_8/java/org/openrewrite/spring/security5/UseNewRequestMatchersTest.java
+++ b/src/testWithSpringSecurity_5_8/java/org/openrewrite/spring/security5/UseNewRequestMatchersTest.java
@@ -22,6 +22,7 @@ import org.openrewrite.java.JavaParser;
 import org.openrewrite.java.spring.security5.UseNewRequestMatchers;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
+import org.openrewrite.test.TypeValidation;
 
 import static org.openrewrite.java.Assertions.java;
 
@@ -30,6 +31,7 @@ class UseNewRequestMatchersTest implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
         spec.recipe(new UseNewRequestMatchers())
+          .typeValidationOptions(TypeValidation.builder().methodInvocations(false).build())
           .parser(JavaParser.fromJavaVersion()
             .logCompilationWarningsAndErrors(true)
             .classpathFromResources(new InMemoryExecutionContext(),"spring-context-5.3.+", "spring-beans-5.3.+", "spring-web-5.3.+", "spring-security-web-5.8.+", "spring-security-config-5.8.+"));
@@ -55,10 +57,7 @@ class UseNewRequestMatchersTest implements RewriteTest {
               class SecurityConfig {
                   @Bean
                   SecurityFilterChain securityFilterChain(HttpSecurity http) {
-                      http
-                              .authorizeHttpRequests((authz) -> authz
-                                      .mvcMatchers("/static/**").permitAll()
-                              );
+                      http.authorizeHttpRequests(authz -> authz.mvcMatchers("/static/**").permitAll());
                       return http.build();
                   }
               }
@@ -78,10 +77,8 @@ class UseNewRequestMatchersTest implements RewriteTest {
               class SecurityConfig {
                   @Bean
                   SecurityFilterChain securityFilterChain(HttpSecurity http) {
-                      http
-                              .authorizeHttpRequests((authz) -> authz
-                                      .requestMatchers("/static/**").permitAll()
-                              );
+                      http.authorizeHttpRequests(authz -> authz
+                              .requestMatchers("/static/**").permitAll());
                       return http.build();
                   }
               }
@@ -110,10 +107,7 @@ class UseNewRequestMatchersTest implements RewriteTest {
               class SecurityConfig {
                   @Bean
                   SecurityFilterChain securityFilterChain(HttpSecurity http) {
-                      http
-                              .authorizeHttpRequests((authz) -> authz
-                                      .mvcMatchers(HttpMethod.GET, "/static/**").permitAll()
-                              );
+                      http.authorizeHttpRequests(authz -> authz.mvcMatchers(HttpMethod.GET, "/static/**").permitAll());
                       return http.build();
                   }
               }
@@ -134,10 +128,8 @@ class UseNewRequestMatchersTest implements RewriteTest {
               class SecurityConfig {
                   @Bean
                   SecurityFilterChain securityFilterChain(HttpSecurity http) {
-                      http
-                              .authorizeHttpRequests((authz) -> authz
-                                      .requestMatchers(HttpMethod.GET, "/static/**").permitAll()
-                              );
+                      http.authorizeHttpRequests(authz -> authz
+                              .requestMatchers(HttpMethod.GET, "/static/**").permitAll());
                       return http.build();
                   }
               }
@@ -165,10 +157,7 @@ class UseNewRequestMatchersTest implements RewriteTest {
               class SecurityConfig {
                   @Bean
                   SecurityFilterChain securityFilterChain(HttpSecurity http) {
-                      http
-                              .authorizeHttpRequests((authz) -> authz
-                                      .regexMatchers("/static/**").permitAll()
-                              );
+                      http.authorizeHttpRequests(authz -> authz.regexMatchers("/static/**").permitAll());
                       return http.build();
                   }
               }
@@ -188,10 +177,8 @@ class UseNewRequestMatchersTest implements RewriteTest {
               class SecurityConfig {
                   @Bean
                   SecurityFilterChain securityFilterChain(HttpSecurity http) {
-                      http
-                              .authorizeHttpRequests((authz) -> authz
-                                      .requestMatchers("/static/**").permitAll()
-                              );
+                      http.authorizeHttpRequests(authz -> authz
+                              .requestMatchers("/static/**").permitAll());
                       return http.build();
                   }
               }
@@ -220,10 +207,7 @@ class UseNewRequestMatchersTest implements RewriteTest {
               class SecurityConfig {
                   @Bean
                   SecurityFilterChain securityFilterChain(HttpSecurity http) {
-                      http
-                              .authorizeHttpRequests((authz) -> authz
-                                      .regexMatchers(HttpMethod.GET, "/static/**").permitAll()
-                              );
+                      http.authorizeHttpRequests(authz -> authz.regexMatchers(HttpMethod.GET, "/static/**").permitAll());
                       return http.build();
                   }
               }
@@ -244,10 +228,8 @@ class UseNewRequestMatchersTest implements RewriteTest {
               class SecurityConfig {
                   @Bean
                   SecurityFilterChain securityFilterChain(HttpSecurity http) {
-                      http
-                              .authorizeHttpRequests((authz) -> authz
-                                      .requestMatchers(HttpMethod.GET, "/static/**").permitAll()
-                              );
+                      http.authorizeHttpRequests(authz -> authz
+                              .requestMatchers(HttpMethod.GET, "/static/**").permitAll());
                       return http.build();
                   }
               }
@@ -275,10 +257,7 @@ class UseNewRequestMatchersTest implements RewriteTest {
               class SecurityConfig {
                   @Bean
                   SecurityFilterChain securityFilterChain(HttpSecurity http) {
-                      http
-                              .authorizeHttpRequests((authz) -> authz
-                                      .antMatchers("/static/**").permitAll()
-                              );
+                      http.authorizeHttpRequests(authz -> authz.antMatchers("/static/**").permitAll());
                       return http.build();
                   }
               }
@@ -298,10 +277,8 @@ class UseNewRequestMatchersTest implements RewriteTest {
               class SecurityConfig {
                   @Bean
                   SecurityFilterChain securityFilterChain(HttpSecurity http) {
-                      http
-                              .authorizeHttpRequests((authz) -> authz
-                                      .requestMatchers("/static/**").permitAll()
-                              );
+                      http.authorizeHttpRequests(authz -> authz
+                              .requestMatchers("/static/**").permitAll());
                       return http.build();
                   }
               }
@@ -330,10 +307,7 @@ class UseNewRequestMatchersTest implements RewriteTest {
               class SecurityConfig {
                   @Bean
                   SecurityFilterChain securityFilterChain(HttpSecurity http) {
-                      http
-                              .authorizeHttpRequests((authz) -> authz
-                                      .antMatchers(HttpMethod.GET).permitAll()
-                              );
+                      http.authorizeHttpRequests(authz -> authz.antMatchers(HttpMethod.GET).permitAll());
                       return http.build();
                   }
               }
@@ -354,10 +328,8 @@ class UseNewRequestMatchersTest implements RewriteTest {
               class SecurityConfig {
                   @Bean
                   SecurityFilterChain securityFilterChain(HttpSecurity http) {
-                      http
-                              .authorizeHttpRequests((authz) -> authz
-                                      .requestMatchers(HttpMethod.GET).permitAll()
-                              );
+                      http.authorizeHttpRequests(authz -> authz
+                              .requestMatchers(HttpMethod.GET).permitAll());
                       return http.build();
                   }
               }
@@ -386,10 +358,7 @@ class UseNewRequestMatchersTest implements RewriteTest {
               class SecurityConfig {
                   @Bean
                   SecurityFilterChain securityFilterChain(HttpSecurity http) {
-                      http
-                              .authorizeHttpRequests((authz) -> authz
-                                      .antMatchers(HttpMethod.GET, "/static/**").permitAll()
-                              );
+                      http.authorizeHttpRequests(authz -> authz.antMatchers(HttpMethod.GET, "/static/**").permitAll());
                       return http.build();
                   }
               }
@@ -410,10 +379,8 @@ class UseNewRequestMatchersTest implements RewriteTest {
               class SecurityConfig {
                   @Bean
                   SecurityFilterChain securityFilterChain(HttpSecurity http) {
-                      http
-                              .authorizeHttpRequests((authz) -> authz
-                                      .requestMatchers(HttpMethod.GET, "/static/**").permitAll()
-                              );
+                      http.authorizeHttpRequests(authz -> authz
+                              .requestMatchers(HttpMethod.GET, "/static/**").permitAll());
                       return http.build();
                   }
               }
@@ -443,8 +410,7 @@ class UseNewRequestMatchersTest implements RewriteTest {
                   @Bean
                   SecurityFilterChain securityFilterChain(HttpSecurity http) {
                       http
-                              .authorizeHttpRequests((authz) -> authz
-                                      .regexMatchers("/api/admin/**").hasRole("ADMIN")
+                              .authorizeHttpRequests(authz -> authz.regexMatchers("/api/admin/**").hasRole("ADMIN")
                                       .antMatchers(HttpMethod.GET, "/api/user/**").hasRole("USER")
                                       .mvcMatchers(HttpMethod.PATCH).denyAll()
                                       .anyRequest().authenticated()
@@ -470,7 +436,7 @@ class UseNewRequestMatchersTest implements RewriteTest {
                   @Bean
                   SecurityFilterChain securityFilterChain(HttpSecurity http) {
                       http
-                              .authorizeHttpRequests((authz) -> authz
+                              .authorizeHttpRequests(authz -> authz
                                       .requestMatchers("/api/admin/**").hasRole("ADMIN")
                                       .requestMatchers(HttpMethod.GET, "/api/user/**").hasRole("USER")
                                       .requestMatchers(HttpMethod.PATCH).denyAll()

--- a/src/testWithSpringSecurity_5_8/java/org/openrewrite/spring/security5/UseNewRequestMatchersTest.java
+++ b/src/testWithSpringSecurity_5_8/java/org/openrewrite/spring/security5/UseNewRequestMatchersTest.java
@@ -31,7 +31,6 @@ class UseNewRequestMatchersTest implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
         spec.recipe(new UseNewRequestMatchers())
-          .typeValidationOptions(TypeValidation.builder().methodInvocations(false).build())
           .parser(JavaParser.fromJavaVersion()
             .logCompilationWarningsAndErrors(true)
             .classpathFromResources(new InMemoryExecutionContext(), "spring-context-5.3.+", "spring-beans-5.3.+", "spring-web-5.3.+", "spring-security-web-5.8.+", "spring-security-config-5.8.+"));

--- a/src/testWithSpringSecurity_5_8/java/org/openrewrite/spring/security5/UseNewRequestMatchersTest.java
+++ b/src/testWithSpringSecurity_5_8/java/org/openrewrite/spring/security5/UseNewRequestMatchersTest.java
@@ -16,8 +16,8 @@
 package org.openrewrite.spring.security5;
 
 import org.junit.jupiter.api.Test;
-import org.openrewrite.InMemoryExecutionContext;
 import org.openrewrite.DocumentExample;
+import org.openrewrite.InMemoryExecutionContext;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.java.spring.security5.UseNewRequestMatchers;
 import org.openrewrite.test.RecipeSpec;
@@ -34,7 +34,7 @@ class UseNewRequestMatchersTest implements RewriteTest {
           .typeValidationOptions(TypeValidation.builder().methodInvocations(false).build())
           .parser(JavaParser.fromJavaVersion()
             .logCompilationWarningsAndErrors(true)
-            .classpathFromResources(new InMemoryExecutionContext(),"spring-context-5.3.+", "spring-beans-5.3.+", "spring-web-5.3.+", "spring-security-web-5.8.+", "spring-security-config-5.8.+"));
+            .classpathFromResources(new InMemoryExecutionContext(), "spring-context-5.3.+", "spring-beans-5.3.+", "spring-web-5.3.+", "spring-security-web-5.8.+", "spring-security-config-5.8.+"));
     }
 
     @DocumentExample
@@ -61,8 +61,7 @@ class UseNewRequestMatchersTest implements RewriteTest {
                       return http.build();
                   }
               }
-              """
-            ,
+              """,
             """
               package com.example;
                           
@@ -77,8 +76,7 @@ class UseNewRequestMatchersTest implements RewriteTest {
               class SecurityConfig {
                   @Bean
                   SecurityFilterChain securityFilterChain(HttpSecurity http) {
-                      http.authorizeHttpRequests(authz -> authz
-                              .requestMatchers("/static/**").permitAll());
+                      http.authorizeHttpRequests(authz -> authz.requestMatchers("/static/**").permitAll());
                       return http.build();
                   }
               }
@@ -128,8 +126,7 @@ class UseNewRequestMatchersTest implements RewriteTest {
               class SecurityConfig {
                   @Bean
                   SecurityFilterChain securityFilterChain(HttpSecurity http) {
-                      http.authorizeHttpRequests(authz -> authz
-                              .requestMatchers(HttpMethod.GET, "/static/**").permitAll());
+                      http.authorizeHttpRequests(authz -> authz.requestMatchers(HttpMethod.GET, "/static/**").permitAll());
                       return http.build();
                   }
               }
@@ -177,8 +174,7 @@ class UseNewRequestMatchersTest implements RewriteTest {
               class SecurityConfig {
                   @Bean
                   SecurityFilterChain securityFilterChain(HttpSecurity http) {
-                      http.authorizeHttpRequests(authz -> authz
-                              .requestMatchers("/static/**").permitAll());
+                      http.authorizeHttpRequests(authz -> authz.requestMatchers("/static/**").permitAll());
                       return http.build();
                   }
               }
@@ -228,8 +224,7 @@ class UseNewRequestMatchersTest implements RewriteTest {
               class SecurityConfig {
                   @Bean
                   SecurityFilterChain securityFilterChain(HttpSecurity http) {
-                      http.authorizeHttpRequests(authz -> authz
-                              .requestMatchers(HttpMethod.GET, "/static/**").permitAll());
+                      http.authorizeHttpRequests(authz -> authz.requestMatchers(HttpMethod.GET, "/static/**").permitAll());
                       return http.build();
                   }
               }
@@ -277,8 +272,7 @@ class UseNewRequestMatchersTest implements RewriteTest {
               class SecurityConfig {
                   @Bean
                   SecurityFilterChain securityFilterChain(HttpSecurity http) {
-                      http.authorizeHttpRequests(authz -> authz
-                              .requestMatchers("/static/**").permitAll());
+                      http.authorizeHttpRequests(authz -> authz.requestMatchers("/static/**").permitAll());
                       return http.build();
                   }
               }
@@ -328,8 +322,7 @@ class UseNewRequestMatchersTest implements RewriteTest {
               class SecurityConfig {
                   @Bean
                   SecurityFilterChain securityFilterChain(HttpSecurity http) {
-                      http.authorizeHttpRequests(authz -> authz
-                              .requestMatchers(HttpMethod.GET).permitAll());
+                      http.authorizeHttpRequests(authz -> authz.requestMatchers(HttpMethod.GET).permitAll());
                       return http.build();
                   }
               }
@@ -379,8 +372,7 @@ class UseNewRequestMatchersTest implements RewriteTest {
               class SecurityConfig {
                   @Bean
                   SecurityFilterChain securityFilterChain(HttpSecurity http) {
-                      http.authorizeHttpRequests(authz -> authz
-                              .requestMatchers(HttpMethod.GET, "/static/**").permitAll());
+                      http.authorizeHttpRequests(authz -> authz.requestMatchers(HttpMethod.GET, "/static/**").permitAll());
                       return http.build();
                   }
               }
@@ -409,12 +401,10 @@ class UseNewRequestMatchersTest implements RewriteTest {
               class SecurityConfig {
                   @Bean
                   SecurityFilterChain securityFilterChain(HttpSecurity http) {
-                      http
-                              .authorizeHttpRequests(authz -> authz.regexMatchers("/api/admin/**").hasRole("ADMIN")
+                      http.authorizeHttpRequests(authz -> authz.regexMatchers("/api/admin/**").hasRole("ADMIN")
                                       .antMatchers(HttpMethod.GET, "/api/user/**").hasRole("USER")
                                       .mvcMatchers(HttpMethod.PATCH).denyAll()
-                                      .anyRequest().authenticated())
-                              .csrf().ignoringAntMatchers("/admin/**");
+                                      .anyRequest().authenticated()).csrf().ignoringAntMatchers("/admin/**");
                       return http.build();
                   }
               }
@@ -435,14 +425,10 @@ class UseNewRequestMatchersTest implements RewriteTest {
               class SecurityConfig {
                   @Bean
                   SecurityFilterChain securityFilterChain(HttpSecurity http) {
-                      http
-                              .authorizeHttpRequests(authz -> authz
-                                      .requestMatchers("/api/admin/**").hasRole("ADMIN")
+                      http.authorizeHttpRequests(authz -> authz.requestMatchers("/api/admin/**").hasRole("ADMIN")
                                       .requestMatchers(HttpMethod.GET, "/api/user/**").hasRole("USER")
                                       .requestMatchers(HttpMethod.PATCH).denyAll()
-                                      .anyRequest().authenticated())
-                              .csrf()
-                              .ignoringRequestMatchers("/admin/**");
+                                      .anyRequest().authenticated()).csrf().ignoringRequestMatchers("/admin/**");
                       return http.build();
                   }
               }


### PR DESCRIPTION
## What's changed?
Adopt JavaTemplate to replace methods.

## What's your motivation?
Replacements failed as we looked for a replacement method in the target type, but only 5.7 classes were available, leading to a mismatch and thus no replacement. Fixes #350

## Anything in particular you'd like reviewers to focus on?
Called out below.