### PR TITLE
removed autoformat when no necessary

### DIFF
--- a/src/main/java/org/openrewrite/java/spring/NoRequestMappingAnnotation.java
+++ b/src/main/java/org/openrewrite/java/spring/NoRequestMappingAnnotation.java
@@ -26,6 +26,7 @@ import org.openrewrite.java.ChangeType;
 import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.search.UsesType;
 import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.Space;
 
 import java.time.Duration;
 import java.util.Collections;
@@ -93,7 +94,8 @@ public class NoRequestMappingAnnotation extends Recipe {
                 // Remove the argument
                 if (requestMethodArg.isPresent() && methodArgumentHasSingleType(requestMethodArg.get()) && resolvedRequestMappingAnnotationClassName != null) {
                     if (a.getArguments() != null) {
-                        a = maybeAutoFormat(a, a.withArguments(ListUtils.map(a.getArguments(), arg -> requestMethodArg.get().equals(arg) ? null : arg)), ctx);
+                        //a = maybeAutoFormat(a, a.withArguments(ListUtils.map(a.getArguments(), arg -> requestMethodArg.get().equals(arg) ? null : arg)), ctx);
+                        a = a.withArguments(ListUtils.map(a.getArguments(), arg -> requestMethodArg.get().equals(arg) ? null : arg));
                     }
                 }
 
@@ -107,15 +109,15 @@ public class NoRequestMappingAnnotation extends Recipe {
 
                 // if there is only one remaining argument now, and it is "path" or "value", then we can drop the key name
                 if (a != null && a.getArguments() != null && a.getArguments().size() == 1) {
-                    a = maybeAutoFormat(a, a.withArguments(ListUtils.map(a.getArguments(), arg -> {
+                    a = a.withArguments(ListUtils.map(a.getArguments(), arg -> {
                         if (arg instanceof J.Assignment && ((J.Assignment) arg).getVariable() instanceof J.Identifier) {
                             J.Identifier ident = (J.Identifier) ((J.Assignment) arg).getVariable();
                             if ("path".equals(ident.getSimpleName()) || "value".equals(ident.getSimpleName())) {
-                                return ((J.Assignment) arg).getAssignment();
+                                return ((J.Assignment) arg).getAssignment().withPrefix(Space.EMPTY);
                             }
                         }
                         return arg;
-                    })), ctx);
+                    }));
                 }
             }
             return a != null ? a : annotation;

--- a/src/testWithSpringBoot_2_1/java/org/openrewrite/java/spring/NoRequestMappingAnnotationTest.java
+++ b/src/testWithSpringBoot_2_1/java/org/openrewrite/java/spring/NoRequestMappingAnnotationTest.java
@@ -281,7 +281,7 @@ class NoRequestMappingAnnotationTest implements RewriteTest {
               
               @RestController
               public class UsersController {
-                  @PostMapping(value = "/user/{userId}/edit", produces = {MediaType.APPLICATION_JSON_VALUE})
+                  @PostMapping(value = "/user/{userId}/edit", produces = { MediaType.APPLICATION_JSON_VALUE })
                   public ResponseEntity<List<String>> getUsersPost(String userId) {
                       return null;
                   }
@@ -317,6 +317,92 @@ class NoRequestMappingAnnotationTest implements RewriteTest {
                       @GetMapping("/api")
                       void test() {
                       }
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void multipleAnnotations() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import java.util.*;
+              import org.springframework.http.ResponseEntity;
+              import org.springframework.web.bind.annotation.RequestMapping;
+              import org.springframework.web.bind.annotation.RestController;
+              import static org.springframework.web.bind.annotation.RequestMethod.POST;
+              
+              @RestController
+              @RequestMapping("/users")
+              public class UsersController {
+                  @Deprecated
+                  @RequestMapping(method = POST)
+                  public ResponseEntity<List<String>> getUsersPost() {
+                      return null;
+                  }
+              }
+              """,
+            """
+              import java.util.*;
+              import org.springframework.http.ResponseEntity;
+              import org.springframework.web.bind.annotation.PostMapping;
+              import org.springframework.web.bind.annotation.RequestMapping;
+              import org.springframework.web.bind.annotation.RestController;
+              
+              @RestController
+              @RequestMapping("/users")
+              public class UsersController {
+                  @Deprecated
+                  @PostMapping
+                  public ResponseEntity<List<String>> getUsersPost() {
+                      return null;
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void multipleAnnotationsWithOneReaminingParameter() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import java.util.*;
+              import org.springframework.http.ResponseEntity;
+              import org.springframework.web.bind.annotation.RequestMapping;
+              import org.springframework.web.bind.annotation.RestController;
+              import static org.springframework.web.bind.annotation.RequestMethod.POST;
+              
+              @RestController
+              @RequestMapping("/users")
+              public class UsersController {
+                  @Deprecated
+                  @RequestMapping(method = POST, path = "/{id}")
+                  public ResponseEntity<List<String>> getUsersPost() {
+                      return null;
+                  }
+              }
+              """,
+            """
+              import java.util.*;
+              import org.springframework.http.ResponseEntity;
+              import org.springframework.web.bind.annotation.PostMapping;
+              import org.springframework.web.bind.annotation.RequestMapping;
+              import org.springframework.web.bind.annotation.RestController;
+              
+              @RestController
+              @RequestMapping("/users")
+              public class UsersController {
+                  @Deprecated
+                  @PostMapping("/{id}")
+                  public ResponseEntity<List<String>> getUsersPost() {
+                      return null;
                   }
               }
               """


### PR DESCRIPTION
## What's changed?
Remove the call to maybeAutoFormat on some places

## What's your motivation?
Autoformat in some places it's not strictly needed, due to the produced changes, and because the limited scope of the autoFormat it can lead to unwanted results.

## Anything in particular you'd like reviewers to focus on?
I've added couple of tests to check for extra scenarios, but maybe I missed some corner case where the autoFormat was needed

## Anyone you would like to review specifically?
@timtebeek @rpau 

## Have you considered any alternatives or workarounds?
Maybe trying to fix the AutoFormat (more specifically the TabsAndIndentsVisitor) could be a better fix, but it seems kinda tricky and complex thing to do, with much bigger (and hard to test) impact. 

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
