### PR TITLE
Remove DefaultBatchConfigurer

### DIFF
--- a/src/main/java/org/openrewrite/java/spring/batch/RemoveDefaultBatchConfigurer.java
+++ b/src/main/java/org/openrewrite/java/spring/batch/RemoveDefaultBatchConfigurer.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openrewrite.java.spring.batch;
 
 import org.openrewrite.ExecutionContext;

--- a/src/main/java/org/openrewrite/java/spring/batch/RemoveDefaultBatchConfigurer.java
+++ b/src/main/java/org/openrewrite/java/spring/batch/RemoveDefaultBatchConfigurer.java
@@ -24,7 +24,7 @@ import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.search.UsesType;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.TypeUtils;
-import org.openrewrite.marker.SearchResult;
+import org.openrewrite.marker.Markup;
 
 import java.util.List;
 
@@ -65,10 +65,10 @@ public class RemoveDefaultBatchConfigurer extends Recipe {
             if (TypeUtils.isAssignableTo(DEFAULT_BATCH_CONFIGURER, method.getMethodType().getDeclaringType())) {
                 // Strip @Override
                 List<J.Annotation> formerLeadingAnnotations = md.getLeadingAnnotations();
-                md = md.withLeadingAnnotations(ListUtils.map(formerLeadingAnnotations,
-                        a -> (TypeUtils.isAssignableTo("java.lang.Override", a.getType())) ? null : a));
-                if (formerLeadingAnnotations.size() != md.getLeadingAnnotations().size()) {
-                    md = SearchResult.found(md, "TODO Used to override a DefaultBatchConfigurer method; reconsider if still needed");
+                if (TypeUtils.isOverride(md.getMethodType())) {
+                    md = md.withLeadingAnnotations(ListUtils.map(formerLeadingAnnotations,
+                            a -> (TypeUtils.isAssignableTo("java.lang.Override", a.getType())) ? null : a));
+                    md = Markup.info(md, "TODO Used to override a DefaultBatchConfigurer method; reconsider if still needed");
                 }
 
                 // Strip calls to super

--- a/src/main/java/org/openrewrite/java/spring/batch/RemoveDefaultBatchConfigurer.java
+++ b/src/main/java/org/openrewrite/java/spring/batch/RemoveDefaultBatchConfigurer.java
@@ -1,0 +1,72 @@
+package org.openrewrite.java.spring.batch;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Preconditions;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.internal.ListUtils;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.search.UsesType;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.TypeUtils;
+import org.openrewrite.marker.SearchResult;
+
+import java.util.List;
+
+public class RemoveDefaultBatchConfigurer extends Recipe {
+
+    private static final String DEFAULT_BATCH_CONFIGURER = "org.springframework.batch.core.configuration.annotation.DefaultBatchConfigurer";
+
+    @Override
+    public String getDisplayName() {
+        return "Remove `DefaultBatchConfigurer`";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Remove `extends DefaultBatchConfigurer` and `@Override` from associated methods.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return Preconditions.check(new UsesType<>(DEFAULT_BATCH_CONFIGURER, true), new RemoveDefaultBatchConfigurerVisitor());
+    }
+
+    static final class RemoveDefaultBatchConfigurerVisitor extends JavaIsoVisitor<ExecutionContext> {
+        @Override
+        public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration classDecl, ExecutionContext executionContext) {
+            J.ClassDeclaration cd = super.visitClassDeclaration(classDecl, executionContext);
+            if (TypeUtils.isAssignableTo(DEFAULT_BATCH_CONFIGURER, cd.getType())) {
+                // Strip extends DefaultBatchConfigurer
+                maybeRemoveImport(DEFAULT_BATCH_CONFIGURER);
+                return cd.withExtends(null);
+            }
+            return cd;
+        }
+
+        @Override
+        public J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration method, ExecutionContext executionContext) {
+            J.MethodDeclaration md = super.visitMethodDeclaration(method, executionContext);
+            if (TypeUtils.isAssignableTo(DEFAULT_BATCH_CONFIGURER, method.getMethodType().getDeclaringType())) {
+                // Strip @Override
+                List<J.Annotation> formerLeadingAnnotations = md.getLeadingAnnotations();
+                md = md.withLeadingAnnotations(ListUtils.map(formerLeadingAnnotations,
+                        a -> (TypeUtils.isAssignableTo("java.lang.Override", a.getType())) ? null : a));
+                if (formerLeadingAnnotations.size() != md.getLeadingAnnotations().size()) {
+                    md = SearchResult.found(md, "TODO Used to override a DefaultBatchConfigurer method; reconsider if still needed");
+                }
+
+                // Strip calls to super
+                md = md.withBody(md.getBody().withStatements(ListUtils.map(md.getBody().getStatements(),
+                        s -> (s instanceof J.MethodInvocation && ((J.MethodInvocation) s).getSelect() instanceof J.Identifier &&
+                                ((J.Identifier) ((J.MethodInvocation) s).getSelect()).getSimpleName().equals("super")) ? null : s)));
+
+                // Strip (now) empty methods
+                if (md.getBody().getStatements().isEmpty()) {
+                    return null;
+                }
+            }
+            return md;
+        }
+    }
+}

--- a/src/main/resources/META-INF/rewrite/spring-batch-5.0.yml
+++ b/src/main/resources/META-INF/rewrite/spring-batch-5.0.yml
@@ -35,6 +35,7 @@ recipeList:
   - org.openrewrite.java.spring.batch.ImplementChunkListenerDirectly
   - org.openrewrite.java.spring.batch.MigrateJobBuilderFactory
   - org.openrewrite.java.spring.batch.MigrateItemWriterWrite
+  - org.openrewrite.java.spring.batch.RemoveDefaultBatchConfigurer
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: org.springframework.batch.core.metrics.BatchMetrics
       newFullyQualifiedTypeName: org.springframework.batch.core.observability.BatchMetrics

--- a/src/testWithSpringBoot_3_0/java/org/openrewrite/java/spring/batch/RemoveDefaultBatchConfigurerTest.java
+++ b/src/testWithSpringBoot_3_0/java/org/openrewrite/java/spring/batch/RemoveDefaultBatchConfigurerTest.java
@@ -65,7 +65,7 @@ class RemoveDefaultBatchConfigurerTest implements RewriteTest {
                 Foo() {
                     super();
                 }
-            
+                        
                 @Override
                 public void setDataSource(javax.sql.DataSource dataSource) {
                     super.setDataSource(dataSource);
@@ -132,6 +132,25 @@ class RemoveDefaultBatchConfigurerTest implements RewriteTest {
                 public void baz() {
                     // Comment only, still retained
                 }
+            }
+            """)
+        );
+    }
+
+    @Test
+    void removeBeanUsage() {
+        // language=java
+        rewriteRun(
+          java("""
+            import org.springframework.batch.core.configuration.annotation.BatchConfigurer;
+            import org.springframework.batch.core.configuration.annotation.DefaultBatchConfigurer;
+            class FooConfig  {
+                public BatchConfigurer bean(javax.sql.DataSource dataSource) {
+                    return new DefaultBatchConfigurer(dataSource);
+                }
+            }
+            """, """
+            class FooConfig {
             }
             """)
         );

--- a/src/testWithSpringBoot_3_0/java/org/openrewrite/java/spring/batch/RemoveDefaultBatchConfigurerTest.java
+++ b/src/testWithSpringBoot_3_0/java/org/openrewrite/java/spring/batch/RemoveDefaultBatchConfigurerTest.java
@@ -62,6 +62,10 @@ class RemoveDefaultBatchConfigurerTest implements RewriteTest {
           java("""
             import org.springframework.batch.core.configuration.annotation.DefaultBatchConfigurer;
             class Foo extends DefaultBatchConfigurer {
+                Foo() {
+                    super();
+                }
+            
                 @Override
                 public void setDataSource(javax.sql.DataSource dataSource) {
                     super.setDataSource(dataSource);

--- a/src/testWithSpringBoot_3_0/java/org/openrewrite/java/spring/batch/RemoveDefaultBatchConfigurerTest.java
+++ b/src/testWithSpringBoot_3_0/java/org/openrewrite/java/spring/batch/RemoveDefaultBatchConfigurerTest.java
@@ -15,7 +15,6 @@
  */
 package org.openrewrite.java.spring.batch;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.InMemoryExecutionContext;
@@ -100,7 +99,6 @@ class RemoveDefaultBatchConfigurerTest implements RewriteTest {
     }
 
     @Test
-    @Disabled("Not retaining additional interface overrides for now")
     void retainInterfaceOverrides() {
         // language=java
         rewriteRun(
@@ -120,14 +118,15 @@ class RemoveDefaultBatchConfigurerTest implements RewriteTest {
                 
                 @Override
                 public void baz() {
-                    super.baz();
+                    // Comment only, still retained
                 }
             }
             """, """
             class Foo implements bar.Bar {
+
                 @Override
                 public void baz() {
-                    super.baz();
+                    // Comment only, still retained
                 }
             }
             """)

--- a/src/testWithSpringBoot_3_0/java/org/openrewrite/java/spring/batch/RemoveDefaultBatchConfigurerTest.java
+++ b/src/testWithSpringBoot_3_0/java/org/openrewrite/java/spring/batch/RemoveDefaultBatchConfigurerTest.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.spring.batch;
+
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.InMemoryExecutionContext;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+@SuppressWarnings("RedundantThrows")
+class RemoveDefaultBatchConfigurerTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(new RemoveDefaultBatchConfigurer())
+          .parser(JavaParser.fromJavaVersion()
+            .classpathFromResources(new InMemoryExecutionContext(),
+              "spring-batch-core-4.3.+"));
+    }
+
+    @DocumentExample
+    @Test
+    void removeSetDataSourceWithCommentOnly() {
+        // language=java
+        rewriteRun(
+          java("""
+            import org.springframework.batch.core.configuration.annotation.DefaultBatchConfigurer;
+            class Foo extends DefaultBatchConfigurer {
+                @Override
+                public void setDataSource(javax.sql.DataSource dataSource) {
+                    // Datasource ignored; this method and comment should be removed
+                }
+            }
+            """, """
+            class Foo {
+            }
+            """)
+        );
+    }
+
+    @Test
+    void removeSetDatasourceWithSuperCallOnly() {
+        // language=java
+        rewriteRun(
+          java("""
+            import org.springframework.batch.core.configuration.annotation.DefaultBatchConfigurer;
+            class Foo extends DefaultBatchConfigurer {
+                @Override
+                public void setDataSource(javax.sql.DataSource dataSource) {
+                    super.setDataSource(dataSource);
+                }
+            }
+            """, """
+            class Foo {
+            }
+            """)
+        );
+    }
+
+    @Test
+    void retainSetDataSourceWithAdditionalStatements() {
+        // language=java
+        rewriteRun(
+          java("""
+            import org.springframework.batch.core.configuration.annotation.DefaultBatchConfigurer;
+            class Foo extends DefaultBatchConfigurer {
+                @Override
+                public void setDataSource(javax.sql.DataSource dataSource) {
+                    super.setDataSource(dataSource);
+                    System.out.println("Additional statements should ensure method is not removed");
+                }
+            }
+            """, """
+            class Foo {
+                /*~~(TODO Used to override a DefaultBatchConfigurer method; reconsider if still needed)~~>*/
+                public void setDataSource(javax.sql.DataSource dataSource) {
+                    System.out.println("Additional statements should ensure method is not removed");
+                }
+            }
+            """)
+        );
+    }
+
+    @Test
+    @Disabled("Not retaining additional interface overrides for now")
+    void retainInterfaceOverrides() {
+        // language=java
+        rewriteRun(
+          java("""
+            package bar;
+            public interface Bar {
+                void baz();
+            }
+            """),
+          java("""
+            import org.springframework.batch.core.configuration.annotation.DefaultBatchConfigurer;
+            class Foo extends DefaultBatchConfigurer implements bar.Bar {
+                @Override
+                public void setDataSource(javax.sql.DataSource dataSource) {
+                    // Datasource ignored; this method and comment should be removed
+                }
+                
+                @Override
+                public void baz() {
+                    super.baz();
+                }
+            }
+            """, """
+            class Foo implements bar.Bar {
+                @Override
+                public void baz() {
+                    super.baz();
+                }
+            }
+            """)
+        );
+    }
+}


### PR DESCRIPTION
## What's changed?
Added a `RemoveDefaultBatchConfigurer` recipe to help migrate Spring Batch.

## What's your motivation?
Fixes #412

## Anything in particular you'd like reviewers to focus on?
Any additional cases we should cover?
Should we handle the disabled `retainInterfaceOverrides` test case?

## Any additional context
- https://github.com/openrewrite/rewrite-spring/issues/412