### PR TITLE
[Test purpose only]Attempt to fix CI

### DIFF
--- a/gradlew
+++ b/gradlew
@@ -86,6 +86,9 @@ APP_BASE_NAME=${0##*/}
 # Discard cd standard output in case $CDPATH is set (https://github.com/gradle/gradle/issues/25036)
 APP_HOME=$( cd "${APP_HOME:-./}" > /dev/null && pwd -P ) || exit
 
+# Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
+DEFAULT_JVM_OPTS='"-Xmx64m" "-Xms64m"'
+
 # Use the maximum available, or set MAX_FD != -1 to use that value.
 MAX_FD=maximum
 
@@ -198,9 +201,6 @@ if "$cygwin" || "$msys" ; then
     done
 fi
 
-
-# Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
-DEFAULT_JVM_OPTS='"-Xmx64m" "-Xms64m"'
 
 # Collect all arguments for the java command;
 #   * $DEFAULT_JVM_OPTS, $JAVA_OPTS, and $GRADLE_OPTS can contain fragments of

--- a/gradlew
+++ b/gradlew
@@ -86,9 +86,6 @@ APP_BASE_NAME=${0##*/}
 # Discard cd standard output in case $CDPATH is set (https://github.com/gradle/gradle/issues/25036)
 APP_HOME=$( cd "${APP_HOME:-./}" > /dev/null && pwd -P ) || exit
 
-# Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
-DEFAULT_JVM_OPTS='"-Xmx64m" "-Xms64m"'
-
 # Use the maximum available, or set MAX_FD != -1 to use that value.
 MAX_FD=maximum
 
@@ -201,6 +198,9 @@ if "$cygwin" || "$msys" ; then
     done
 fi
 
+
+# Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
+DEFAULT_JVM_OPTS='"-Xmx64m" "-Xms64m"'
 
 # Collect all arguments for the java command;
 #   * $DEFAULT_JVM_OPTS, $JAVA_OPTS, and $GRADLE_OPTS can contain fragments of

--- a/src/testWithSpringBoot_2_7/java/org/openrewrite/java/spring/boot2/UpdateMysqlDriverArtifactIdTest.java
+++ b/src/testWithSpringBoot_2_7/java/org/openrewrite/java/spring/boot2/UpdateMysqlDriverArtifactIdTest.java
@@ -37,7 +37,7 @@ class UpdateMysqlDriverArtifactIdTest implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
         spec.recipe(Environment.builder()
-          .scanRuntimeClasspath("org.openrewrite.java.spring.boot2")
+          .scanRuntimeClasspath()
           .build()
           .activateRecipes("org.openrewrite.java.spring.boot2.UpgradeSpringBoot_2_7"));
     }


### PR DESCRIPTION
We are seeing CI build failure caused by failing tests 
```
UpdateMysqlDriverArtifactIdTest > Gradle > switchArtifactIdAndUpdateVersionNumber() FAILED
    java.lang.AssertionError: [Recipe validation must have no failures] 
    Expecting no elements of:
      [[Valid{property='initialization', value='org.openrewrite.config.DeclarativeRecipe@9748ae0c'},
        Valid{property='initialization', value='org.openrewrite.config.DeclarativeRecipe@9748ae0c'},
        Valid{property='initialization', value='org.openrewrite.config.DeclarativeRecipe@9748ae0b'},
        Valid{property='initialization', value='org.openrewrite.config.DeclarativeRecipe@9748ae0a'},
        Valid{property='initialization', value='org.openrewrite.config.DeclarativeRecipe@9748ae09'},
        Valid{property='initialization', value='org.openrewrite.config.DeclarativeRecipe@9748ae08'},
```

Trying to fix it by reverting some changes recently.