### PR TITLE
removed unnecessary autoFormat

### DIFF
--- a/src/main/java/org/openrewrite/java/spring/ImplicitWebAnnotationNames.java
+++ b/src/main/java/org/openrewrite/java/spring/ImplicitWebAnnotationNames.java
@@ -75,7 +75,7 @@ public class ImplicitWebAnnotationNames extends Recipe {
             if (PARAM_ANNOTATIONS.stream().anyMatch(annotationClass -> isOfClassType(annotation.getType(), annotationClass)) &&
                     annotation.getArguments() != null && getCursor().getParentOrThrow().getValue() instanceof J.VariableDeclarations) {
 
-                a = maybeAutoFormat(a, a.withArguments(ListUtils.map(a.getArguments(), arg -> {
+                a = a.withArguments(ListUtils.map(a.getArguments(), arg -> {
                     Cursor varDecsCursor = getCursor().getParentOrThrow();
                     J.VariableDeclarations.NamedVariable namedVariable = varDecsCursor.<J.VariableDeclarations>getValue().getVariables().get(0);
                     if (arg instanceof J.Assignment) {
@@ -95,7 +95,7 @@ public class ImplicitWebAnnotationNames extends Recipe {
                     }
 
                     return arg;
-                })), ctx);
+                }));
             }
 
             return a;

--- a/src/testWithSpringBoot_2_1/java/org/openrewrite/java/spring/ImplicitWebAnnotationNamesTest.java
+++ b/src/testWithSpringBoot_2_1/java/org/openrewrite/java/spring/ImplicitWebAnnotationNamesTest.java
@@ -36,6 +36,7 @@ class ImplicitWebAnnotationNamesTest implements RewriteTest {
     @DocumentExample
     @Test
     void removeUnnecessaryAnnotationArgument() {
+        //language=java
         rewriteRun(
           java(
             """


### PR DESCRIPTION
## What's changed?
Removed unnecessary autoFormat

## What's your motivation?
This recipe, in combination with others that called autoFormat on annotations, could cause autoFormat to cause unexpected results because it was finding a message in a cursor that was causing to change indentation.

## Anything in particular you'd like reviewers to focus on?
Any corner case where the autoFormat was needed?

## Anyone you would like to review specifically?
@timtebeek 
