### PR TITLE
Simplify `MediaType.parse` Calls

### DIFF
--- a/src/main/java/org/openrewrite/java/spring/http/SimplifyMediaTypeParseCalls.java
+++ b/src/main/java/org/openrewrite/java/spring/http/SimplifyMediaTypeParseCalls.java
@@ -1,0 +1,47 @@
+package org.openrewrite.java.spring.http;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.JavaTemplate;
+import org.openrewrite.java.JavaVisitor;
+import org.openrewrite.java.MethodMatcher;
+import org.openrewrite.java.tree.J;
+
+public class SimplifyMediaTypeParseCalls extends Recipe {
+    @Override
+    public String getDisplayName() {
+        return "Simplify Unnecessary `MediaType.parse` calls";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Replaces `MediaType.parse('application/json')` with `MediaType.APPLICATION_JSON`.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new SimplifyParseCallsVisitor();
+    }
+
+    private static final class SimplifyParseCallsVisitor extends JavaVisitor<ExecutionContext> {
+        private final MethodMatcher MEDIATYPE_PARSE_MATCHER = new MethodMatcher("org.springframework.http.MediaType parse(..)");
+
+        @Override
+        public J visitMethodInvocation(J.MethodInvocation mi, ExecutionContext ctx) {
+            System.out.println(mi.getSimpleName());
+            if (!MEDIATYPE_PARSE_MATCHER.matches(mi) && !mi.getArguments().isEmpty()) {
+                return mi;
+            }
+
+            J.Literal test = (J.Literal) mi.getArguments().get(0);
+            if (!test.getValue().equals("application/json")) {
+                return mi;
+            }
+
+            return JavaTemplate.builder("MediaType.APPLICATION_JSON")
+                    .build()
+                    .apply(getCursor(), mi.getCoordinates().replace());
+        }
+    }
+}

--- a/src/main/java/org/openrewrite/java/spring/http/SimplifyMediaTypeParseCalls.java
+++ b/src/main/java/org/openrewrite/java/spring/http/SimplifyMediaTypeParseCalls.java
@@ -59,10 +59,13 @@ public class SimplifyMediaTypeParseCalls extends Recipe {
                 Expression methodArg = mi.getArguments().get(0);
                 if (methodArg instanceof J.FieldAccess
                         && TypeUtils.isOfClassType(((J.FieldAccess) methodArg).getTarget().getType(), MEDIA_TYPE)) {
-                    J.FieldAccess access = (J.FieldAccess) methodArg;
-                    return access
+                    maybeRemoveImport(MEDIA_TYPE + ".parseMediaType");
+                    maybeRemoveImport(MEDIA_TYPE + ".valueOf");
+                    J.FieldAccess fieldAccess = (J.FieldAccess) methodArg;
+                    String replacementConstant = fieldAccess.getSimpleName().replace("_VALUE", "");
+                    return fieldAccess
                             .withType(JavaType.Primitive.String)
-                            .withName(access.getName().withSimpleName(access.getSimpleName().replace("_VALUE", "")))
+                            .withName(fieldAccess.getName().withSimpleName(replacementConstant))
                             .withPrefix(mi.getPrefix())
                             .withMarkers(mi.getMarkers())
                             .withComments(mi.getComments());

--- a/src/main/java/org/openrewrite/java/spring/http/SimplifyMediaTypeParseCalls.java
+++ b/src/main/java/org/openrewrite/java/spring/http/SimplifyMediaTypeParseCalls.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openrewrite.java.spring.http;
 
 import org.openrewrite.ExecutionContext;
@@ -29,7 +44,6 @@ public class SimplifyMediaTypeParseCalls extends Recipe {
 
         @Override
         public J visitMethodInvocation(J.MethodInvocation mi, ExecutionContext ctx) {
-            System.out.println(mi.getSimpleName());
             if (!MEDIATYPE_PARSE_MATCHER.matches(mi) && !mi.getArguments().isEmpty()) {
                 return mi;
             }

--- a/src/test/java/org/openrewrite/java/spring/SimplifyMediaTypeParseCallsTest.java
+++ b/src/test/java/org/openrewrite/java/spring/SimplifyMediaTypeParseCallsTest.java
@@ -30,12 +30,12 @@ public class SimplifyMediaTypeParseCallsTest implements RewriteTest {
     public void defaults(RecipeSpec spec) {
         spec
           .recipe(new SimplifyMediaTypeParseCalls())
-          .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(), "spring-web"));
+          .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(), "spring-web-6.+", "spring-core-6.+"));
     }
 
     @DocumentExample
     @Test
-    void replaceUnnecessaryParseCall() {
+    void replaceUnnecessaryMediaTypeParseMediaTypeCall() {
         //language=java
         rewriteRun(
           java(
@@ -45,9 +45,7 @@ public class SimplifyMediaTypeParseCallsTest implements RewriteTest {
               import org.springframework.http.MediaType;
               
               class Test {
-                  void test() {
-                      MediaType.parse("application/json");
-                  }
+                  MediaType mediaType = MediaType.parseMediaType("application/json");
               }
               """,
             """
@@ -56,9 +54,34 @@ public class SimplifyMediaTypeParseCallsTest implements RewriteTest {
               import org.springframework.http.MediaType;
               
               class Test {
-                  void test() {
-                      MediaType.APPLICATION_JSON;
-                  }
+                  MediaType mediaType = MediaType.APPLICATION_JSON;
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void replaceUnnecessaryMediaTypeValueOfCall() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              package com.mycompany;
+              
+              import org.springframework.http.MediaType;
+              
+              class Test {
+                  MediaType mediaType = MediaType.valueOf("application/json");
+              }
+              """,
+            """
+              package com.mycompany;
+              
+              import org.springframework.http.MediaType;
+              
+              class Test {
+                  MediaType mediaType = MediaType.APPLICATION_JSON;
               }
               """
           )

--- a/src/test/java/org/openrewrite/java/spring/SimplifyMediaTypeParseCallsTest.java
+++ b/src/test/java/org/openrewrite/java/spring/SimplifyMediaTypeParseCallsTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openrewrite.java.spring;
 
 import org.junit.jupiter.api.Test;

--- a/src/test/java/org/openrewrite/java/spring/SimplifyMediaTypeParseCallsTest.java
+++ b/src/test/java/org/openrewrite/java/spring/SimplifyMediaTypeParseCallsTest.java
@@ -45,7 +45,7 @@ public class SimplifyMediaTypeParseCallsTest implements RewriteTest {
               import org.springframework.http.MediaType;
               
               class Test {
-                  MediaType mediaType = MediaType.parseMediaType("application/json");
+                  MediaType mediaType = MediaType.parseMediaType(MediaType.APPLICATION_JSON_VALUE);
               }
               """,
             """
@@ -72,7 +72,7 @@ public class SimplifyMediaTypeParseCallsTest implements RewriteTest {
               import org.springframework.http.MediaType;
               
               class Test {
-                  MediaType mediaType = MediaType.valueOf("application/json");
+                  MediaType mediaType = MediaType.valueOf(MediaType.APPLICATION_JSON_VALUE);
               }
               """,
             """

--- a/src/test/java/org/openrewrite/java/spring/SimplifyMediaTypeParseCallsTest.java
+++ b/src/test/java/org/openrewrite/java/spring/SimplifyMediaTypeParseCallsTest.java
@@ -1,0 +1,52 @@
+package org.openrewrite.java.spring;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.InMemoryExecutionContext;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.java.spring.http.SimplifyMediaTypeParseCalls;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+public class SimplifyMediaTypeParseCallsTest implements RewriteTest {
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec
+          .recipe(new SimplifyMediaTypeParseCalls())
+          .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(), "spring-web"));
+    }
+
+    @DocumentExample
+    @Test
+    void replaceUnnecessaryParseCall() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              package com.mycompany;
+              
+              import org.springframework.http.MediaType;
+              
+              class Test {
+                  void test() {
+                      MediaType.parse("application/json");
+                  }
+              }
+              """,
+            """
+              package com.mycompany;
+              
+              import org.springframework.http.MediaType;
+              
+              class Test {
+                  void test() {
+                      MediaType.APPLICATION_JSON;
+                  }
+              }
+              """
+          )
+        );
+    }
+}

--- a/src/test/java/org/openrewrite/java/spring/SimplifyMediaTypeParseCallsTest.java
+++ b/src/test/java/org/openrewrite/java/spring/SimplifyMediaTypeParseCallsTest.java
@@ -15,7 +15,8 @@
  */
 package org.openrewrite.java.spring;
 
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.InMemoryExecutionContext;
 import org.openrewrite.java.JavaParser;
@@ -25,7 +26,7 @@ import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.java.Assertions.java;
 
-public class SimplifyMediaTypeParseCallsTest implements RewriteTest {
+class SimplifyMediaTypeParseCallsTest implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
         spec
@@ -34,56 +35,55 @@ public class SimplifyMediaTypeParseCallsTest implements RewriteTest {
     }
 
     @DocumentExample
-    @Test
-    void replaceUnnecessaryMediaTypeParseMediaTypeCall() {
-        //language=java
+    @ParameterizedTest
+    @ValueSource(strings = {
+      "ALL_VALUE",
+      "APPLICATION_ATOM_XML_VALUE",
+      "APPLICATION_CBOR_VALUE",
+      "APPLICATION_FORM_URLENCODED_VALUE",
+      "APPLICATION_JSON_VALUE",
+      "APPLICATION_JSON_UTF8_VALUE",
+      "APPLICATION_OCTET_STREAM_VALUE",
+      "APPLICATION_PDF_VALUE",
+      "APPLICATION_PROBLEM_JSON_VALUE",
+      "APPLICATION_PROBLEM_JSON_UTF8_VALUE",
+      "APPLICATION_PROBLEM_XML_VALUE",
+      "APPLICATION_RSS_XML_VALUE",
+      "APPLICATION_STREAM_JSON_VALUE",
+      "APPLICATION_XHTML_XML_VALUE",
+      "APPLICATION_XML_VALUE",
+      "IMAGE_GIF_VALUE",
+      "IMAGE_JPEG_VALUE",
+      "IMAGE_PNG_VALUE",
+      "MULTIPART_FORM_DATA_VALUE",
+      "MULTIPART_MIXED_VALUE",
+      "MULTIPART_RELATED_VALUE",
+      "TEXT_EVENT_STREAM_VALUE",
+      "TEXT_HTML_VALUE",
+      "TEXT_MARKDOWN_VALUE",
+      "TEXT_PLAIN_VALUE",
+      "TEXT_XML_VALUE"
+    })
+    void replaceMediaTypes(String value) {
         rewriteRun(
+          //language=java
           java(
             """
-              package com.mycompany;
-              
               import org.springframework.http.MediaType;
               
               class Test {
-                  MediaType mediaType = MediaType.parseMediaType(MediaType.APPLICATION_JSON_VALUE);
+                  MediaType mediaType1 = MediaType.parseMediaType(MediaType.%1$s);
+                  MediaType mediaType2 = MediaType.valueOf(MediaType.%1$s);
               }
-              """,
+              """.formatted(value),
             """
-              package com.mycompany;
-              
               import org.springframework.http.MediaType;
-              
+                            
               class Test {
-                  MediaType mediaType = MediaType.APPLICATION_JSON;
+                  MediaType mediaType1 = MediaType.%1$s;
+                  MediaType mediaType2 = MediaType.%1$s;
               }
-              """
-          )
-        );
-    }
-
-    @Test
-    void replaceUnnecessaryMediaTypeValueOfCall() {
-        //language=java
-        rewriteRun(
-          java(
-            """
-              package com.mycompany;
-              
-              import org.springframework.http.MediaType;
-              
-              class Test {
-                  MediaType mediaType = MediaType.valueOf(MediaType.APPLICATION_JSON_VALUE);
-              }
-              """,
-            """
-              package com.mycompany;
-              
-              import org.springframework.http.MediaType;
-              
-              class Test {
-                  MediaType mediaType = MediaType.APPLICATION_JSON;
-              }
-              """
+              """.formatted(value.replace("_VALUE", ""))
           )
         );
     }

--- a/src/test/java/org/openrewrite/java/spring/SimplifyMediaTypeParseCallsTest.java
+++ b/src/test/java/org/openrewrite/java/spring/SimplifyMediaTypeParseCallsTest.java
@@ -71,17 +71,24 @@ class SimplifyMediaTypeParseCallsTest implements RewriteTest {
             """
               import org.springframework.http.MediaType;
               
+              import static org.springframework.http.MediaType.parseMediaType;
+              import static org.springframework.http.MediaType.valueOf;
+              
               class Test {
                   MediaType mediaType1 = MediaType.parseMediaType(MediaType.%1$s);
                   MediaType mediaType2 = MediaType.valueOf(MediaType.%1$s);
+                  MediaType mediaType3 = parseMediaType(MediaType.%1$s);
+                  MediaType mediaType4 = valueOf(MediaType.%1$s);
               }
               """.formatted(value),
             """
               import org.springframework.http.MediaType;
-                            
+              
               class Test {
                   MediaType mediaType1 = MediaType.%1$s;
                   MediaType mediaType2 = MediaType.%1$s;
+                  MediaType mediaType3 = MediaType.%1$s;
+                  MediaType mediaType4 = MediaType.%1$s;
               }
               """.formatted(value.replace("_VALUE", ""))
           )


### PR DESCRIPTION
## What's changed?
This PR introduces a recipe to replaces uses of `MediaType.parse("application/json")` with `MediaType.APPLICATION_JSON`. 

## What's your motivation?
Fixes https://github.com/openrewrite/rewrite-spring/issues/337

## Anything in particular you'd like reviewers to focus on?
Currently when the recipe runs the `methodType` for `MediaType.parse` is null which is causing the recipe to stop running early. I think it is because I am not including the correct classpath. I have tried using `classpath("spring-web")` but it kept telling me that this was not a valid resource name. I'm confused why it would tell me that since I've seen `spring-web` used in other tests in rewrite-spring.

## Anyone you would like to review specifically?
@timtebeek 

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [x] I've added the license header to any new files through `./gradlew licenseFormat`
- [x] I've used the IntelliJ auto-formatter on affected files
- [ ] I've updated the documentation (if applicable)
