### PR TITLE
Moved WebSecurityConfigurerAdapter to spring-security 5.7 (new file) …

### DIFF
--- a/src/main/resources/META-INF/rewrite/spring-boot-27.yml
+++ b/src/main/resources/META-INF/rewrite/spring-boot-27.yml
@@ -39,6 +39,7 @@ recipeList:
   - org.openrewrite.gradle.plugins.UpgradePluginVersion:
       pluginIdPattern: org.springframework.boot
       newVersion: 2.7.x
+  - org.openrewrite.java.spring.security5.UpgradeSpringSecurity_5_7
   # Use recommended replacements for deprecated APIs
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: org.springframework.boot.web.server.LocalServerPort

--- a/src/main/resources/META-INF/rewrite/spring-security-57.yml
+++ b/src/main/resources/META-INF/rewrite/spring-security-57.yml
@@ -1,0 +1,33 @@
+#
+# Copyright 2023 the original author or authors.
+# <p>
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# <p>
+# https://www.apache.org/licenses/LICENSE-2.0
+# <p>
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.spring.security5.UpgradeSpringSecurity_5_7
+displayName: Migrate to Spring Security 5.7
+description: >
+  Migrate applications to the latest Spring Security 5.7 release. This recipe will modify an
+  application's build files, make changes to deprecated/preferred APIs, and migrate configuration settings that have
+  changes between versions.
+tags:
+  - spring
+  - security
+recipeList:
+  - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
+      groupId: org.springframework.security
+      artifactId: "*"
+      newVersion: 5.7.x
+      overrideManagedVersion: false
+  - org.openrewrite.java.spring.security5.WebSecurityConfigurerAdapter

--- a/src/main/resources/META-INF/rewrite/spring-security-58.yml
+++ b/src/main/resources/META-INF/rewrite/spring-security-58.yml
@@ -25,6 +25,7 @@ tags:
   - spring
   - security
 recipeList:
+  - org.openrewrite.java.spring.security5.UpgradeSpringSecurity_5_7
   - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
       groupId: org.springframework.security
       artifactId: "*"
@@ -37,7 +38,6 @@ recipeList:
   - org.openrewrite.java.spring.security5.UpdateArgon2PasswordEncoder
   - org.openrewrite.java.spring.security5.ReplaceGlobalMethodSecurityWithMethodSecurity
   - org.openrewrite.java.spring.security5.ReplaceGlobalMethodSecurityWithMethodSecurityXml
-  - org.openrewrite.java.spring.security5.WebSecurityConfigurerAdapter
 
 ---
 type: specs.openrewrite.org/v1beta/recipe


### PR DESCRIPTION
…used by spring-boot 2.7

## What's your motivation?
Currently, this recipe gets called as part of spring security 5.8 / spring boot 3.0, which is one version *after* the relevant class has already been deprecated

### Checklist
- ~~[ ] I've added unit tests to cover both positive and negative cases~~
- [X] I've added the license header to any new files through `./gradlew licenseFormat`
- [X] I've used the IntelliJ auto-formatter on affected files
- ~~[ ] I've updated the documentation (if applicable)~~
