### PR TITLE
Migrate Hibernate as part of Spring Boot migration

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -120,9 +120,9 @@ dependencies {
     implementation("org.openrewrite.gradle.tooling:model:${rewriteVersion}")
 
     runtimeOnly("org.openrewrite:rewrite-java-17:$rewriteVersion")
-    runtimeOnly("org.openrewrite.recipe:rewrite-testing-frameworks:$rewriteVersion")
+    runtimeOnly("org.openrewrite.recipe:rewrite-hibernate:$rewriteVersion")
     runtimeOnly("org.openrewrite.recipe:rewrite-migrate-java:$rewriteVersion")
-    runtimeOnly("org.openrewrite:rewrite-java-17:$rewriteVersion")
+    runtimeOnly("org.openrewrite.recipe:rewrite-testing-frameworks:$rewriteVersion")
 
     testRuntimeOnly("ch.qos.logback:logback-classic:1.+")
     testRuntimeOnly(gradleApi())

--- a/src/main/resources/META-INF/rewrite/spring-boot-30.yml
+++ b/src/main/resources/META-INF/rewrite/spring-boot-30.yml
@@ -64,6 +64,7 @@ recipeList:
   - org.openrewrite.java.spring.boot3.MigrateThymeleafDependencies
   - org.openrewrite.java.spring.security6.UpgradeSpringSecurity_6_0
   - org.openrewrite.java.spring.cloud2022.UpgradeSpringCloud_2022
+  - org.openrewrite.hibernate.MigrateToHibernate61
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.spring.boot3.ActuatorEndpointSanitization

--- a/src/main/resources/META-INF/rewrite/spring-boot-31.yml
+++ b/src/main/resources/META-INF/rewrite/spring-boot-31.yml
@@ -37,6 +37,7 @@ recipeList:
       pluginIdPattern: org.springframework.boot
       newVersion: 3.1.x
   - org.openrewrite.java.spring.boot3.SpringBootProperties_3_1
+  - org.openrewrite.hibernate.MigrateToHibernate62
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.spring.boot3.SpringBootProperties_3_1


### PR DESCRIPTION
## What's changed?
- Added dependency on rewrite-hibernate
- Chain in Hibernate 6.1/62 migrations when upgrading Spring Boot 3.0/3.1

## What's your motivation?
> I'd like to have this recipe while running Boot 2.x to 3.x upgrade. -- @BoykoAlex 

## Have you considered any alternatives or workarounds?
We _could_ migrate hibernate as part of Spring Framework migrations instead, but this seemed most appropriate given the managed dependency versions.

## Any additional context
- https://github.com/openrewrite/rewrite-hibernate/pull/8
- https://docs.spring.io/spring-boot/docs/3.0.x/reference/htmlsingle/#appendix.dependency-versions.coordinates
- https://docs.spring.io/spring-boot/docs/3.1.x/reference/htmlsingle/#appendix.dependency-versions