### PR TITLE
removed autoFormat and replaced with manual format

### DIFF
--- a/src/main/java/org/openrewrite/java/spring/ImplicitWebAnnotationNames.java
+++ b/src/main/java/org/openrewrite/java/spring/ImplicitWebAnnotationNames.java
@@ -21,6 +21,7 @@ import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.search.UsesType;
 import org.openrewrite.java.tree.J;
 
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Stream;
 
@@ -62,10 +63,24 @@ public class ImplicitWebAnnotationNames extends Recipe {
                 "SessionAttribute"
         ).map(className -> "org.springframework.web.bind.annotation." + className).collect(toSet());
 
+
         @Override
         public J.VariableDeclarations visitVariableDeclarations(J.VariableDeclarations multiVariable, ExecutionContext executionContext) {
             J.VariableDeclarations varDecls = super.visitVariableDeclarations(multiVariable, executionContext);
-            return maybeAutoFormat(multiVariable, varDecls, executionContext);
+            // Fix when the annotation looses all it's arguments, and there is no prefix between the annotation and the type expression
+            // i.e: @Annotation(argument)Type is valid but @AnnotationType it's not
+            if (!varDecls.getLeadingAnnotations().isEmpty()) {
+                if (varDecls.getTypeExpression() != null && varDecls.getTypeExpression().getPrefix().getWhitespace().isEmpty()) {
+                    List<J.Annotation> annotations = varDecls.getLeadingAnnotations();
+                    J.Annotation lastAnnotation = annotations.get(annotations.size() - 1);
+                    if (lastAnnotation.getArguments() == null || lastAnnotation.getArguments().isEmpty()) {
+                        varDecls = varDecls.withTypeExpression(
+                                varDecls.getTypeExpression().withPrefix(
+                                        varDecls.getTypeExpression().getPrefix().withWhitespace(" ")));
+                    }
+                }
+            }
+            return varDecls;
         }
 
         @Override
@@ -74,6 +89,11 @@ public class ImplicitWebAnnotationNames extends Recipe {
 
             if (PARAM_ANNOTATIONS.stream().anyMatch(annotationClass -> isOfClassType(annotation.getType(), annotationClass)) &&
                     annotation.getArguments() != null && getCursor().getParentOrThrow().getValue() instanceof J.VariableDeclarations) {
+
+                // Copying the first argument whitespace to use it later on in case we remove the original first argument.
+                String firstWhitespace = a.getArguments() != null && !a.getArguments().isEmpty() ?
+                        a.getArguments().get(0).getPrefix().getWhitespace() :
+                        null;
 
                 a = a.withArguments(ListUtils.map(a.getArguments(), arg -> {
                     Cursor varDecsCursor = getCursor().getParentOrThrow();
@@ -96,6 +116,11 @@ public class ImplicitWebAnnotationNames extends Recipe {
 
                     return arg;
                 }));
+                // Copying the original first argument whitespace to the new first argument in case the original first argument was removed.
+                // No need to check if the first argument has been removed. Worst case scenario we are overriding the same whitespace.
+                if (firstWhitespace != null) {
+                    a = a.withArguments(ListUtils.mapFirst(a.getArguments(), arg -> arg.withPrefix(arg.getPrefix().withWhitespace(firstWhitespace))));
+                }
             }
 
             return a;


### PR DESCRIPTION
## What's changed?
Manually formatting potential introduced errors due to removal of annotation arguments

## What's your motivation?
Calling autoFormat has some unwanted side effects, probably due to some bugs in autoFormat. However, we do not actually need to call autoFormat here, since the span of potential format changes needed is small and we can take care of it in the recipe itself.

## Anyone you would like to review specifically?
@timtebeek 
