### PR TITLE
Update usage of list and call getItems when needed

### DIFF
--- a/src/main/java/org/openrewrite/java/spring/batch/MigrateItemWriterWrite.java
+++ b/src/main/java/org/openrewrite/java/spring/batch/MigrateItemWriterWrite.java
@@ -182,7 +182,7 @@ public class MigrateItemWriterWrite extends Recipe {
 
         private boolean notAssignableFromChunk(@Nullable JavaType type) {
             // Iterable is the only common type between List and Chunk
-            return type != null && !type.toString().startsWith(ITERABLE_FQN);
+            return !TypeUtils.isOfClassType(type, ITERABLE_FQN);
         }
 
         private boolean isParameter(J.Identifier maybeParameter) {

--- a/src/main/java/org/openrewrite/java/spring/batch/MigrateItemWriterWrite.java
+++ b/src/main/java/org/openrewrite/java/spring/batch/MigrateItemWriterWrite.java
@@ -129,7 +129,7 @@ public class MigrateItemWriterWrite extends Recipe {
                     mi = mi.withSelect(newGetItemsMethodInvocation(mi.getPadding().getSelect()));
                 }
             }
-            if (mi.getMethodType() != null && !ITEM_WRITER_MATCHER.matches(mi)) {
+            if (!ITEM_WRITER_MATCHER.matches(mi)) {
                 final List<JavaType> parameterTypes = mi.getMethodType().getParameterTypes();
                 mi = mi.withArguments(ListUtils.map(mi.getArguments(), (i, e) -> {
                     if (e instanceof J.Identifier && isParameter((J.Identifier) e)) {


### PR DESCRIPTION
## What's changed?
After changing the type of the method, we can have scenarios where the method was manipulating the original List, and the used methods does not exist in Chunk. So we need to call `Chunk::getItems` to retrieve the actual list and keep compilable code.
Also calling getItems when needed on assignments, variable initialization and method invocations (if the destination type is not `java.lang.Iterable` since it's the only common interface between List and Chunk).

## What's your motivation?
Fixes #411 

## Anything in particular you'd like reviewers to focus on?
Any other corner case where we should call getItems?

## Anyone you would like to review specifically?
@timtebeek @sambsnyd 

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've added the license header to any new files through `./gradlew licenseFormat`
- [x] I've used the IntelliJ IDEA auto-formatter on affected files

