### PR TITLE
Upgrade `httpcore` -> `httpcore5` in the `UpgradeApacheHttpClient_5` recipe

### DIFF
--- a/src/main/resources/META-INF/rewrite/apache-httpclient-5.yml
+++ b/src/main/resources/META-INF/rewrite/apache-httpclient-5.yml
@@ -35,6 +35,12 @@ recipeList:
       newGroupId: org.apache.httpcomponents.client5
       newArtifactId: httpclient5
       newVersion: 5.1.x
+  - org.openrewrite.java.dependencies.ChangeDependency:
+      oldGroupId: org.apache.httpcomponents
+      oldArtifactId: httpcore
+      newGroupId: org.apache.httpcomponents.core5
+      newArtifactId: httpcore5
+      newVersion: 5.1.x
   - org.openrewrite.java.apache.httpclient5.UpgradeApacheHttpClient_5_ClassMapping
   - org.openrewrite.java.apache.httpclient5.UpgradeApacheHttpClient_5_DeprecatedMethods
   - org.openrewrite.java.apache.httpclient5.UpgradeApacheHttpClient_5_TimeUnit


### PR DESCRIPTION
## What's changed?

Let the `UpgradeApacheHttpClient_5` recipe upgrade the `org.apache.httpcomponents:httpcore` dependency to `org.apache.httpcomponents.core5:httpcore5`. 

## What's your motivation?

When running the `UpgradeApacheHttpClient_5` we had to perform this part of the upgrade manually. With this addition, not anymore 😉. 

## Anyone you would like to review specifically?

@timtebeek 
