### PR TITLE
Chain in AuthorizeHttpRequests with spring-security-58.yml

### DIFF
--- a/src/main/resources/META-INF/rewrite/spring-security-58.yml
+++ b/src/main/resources/META-INF/rewrite/spring-security-58.yml
@@ -30,6 +30,7 @@ recipeList:
       artifactId: "*"
       newVersion: 5.8.x
       overrideManagedVersion: false
+  - org.openrewrite.java.spring.security5.AuthorizeHttpRequests
   - org.openrewrite.java.spring.security5.UseNewRequestMatchers
   - org.openrewrite.java.spring.security5.UseNewSecurityMatchers
   - org.openrewrite.java.spring.security5.UpdatePbkdf2PasswordEncoder

--- a/src/testWithSpringBoot_2_7/java/org/openrewrite/java/spring/security5/AuthorizeHttpRequestsTest.java
+++ b/src/testWithSpringBoot_2_7/java/org/openrewrite/java/spring/security5/AuthorizeHttpRequestsTest.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.openrewrite.java.spring.boot2;
+package org.openrewrite.java.spring.security5;
 
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
@@ -23,7 +23,7 @@ import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.java.Assertions.java;
 
-public class AuthorizeHttpRequestsTest implements RewriteTest {
+class AuthorizeHttpRequestsTest implements RewriteTest {
 
     @Override
     public void defaults(RecipeSpec spec) {


### PR DESCRIPTION
## What's changed?
- Moved into `security5` package, as both methods are available in 5.8
- Wrap `doAfterVisit` calls inside a method, instead of always executing those
- Linked the recipe into the 5.8 spring security upgrade
- Formatting changes

## What's your motivation?
Got reports of these changes not being applied, despite a recipe being available.

## Anything in particular you'd like reviewers to focus on?
- Was there any particular reason this recipe was not hooked into the yaml chain of recipes?
- Was there a reason to keep this under `boot2` instead of `security5`?

## Anyone you would like to review specifically?
@BoykoAlex