### PR TITLE
Replace getStatusLine on HttpResponse

### DIFF
--- a/src/main/java/org/openrewrite/java/apache/httpclient5/NewStatusLine.java
+++ b/src/main/java/org/openrewrite/java/apache/httpclient5/NewStatusLine.java
@@ -24,7 +24,7 @@ import org.openrewrite.java.tree.J;
 public class NewStatusLine extends Recipe {
     @Override
     public String getDisplayName() {
-        return "Replaces deprecated HttpResponse::getStatusLine()";
+        return "Replaces deprecated `HttpResponse::getStatusLine()`";
     }
 
     @Override

--- a/src/main/java/org/openrewrite/java/apache/httpclient5/NewStatusLine.java
+++ b/src/main/java/org/openrewrite/java/apache/httpclient5/NewStatusLine.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openrewrite.java.apache.httpclient5;
 
 import org.openrewrite.ExecutionContext;

--- a/src/main/java/org/openrewrite/java/apache/httpclient5/NewStatusLine.java
+++ b/src/main/java/org/openrewrite/java/apache/httpclient5/NewStatusLine.java
@@ -1,0 +1,44 @@
+package org.openrewrite.java.apache.httpclient5;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.*;
+import org.openrewrite.java.tree.J;
+
+public class NewStatusLine extends Recipe {
+    @Override
+    public String getDisplayName() {
+        return "Replaces deprecated HttpResponse::getStatusLine()";
+    }
+
+    @Override
+    public String getDescription() {
+        return "HttpResponse::getStatusLine() was deprecated in 4.x, so we replace it for new StatusLine(HttpResponse). " +
+                "Ideally we will try to simplify method chains for getStatusCode, getProtocolVersion and getReasonPhrase, " +
+                "but there are some scenarios wher ethe StatusLine object is assigned or used directly, and we need to " +
+                "instantiate the object.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new JavaVisitor<ExecutionContext>() {
+
+            final MethodMatcher matcher = new MethodMatcher("org.apache.hc.core5.http.HttpResponse getStatusLine()");
+            final JavaTemplate template = JavaTemplate.builder("new StatusLine(#{any(org.apache.hc.core5.http.HttpResponse)})")
+                    .javaParser(JavaParser.fromJavaVersion().classpath("httpcore5"))
+                    .imports("org.apache.hc.core5.http.message.StatusLine")
+                    .build();
+
+            @Override
+            public J visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
+                J.MethodInvocation m = (J.MethodInvocation) super.visitMethodInvocation(method, ctx);
+                if (matcher.matches(m)) {
+                    maybeAddImport("org.apache.hc.core5.http.message.StatusLine");
+                    return template.apply(updateCursor(m), m.getCoordinates().replace(), m.getSelect());
+                }
+                return m;
+            }
+        };
+    }
+}

--- a/src/main/java/org/openrewrite/java/apache/httpclient5/NewStatusLine.java
+++ b/src/main/java/org/openrewrite/java/apache/httpclient5/NewStatusLine.java
@@ -29,9 +29,9 @@ public class NewStatusLine extends Recipe {
 
     @Override
     public String getDescription() {
-        return "HttpResponse::getStatusLine() was deprecated in 4.x, so we replace it for new StatusLine(HttpResponse). " +
-                "Ideally we will try to simplify method chains for getStatusCode, getProtocolVersion and getReasonPhrase, " +
-                "but there are some scenarios wher ethe StatusLine object is assigned or used directly, and we need to " +
+        return "`HttpResponse::getStatusLine()` was deprecated in 4.x, so we replace it for `new StatusLine(HttpResponse)`. " +
+                "Ideally we will try to simplify method chains for `getStatusCode`, `getProtocolVersion` and `getReasonPhrase`, " +
+                "but there are some scenarios where the `StatusLine` object is assigned or used directly, and we need to " +
                 "instantiate the object.";
     }
 

--- a/src/main/resources/META-INF/rewrite/apache-httpclient-5.yml
+++ b/src/main/resources/META-INF/rewrite/apache-httpclient-5.yml
@@ -39,6 +39,7 @@ recipeList:
   - org.openrewrite.java.apache.httpclient5.UpgradeApacheHttpClient_5_DeprecatedMethods
   - org.openrewrite.java.apache.httpclient5.UseTimeout
   - org.openrewrite.java.apache.httpclient5.UseTimeValue
+  - org.openrewrite.java.apache.httpclient5.StatusLine
 
 ---
 type: specs.openrewrite.org/v1beta/recipe
@@ -412,3 +413,19 @@ recipeList:
   - org.openrewrite.java.ChangeMethodName:
       methodPattern: org.apache.hc.client5.http.config.RequestConfig.Builder setSocketTimeout(int)
       newMethodName: setResponseTimeout
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.apache.httpclient5.StatusLine
+displayName: Migrate to ApacheHttpClient 5.x deprecated methods from 4.x
+description: Migrates deprecated methods to their equivalent ones in 5.x
+recipeList:
+  - org.openrewrite.java.SimplifyMethodChain:
+      methodPatternChain: ['org.apache.hc.core5.http.HttpResponse getStatusLine()', 'org.apache.hc.core5.http.message.StatusLine getStatusCode()']
+      newMethodName: getCode
+  - org.openrewrite.java.SimplifyMethodChain:
+      methodPatternChain: ['org.apache.hc.core5.http.HttpResponse getStatusLine()', 'org.apache.hc.core5.http.message.StatusLine getReasonPhrase()']
+      newMethodName: getReasonPhrase
+  - org.openrewrite.java.SimplifyMethodChain:
+      methodPatternChain: [ 'org.apache.hc.core5.http.HttpResponse getStatusLine()', 'org.apache.hc.core5.http.message.StatusLine getProtocolVersion()' ]
+      newMethodName: getVersion
+  - org.openrewrite.java.apache.httpclient5.NewStatusLine

--- a/src/test/java/org/openrewrite/java/apache/httpclient5/UpgradeApacheHttpClient5Test.java
+++ b/src/test/java/org/openrewrite/java/apache/httpclient5/UpgradeApacheHttpClient5Test.java
@@ -179,4 +179,59 @@ class UpgradeApacheHttpClient5Test implements RewriteTest {
             """)
         );
     }
+
+    @Test
+    void removeStatusLineHttpResponse() {
+        rewriteRun(
+          //language=java
+          java("""
+                import org.apache.http.HttpStatus;
+                import org.apache.http.client.methods.CloseableHttpResponse;
+                import org.apache.http.client.methods.HttpGet;
+                import org.apache.http.impl.client.CloseableHttpClient;
+                import org.apache.http.impl.client.HttpClientBuilder;
+                import org.apache.http.ProtocolVersion;
+                
+                import java.io.IOException;
+                
+                class A {
+                    void method() throws IOException {
+                        HttpGet httpGet = new HttpGet("https://moderne.io");
+                        CloseableHttpClient instance = HttpClientBuilder.create().build();
+                        CloseableHttpResponse response = instance.execute(httpGet);
+                        
+                        System.out.println("response.getStatusLine() :: " + response.getStatusLine());
+                        int statusCode = response.getStatusLine().getStatusCode();
+                        String reason = response.getStatusLine().getReasonPhrase();
+                        ProtocolVersion version = response.getStatusLine().getProtocolVersion();
+                    }
+                }
+            """,
+            """
+                import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
+                import org.apache.hc.core5.http.HttpStatus;
+                import org.apache.hc.client5.http.classic.methods.HttpGet;
+                import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+                import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
+                import org.apache.hc.core5.http.ProtocolVersion;
+                import org.apache.hc.core5.http.message.StatusLine;
+                
+                import java.io.IOException;
+                
+                class A {
+                    void method() throws IOException {
+                        HttpGet httpGet = new HttpGet("https://moderne.io");
+                        CloseableHttpClient instance = HttpClientBuilder.create().build();
+                        CloseableHttpResponse response = instance.execute(httpGet);
+                        
+                        System.out.println("response.getStatusLine() :: " + new StatusLine(response));
+                        int statusCode = response.getCode();
+                        String reason = response.getReasonPhrase();
+                        ProtocolVersion version = response.getVersion();
+                    }
+                }
+            """)
+        );
+    }
+
 }


### PR DESCRIPTION
## What's changed?
HttpResponse::getStatusLine has been removed in Apache HttpClient 5.x, you can call the getStatusCode, getProtocolVersion and getReasonPhrase directly on the HttpResponse object.
When applicable, we will apply a simplify method chain, but for scenarios where the StatusLine is stored or used directly, we are going to instantiate a StatusLine object (which has the same previous 4.x methods) with the response object.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've added the license header to any new files through `./gradlew licenseFormat`
- [x] I've used the IntelliJ auto-formatter on affected files
