### PR TITLE
Convert `oauth2*` Spring Security subcomponents to lambda dsl

### DIFF
--- a/src/main/java/org/openrewrite/java/spring/security6/oauth2/client/OAuth2ClientLambdaDsl.java
+++ b/src/main/java/org/openrewrite/java/spring/security6/oauth2/client/OAuth2ClientLambdaDsl.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.spring.security6.oauth2.client;
+
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Preconditions;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.search.UsesType;
+import org.openrewrite.java.spring.boot2.ConvertToSecurityDslVisitor;
+
+import java.util.Collection;
+import java.util.Collections;
+
+@Value
+@EqualsAndHashCode(callSuper = true)
+public class OAuth2ClientLambdaDsl extends Recipe {
+    private static final String FQN_OAUTH2_CLIENT_CONFIGURER = "org.springframework.security.config.annotation.web.configurers.oauth2.client.OAuth2ClientConfigurer";
+
+    private static final Collection<String> APPLICABLE_METHODS = Collections.singletonList("authorizationCodeGrant");
+
+    @Override
+    public String getDisplayName() {
+        return "Convert `OAuth2ClientConfigurer` chained calls into Lambda DSL";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Converts `OAuth2ClientConfigurer` chained call from Spring Security pre 5.2.x into new lambda DSL style calls and removes `and()` methods.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return Preconditions.check(
+                new UsesType<>(FQN_OAUTH2_CLIENT_CONFIGURER, true),
+                new ConvertToSecurityDslVisitor<>(FQN_OAUTH2_CLIENT_CONFIGURER, APPLICABLE_METHODS)
+        );
+    }
+}

--- a/src/main/java/org/openrewrite/java/spring/security6/oauth2/client/OAuth2LoginLambdaDsl.java
+++ b/src/main/java/org/openrewrite/java/spring/security6/oauth2/client/OAuth2LoginLambdaDsl.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.spring.security6.oauth2.client;
+
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Preconditions;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.search.UsesType;
+import org.openrewrite.java.spring.boot2.ConvertToSecurityDslVisitor;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+@Value
+@EqualsAndHashCode(callSuper = true)
+public class OAuth2LoginLambdaDsl extends Recipe {
+    private static final String FQN_OAUTH2_LOGIN_CONFIGURER = "org.springframework.security.config.annotation.web.configurers.oauth2.client.OAuth2LoginConfigurer";
+
+    private static final Collection<String> APPLICABLE_METHOD_NAMES = Arrays.asList("authorizationEndpoint", "redirectionEndpoint",
+            "tokenEndpoint", "userInfoEndpoint");
+    @Override
+    public String getDisplayName() {
+        return "Convert `OAuth2LoginConfigurer` chained calls into Lambda DSL";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Converts `OAuth2LoginConfigurer` chained call from Spring Security pre 5.2.x into new lambda DSL style calls and removes `and()` methods.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return Preconditions.check(
+                new UsesType<>(FQN_OAUTH2_LOGIN_CONFIGURER, true),
+                new ConvertToSecurityDslVisitor<>(FQN_OAUTH2_LOGIN_CONFIGURER, APPLICABLE_METHOD_NAMES)
+        );
+    }
+}

--- a/src/main/java/org/openrewrite/java/spring/security6/oauth2/server/resource/OAuth2ResourceServerLambdaDsl.java
+++ b/src/main/java/org/openrewrite/java/spring/security6/oauth2/server/resource/OAuth2ResourceServerLambdaDsl.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.spring.security6.oauth2.server.resource;
+
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Preconditions;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.search.UsesType;
+import org.openrewrite.java.spring.boot2.ConvertToSecurityDslVisitor;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+@Value
+@EqualsAndHashCode(callSuper = true)
+public class OAuth2ResourceServerLambdaDsl extends Recipe {
+    private static final String FQN_OAUTH2_CLIENT_CONFIGURER = "org.springframework.security.config.annotation.web.configurers.oauth2.server.resource.OAuth2ResourceServerConfigurer";
+
+    private static final Collection<String> APPLICABLE_METHODS = Arrays.asList("jwt", "opaqueToken");
+
+    @Override
+    public String getDisplayName() {
+        return "Convert `OAuth2ResourceServerConfigurer` chained calls into Lambda DSL";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Converts `OAuth2ResourceServerConfigurer` chained call from Spring Security pre 5.2.x into new lambda DSL style calls and removes `and()` methods.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return Preconditions.check(
+                new UsesType<>(FQN_OAUTH2_CLIENT_CONFIGURER, true),
+                new ConvertToSecurityDslVisitor<>(FQN_OAUTH2_CLIENT_CONFIGURER, APPLICABLE_METHODS)
+        );
+    }
+}

--- a/src/main/resources/META-INF/rewrite/spring-security-60.yml
+++ b/src/main/resources/META-INF/rewrite/spring-security-60.yml
@@ -34,7 +34,8 @@ recipeList:
   - org.openrewrite.java.spring.security6.UseSha256InRememberMe
   - org.openrewrite.java.spring.security6.PropagateAuthenticationServiceExceptions
   - org.openrewrite.java.spring.security6.RequireExplicitSavingOfSecurityContextRepository
-  - org.openrewrite.java.spring.security6.RemoveOauth2LoginConfig
+# TODO: Presently violates the "do no harm" principle
+#  - org.openrewrite.java.spring.security6.RemoveOauth2LoginConfig
   - org.openrewrite.java.spring.security6.UpdateRequestCache
   - org.openrewrite.java.spring.security6.RemoveUseAuthorizationManager
   - org.openrewrite.java.spring.security6.UpdateEnableReactiveMethodSecurity

--- a/src/main/resources/META-INF/rewrite/spring-security-61.yml
+++ b/src/main/resources/META-INF/rewrite/spring-security-61.yml
@@ -34,3 +34,6 @@ recipeList:
   - org.openrewrite.java.spring.boot2.HttpSecurityLambdaDsl
   - org.openrewrite.java.spring.boot2.ServerHttpSecurityLambdaDsl
   - org.openrewrite.java.spring.boot2.HeadersConfigurerLambdaDsl
+  - org.openrewrite.java.spring.security6.oauth2.client.OAuth2LoginLambdaDsl
+  - org.openrewrite.java.spring.security6.oauth2.client.OAuth2ClientLambdaDsl
+  - org.openrewrite.java.spring.security6.oauth2.server.resource.OAuth2ResourceServerLambdaDsl

--- a/src/testWithSpringBoot_2_4/java/org/openrewrite/java/spring/security6/oauth2/client/OAuth2ClientLambdaDslTest.java
+++ b/src/testWithSpringBoot_2_4/java/org/openrewrite/java/spring/security6/oauth2/client/OAuth2ClientLambdaDslTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.spring.security6.oauth2.client;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+class OAuth2ClientLambdaDslTest implements RewriteTest {
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(new OAuth2ClientLambdaDsl())
+          .parser(JavaParser.fromJavaVersion()
+            .classpath("spring-beans", "spring-context", "spring-boot", "spring-security", "spring-web", "tomcat-embed", "spring-core"));
+    }
+
+    @Test
+    void simple() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+              import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+              import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+              
+              @EnableWebSecurity
+              public class ConventionalSecurityConfig extends WebSecurityConfigurerAdapter {
+                  @Override
+                  protected void configure(HttpSecurity http) throws Exception {
+                      http
+                              .oauth2Client(client -> client
+                                      .authorizationCodeGrant()
+                                              .accessTokenResponseClient(null));
+                  }
+              }
+              """,
+            """
+              import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+              import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+              import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+              
+              @EnableWebSecurity
+              public class ConventionalSecurityConfig extends WebSecurityConfigurerAdapter {
+                  @Override
+                  protected void configure(HttpSecurity http) throws Exception {
+                      http
+                              .oauth2Client(client -> client
+                                      .authorizationCodeGrant(grant -> grant
+                                              .accessTokenResponseClient(null)));
+                  }
+              }
+              """
+          )
+        );
+    }
+}

--- a/src/testWithSpringBoot_2_4/java/org/openrewrite/java/spring/security6/oauth2/client/OAuth2LoginLambdaDslTest.java
+++ b/src/testWithSpringBoot_2_4/java/org/openrewrite/java/spring/security6/oauth2/client/OAuth2LoginLambdaDslTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.spring.security6.oauth2.client;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+class OAuth2LoginLambdaDslTest implements RewriteTest {
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(new OAuth2LoginLambdaDsl())
+          .parser(JavaParser.fromJavaVersion()
+            .classpath("spring-beans", "spring-context", "spring-boot", "spring-security", "spring-web", "tomcat-embed", "spring-core"));
+    }
+
+    @Test
+    void advanced() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+              import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+              import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+              
+              @EnableWebSecurity
+              public class ConventionalSecurityConfig extends WebSecurityConfigurerAdapter {
+                  @Override
+                  protected void configure(HttpSecurity http) throws Exception {
+                      http
+                              .oauth2Login(login -> login
+                                      .tokenEndpoint()
+                                              .accessTokenResponseClient(authorizationGrantRequest -> null)
+                                              .and()
+                                      .userInfoEndpoint()
+                                              .userAuthoritiesMapper(authorities -> null));
+                  }
+              }
+              """,
+            """
+              import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+              import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+              import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+              
+              @EnableWebSecurity
+              public class ConventionalSecurityConfig extends WebSecurityConfigurerAdapter {
+                  @Override
+                  protected void configure(HttpSecurity http) throws Exception {
+                      http
+                              .oauth2Login(login -> login
+                                      .tokenEndpoint(endpoint -> endpoint
+                                              .accessTokenResponseClient(authorizationGrantRequest -> null))
+                                      .userInfoEndpoint(endpoint -> endpoint
+                                              .userAuthoritiesMapper(authorities -> null)));
+                  }
+              }
+              """
+          )
+        );
+    }
+}

--- a/src/testWithSpringBoot_2_4/java/org/openrewrite/java/spring/security6/oauth2/server/resource/OAuth2ResourceServerLambdaDslTest.java
+++ b/src/testWithSpringBoot_2_4/java/org/openrewrite/java/spring/security6/oauth2/server/resource/OAuth2ResourceServerLambdaDslTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.spring.security6.oauth2.server.resource;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+class OAuth2ResourceServerLambdaDslTest implements RewriteTest {
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(new OAuth2ResourceServerLambdaDsl())
+          .parser(JavaParser.fromJavaVersion()
+            .classpath("spring-beans", "spring-context", "spring-boot", "spring-security", "spring-web", "tomcat-embed", "spring-core"));
+    }
+
+    @Test
+    void advanced() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+              import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+              import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+              
+              @EnableWebSecurity
+              public class ConventionalSecurityConfig extends WebSecurityConfigurerAdapter {
+                  @Override
+                  protected void configure(HttpSecurity http) throws Exception {
+                      http
+                              .oauth2ResourceServer(server -> server
+                                      .jwt()
+                                              .jwkSetUri("")
+                                              .and()
+                                      .opaqueToken()
+                                              .introspectionUri(""));
+                  }
+              }
+              """,
+            """
+              import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+              import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+              import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+              
+              @EnableWebSecurity
+              public class ConventionalSecurityConfig extends WebSecurityConfigurerAdapter {
+                  @Override
+                  protected void configure(HttpSecurity http) throws Exception {
+                      http
+                              .oauth2ResourceServer(server -> server
+                                      .jwt(jwt -> jwt
+                                              .jwkSetUri(""))
+                                      .opaqueToken(token -> token
+                                              .introspectionUri("")));
+                  }
+              }
+              """
+          )
+        );
+    }
+}


### PR DESCRIPTION
## What's changed?
Add lambda dsl conversions for `oauth2Login`, `oauth2Client`, and `oauth2ResourceServer` subcomponents.

## What's your motivation?
Preparing for the Spring Security 7.x migration where the lambda DSL will be required.

## Anyone you would like to review specifically?
@timtebeek @nmck257 @BoykoAlex 

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've added the license header to any new files through `./gradlew licenseFormat`
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
- [ ] I've updated the documentation (if applicable)
