### PR TITLE
bump some versions on some tests

### DIFF
--- a/src/testWithSpringBoot_2_7/java/org/openrewrite/gradle/spring/UpdateGradleTest.java
+++ b/src/testWithSpringBoot_2_7/java/org/openrewrite/gradle/spring/UpdateGradleTest.java
@@ -65,7 +65,7 @@ class UpdateGradleTest implements RewriteTest {
             """
               plugins {
                   id "java"
-                  id "org.springframework.boot" version "2.7.14"
+                  id "org.springframework.boot" version "2.7.15"
                   id "io.spring.dependency-management" version "1.0.15.RELEASE"
               }
               
@@ -148,7 +148,7 @@ class UpdateGradleTest implements RewriteTest {
             """
               plugins {
                   id "java"
-                  id "org.springframework.boot" version "2.7.14"
+                  id "org.springframework.boot" version "2.7.15"
               }
               
               repositories {

--- a/src/testWithSpringBoot_2_7/java/org/openrewrite/gradle/spring/UpdateGradleTest.java
+++ b/src/testWithSpringBoot_2_7/java/org/openrewrite/gradle/spring/UpdateGradleTest.java
@@ -15,13 +15,15 @@
  */
 package org.openrewrite.gradle.spring;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.Tree;
 import org.openrewrite.config.Environment;
 import org.openrewrite.marker.BuildTool;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.openrewrite.gradle.Assertions.buildGradle;
@@ -60,12 +62,14 @@ class UpdateGradleTest implements RewriteTest {
               dependencies {
                   implementation "org.springframework.boot:spring-boot-starter-web"
               }
-              """,
-            //language=gradle
-            """
+              """, spec -> spec.after(gradle -> {
+                Matcher version = Pattern.compile("2\\.7\\.\\d+").matcher(gradle);
+                assertThat(version.find()).describedAs("Expected 2.7.x in %s", gradle).isTrue();
+                //language=gradle
+                return """
               plugins {
                   id "java"
-                  id "org.springframework.boot" version "2.7.15"
+                  id "org.springframework.boot" version "%s"
                   id "io.spring.dependency-management" version "1.0.15.RELEASE"
               }
               
@@ -76,7 +80,9 @@ class UpdateGradleTest implements RewriteTest {
               dependencies {
                   implementation "org.springframework.boot:spring-boot-starter-web"
               }
-              """
+              """.formatted(version.group());
+            })
+            //language=gradle
           ),
           properties(
             //language=properties
@@ -143,12 +149,14 @@ class UpdateGradleTest implements RewriteTest {
                   implementation platform("org.springframework.boot:spring-boot-dependencies:2.6.15")
                   implementation "org.springframework.boot:spring-boot-starter-web"
               }
-              """,
-            //language=gradle
-            """
+              """, spec -> spec.after(gradle -> {
+                Matcher version = Pattern.compile("2\\.7\\.\\d+").matcher(gradle);
+                assertThat(version.find()).describedAs("Expected 2.7.x in %s", gradle).isTrue();
+                //language=gradle
+                return """
               plugins {
                   id "java"
-                  id "org.springframework.boot" version "2.7.15"
+                  id "org.springframework.boot" version "%s"
               }
               
               repositories {
@@ -156,10 +164,11 @@ class UpdateGradleTest implements RewriteTest {
               }
               
               dependencies {
-                  implementation platform("org.springframework.boot:spring-boot-dependencies:2.7.14")
+                  implementation platform("org.springframework.boot:spring-boot-dependencies:%s")
                   implementation "org.springframework.boot:spring-boot-starter-web"
               }
-              """
+              """.formatted(version.group(), version.group());
+            })
           ),
           properties(
             //language=properties

--- a/src/testWithSpringBoot_2_7/java/org/openrewrite/java/spring/boot2/UpdateMysqlDriverArtifactIdTest.java
+++ b/src/testWithSpringBoot_2_7/java/org/openrewrite/java/spring/boot2/UpdateMysqlDriverArtifactIdTest.java
@@ -204,7 +204,7 @@ public class UpdateMysqlDriverArtifactIdTest implements RewriteTest {
                 """
                   plugins {
                     id 'java'
-                    id 'org.springframework.boot' version '2.7.14'
+                    id 'org.springframework.boot' version '2.7.15'
                     id 'io.spring.dependency-management' version '1.0.15.RELEASE'
                   }
                   

--- a/src/testWithSpringBoot_2_7/java/org/openrewrite/java/spring/boot2/UpdateMysqlDriverArtifactIdTest.java
+++ b/src/testWithSpringBoot_2_7/java/org/openrewrite/java/spring/boot2/UpdateMysqlDriverArtifactIdTest.java
@@ -20,7 +20,6 @@ import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.Issue;
 import org.openrewrite.config.Environment;
-import org.openrewrite.gradle.Assertions;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
@@ -29,6 +28,7 @@ import java.util.regex.Pattern;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.openrewrite.gradle.Assertions.withToolingApi;
+import static org.openrewrite.gradle.Assertions.buildGradle;
 import static org.openrewrite.maven.Assertions.pomXml;
 
 @Issue("https://github.com/openrewrite/rewrite-spring/issues/274")
@@ -151,7 +151,7 @@ public class UpdateMysqlDriverArtifactIdTest implements RewriteTest {
         void switchArtifactIdAndUpdateVersionNumber() {
             rewriteRun(spec -> spec.beforeRecipe(withToolingApi()),
               //language=groovy
-              Assertions.buildGradle(
+              buildGradle(
                 """
                   plugins {
                     id 'java'
@@ -184,8 +184,8 @@ public class UpdateMysqlDriverArtifactIdTest implements RewriteTest {
         @Test
         void doNotPinWhenNotVersioned() {
             rewriteRun(spec -> spec.beforeRecipe(withToolingApi()),
-              //language=groovy
-              Assertions.buildGradle(
+              buildGradle(
+                //language=gradle
                 """
                   plugins {
                     id 'java'
@@ -200,11 +200,14 @@ public class UpdateMysqlDriverArtifactIdTest implements RewriteTest {
                   dependencies {
                       runtimeOnly 'mysql:mysql-connector-java'
                   }
-                  """,
-                """
+                  """, spec -> spec.after(gradle -> {
+                    Matcher version = Pattern.compile("2\\.7\\.\\d+").matcher(gradle);
+                    assertThat(version.find()).describedAs("Expected 2.7.x in %s", gradle).isTrue();
+                    //language=gradle
+                    return """
                   plugins {
                     id 'java'
-                    id 'org.springframework.boot' version '2.7.15'
+                    id 'org.springframework.boot' version '%s'
                     id 'io.spring.dependency-management' version '1.0.15.RELEASE'
                   }
                   
@@ -215,7 +218,9 @@ public class UpdateMysqlDriverArtifactIdTest implements RewriteTest {
                   dependencies {
                       runtimeOnly 'com.mysql:mysql-connector-j'
                   }
-                  """)
+                  """.formatted(version.group());
+                  })
+              )
             );
         }
     }


### PR DESCRIPTION
## What's changed?
There has been a new patch release of 2.7.x
Updated the tests so we validate that the updated version is in the 2.7.x range instead of looking for an specific match.
