### PR TITLE
Security lambda DSL enhancements

### DIFF
--- a/src/main/java/org/openrewrite/java/spring/boot2/ConvertToSecurityDslVisitor.java
+++ b/src/main/java/org/openrewrite/java/spring/boot2/ConvertToSecurityDslVisitor.java
@@ -171,6 +171,16 @@ public class ConvertToSecurityDslVisitor<P> extends JavaIsoVisitor<P> {
                 .findFirst();
     }
 
+    // this method is unused in this repo, but, useful in Spring Tool Suite integration
+    public boolean isApplicableTopLevelMethodInvocation(J.MethodInvocation m) {
+        if (isApplicableMethod(m)) {
+            return true;
+        } else if (m.getSelect() instanceof J.MethodInvocation) {
+            return isApplicableTopLevelMethodInvocation((J.MethodInvocation) m.getSelect());
+        }
+        return false;
+    }
+
     private boolean isApplicableCallCursor(Cursor c) {
         if (c != null && c.getValue() instanceof J.MethodInvocation) {
             J.MethodInvocation inv = c.getValue();

--- a/src/main/java/org/openrewrite/java/spring/boot2/ConvertToSecurityDslVisitor.java
+++ b/src/main/java/org/openrewrite/java/spring/boot2/ConvertToSecurityDslVisitor.java
@@ -48,7 +48,7 @@ public class ConvertToSecurityDslVisitor<P> extends JavaIsoVisitor<P> {
     }
 
     public ConvertToSecurityDslVisitor(String securityFqn, Collection<String> convertableMethods,
-            final Map<String, String> argReplacements) {
+            Map<String, String> argReplacements) {
         this.securityFqn = securityFqn;
         this.convertableMethods = convertableMethods;
         this.argReplacements = argReplacements;

--- a/src/main/java/org/openrewrite/java/spring/boot2/HeadersConfigurerLambdaDsl.java
+++ b/src/main/java/org/openrewrite/java/spring/boot2/HeadersConfigurerLambdaDsl.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.spring.boot2;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Preconditions;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.search.UsesType;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+public final class HeadersConfigurerLambdaDsl extends Recipe {
+
+    private static final String FQN_HEADERS_CONFIGURER = "org.springframework.security.config.annotation.web.configurers.HeadersConfigurer";
+
+    private static final Collection<String> APPLICABLE_METHOD_NAMES = Arrays.asList(
+            "contentTypeOptions", "xssProtection", "cacheControl", "httpStrictTransportSecurity", "frameOptions",
+            "contentSecurityPolicy", "referrerPolicy", "permissionsPolicy", "crossOriginOpenerPolicy",
+            "crossOriginEmbedderPolicy", "crossOriginResourcePolicy");
+
+    private static final Map<String, String> ARG_REPLACEMENTS = new HashMap<String, String>() {{
+        put("contentSecurityPolicy", "policyDirectives");
+        put("referrerPolicy", "policy");
+    }};
+
+    @Override
+    public String getDisplayName() {
+        return "Convert `HeadersConfigurer` chained calls into Lambda DSL";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Converts `HeadersConfigurer` chained call from Spring Security pre 5.2.x into new lambda DSL style calls and removes `and()` methods.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return Preconditions.check(
+                new UsesType<>(FQN_HEADERS_CONFIGURER, true),
+                new ConvertToSecurityDslVisitor<>(FQN_HEADERS_CONFIGURER, APPLICABLE_METHOD_NAMES, ARG_REPLACEMENTS)
+        );
+    }
+
+}

--- a/src/main/resources/META-INF/rewrite/spring-boot-24.yml
+++ b/src/main/resources/META-INF/rewrite/spring-boot-24.yml
@@ -60,8 +60,6 @@ recipeList:
   - org.openrewrite.java.spring.boot2.MigrateUndertowServletWebServerFactorySetEagerInitFilters
   - org.openrewrite.java.spring.boot2.MigrateLoggingSystemPropertyConstants
   - org.openrewrite.java.spring.boot2.MigrateHsqlEmbeddedDatabaseConnection
-  - org.openrewrite.java.spring.boot2.HttpSecurityLambdaDsl
-  - org.openrewrite.java.spring.boot2.ServerHttpSecurityLambdaDsl
 
   # Update properties
   - org.openrewrite.java.spring.boot2.SpringBootProperties_2_4

--- a/src/main/resources/META-INF/rewrite/spring-boot-31.yml
+++ b/src/main/resources/META-INF/rewrite/spring-boot-31.yml
@@ -36,6 +36,7 @@ recipeList:
   - org.openrewrite.gradle.plugins.UpgradePluginVersion:
       pluginIdPattern: org.springframework.boot
       newVersion: 3.1.x
+  - org.openrewrite.java.spring.security6.UpgradeSpringSecurity_6_1
   - org.openrewrite.java.spring.boot3.SpringBootProperties_3_1
 ---
 type: specs.openrewrite.org/v1beta/recipe

--- a/src/main/resources/META-INF/rewrite/spring-security-61.yml
+++ b/src/main/resources/META-INF/rewrite/spring-security-61.yml
@@ -1,0 +1,35 @@
+#
+# Copyright 2023 the original author or authors.
+# <p>
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# <p>
+# https://www.apache.org/licenses/LICENSE-2.0
+# <p>
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.spring.security6.UpgradeSpringSecurity_6_1
+displayName: Migrate to Spring Security 6.1
+description: >
+  Migrate applications to the latest Spring Security 6.1 release. This recipe will modify an
+  application's build files, make changes to deprecated/preferred APIs, and migrate configuration settings that have
+  changes between versions.
+tags:
+  - spring
+  - security
+recipeList:
+  - org.openrewrite.java.spring.security5.UpgradeSpringSecurity_6_0
+  - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
+      groupId: org.springframework.security
+      artifactId: "*"
+      newVersion: 6.1.x
+      overrideManagedVersion: false
+  - org.openrewrite.java.spring.boot2.HttpSecurityLambdaDsl
+  - org.openrewrite.java.spring.boot2.ServerHttpSecurityLambdaDsl

--- a/src/main/resources/META-INF/rewrite/spring-security-61.yml
+++ b/src/main/resources/META-INF/rewrite/spring-security-61.yml
@@ -33,3 +33,4 @@ recipeList:
       overrideManagedVersion: false
   - org.openrewrite.java.spring.boot2.HttpSecurityLambdaDsl
   - org.openrewrite.java.spring.boot2.ServerHttpSecurityLambdaDsl
+  - org.openrewrite.java.spring.boot2.HeadersConfigurerLambdaDsl

--- a/src/testWithSpringBoot_2_4/java/org/openrewrite/java/spring/boot2/HeadersConfigurerLambdaDslTest.java
+++ b/src/testWithSpringBoot_2_4/java/org/openrewrite/java/spring/boot2/HeadersConfigurerLambdaDslTest.java
@@ -1,0 +1,212 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.spring.boot2;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+class HeadersConfigurerLambdaDslTest implements RewriteTest {
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(new HeadersConfigurerLambdaDsl())
+          .parser(JavaParser.fromJavaVersion()
+            .classpath("spring-beans", "spring-context", "spring-boot", "spring-security", "spring-web", "tomcat-embed", "spring-core"));
+    }
+
+    @Test
+    void simpleContentSecurityPolicy() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+
+@EnableWebSecurity
+public class ConventionalSecurityConfig extends WebSecurityConfigurerAdapter {
+
+    @Override
+    protected void configure(HttpSecurity http) throws Exception {
+        http
+                .headers(headers -> headers
+                         .contentSecurityPolicy("foobar"));
+    }
+}
+              """,
+            """
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+
+@EnableWebSecurity
+public class ConventionalSecurityConfig extends WebSecurityConfigurerAdapter {
+
+    @Override
+    protected void configure(HttpSecurity http) throws Exception {
+        http
+                .headers(headers -> headers
+                        .contentSecurityPolicy(policy -> policy
+                                .policyDirectives("foobar")));
+    }
+}
+              """
+          )
+        );
+    }
+
+    @Test
+    void complexContentSecurityPolicy() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+
+@EnableWebSecurity
+public class ConventionalSecurityConfig extends WebSecurityConfigurerAdapter {
+
+    @Override
+    protected void configure(HttpSecurity http) throws Exception {
+        http
+                .headers(headers -> headers
+                        .contentSecurityPolicy("foobar").reportOnly());
+    }
+}
+              """,
+            """
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+
+@EnableWebSecurity
+public class ConventionalSecurityConfig extends WebSecurityConfigurerAdapter {
+
+    @Override
+    protected void configure(HttpSecurity http) throws Exception {
+        http
+                .headers(headers -> headers
+                        .contentSecurityPolicy(policy -> policy
+                                .policyDirectives("foobar").reportOnly()));
+    }
+}
+              """
+          )
+        );
+    }
+
+    @Test
+    void referrerPolicy() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.web.header.writers.ReferrerPolicyHeaderWriter.ReferrerPolicy;
+
+@EnableWebSecurity
+public class ConventionalSecurityConfig extends WebSecurityConfigurerAdapter {
+
+    @Override
+    protected void configure(HttpSecurity http) throws Exception {
+        http
+                .headers(headers -> headers
+                         .referrerPolicy(ReferrerPolicy.ORIGIN));
+    }
+}
+              """,
+            """
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.web.header.writers.ReferrerPolicyHeaderWriter.ReferrerPolicy;
+
+@EnableWebSecurity
+public class ConventionalSecurityConfig extends WebSecurityConfigurerAdapter {
+
+    @Override
+    protected void configure(HttpSecurity http) throws Exception {
+        http
+                .headers(headers -> headers
+                        .referrerPolicy(policy -> policy
+                                .policy(ReferrerPolicy.ORIGIN)));
+    }
+}
+              """
+          )
+        );
+    }
+
+    @Test
+    void mix() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.web.header.writers.ReferrerPolicyHeaderWriter.ReferrerPolicy;
+
+@EnableWebSecurity
+public class ConventionalSecurityConfig extends WebSecurityConfigurerAdapter {
+
+    @Override
+    protected void configure(HttpSecurity http) throws Exception {
+        http
+                .headers(headers -> headers
+                         .contentSecurityPolicy("foobar").reportOnly().and()
+                         .cacheControl().and()
+                         .referrerPolicy(ReferrerPolicy.ORIGIN));
+    }
+}
+              """,
+            """
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.web.header.writers.ReferrerPolicyHeaderWriter.ReferrerPolicy;
+
+import static org.springframework.security.config.Customizer.withDefaults;
+
+@EnableWebSecurity
+public class ConventionalSecurityConfig extends WebSecurityConfigurerAdapter {
+
+    @Override
+    protected void configure(HttpSecurity http) throws Exception {
+        http
+                .headers(headers -> headers
+                        .contentSecurityPolicy(policy -> policy
+                                .policyDirectives("foobar").reportOnly())
+                        .cacheControl(withDefaults())
+                        .referrerPolicy(policy -> policy
+                                .policy(ReferrerPolicy.ORIGIN)));
+    }
+}
+              """
+          )
+        );
+    }
+
+}


### PR DESCRIPTION
## What's changed?
Two things:
- moved Spring Security Lambda DSL recipes from SB 2.4 to the point at which the non-lambda DSL was deprecated: Spring Security 6.1 (new file) used by SB 3.1
- added argReplacements option to ConvertToSecurityDslVisitor, enabling migration of non-lambda-DSL overloads which accept an argument. then used that new feature to implement HeadersConfigurerLambdaDsl.

## What's your motivation?
- avoiding making changes "too early"
- #415

## Anything in particular you'd like reviewers to focus on?
The changes to `ConvertToSecurityDslVisitor` haven't broken any existing tests, but, still good to spot-check.
Also, if anyone is aware of other HttpSecurity-relevant methods which can be covered now that we have the `argReplacements` mechanism, then it would be good to (minimally) define that scope.

## Anyone you would like to review specifically?
@shanman190 @BoykoAlex @timtebeek 

### Checklist
- [X] I've added unit tests to cover both positive and negative cases
- [X] I've added the license header to any new files through `./gradlew licenseFormat`
- [X] I've used the IntelliJ auto-formatter on affected files
- ~~[ ] I've updated the documentation (if applicable)~~
