### PR TITLE
Add recipe to upgrade to springdoc-openapi 2

### DIFF
--- a/src/main/resources/META-INF/rewrite/spring-boot-30.yml
+++ b/src/main/resources/META-INF/rewrite/spring-boot-30.yml
@@ -62,6 +62,7 @@ recipeList:
   - org.openrewrite.java.spring.boot3.ConfigurationOverEnableSecurity
   - org.openrewrite.java.spring.boot3.SpringBootProperties_3_0
   - org.openrewrite.java.spring.boot3.MigrateThymeleafDependencies
+  - org.openrewrite.java.spring.boot3.UpgradeSpringDoc_2
   - org.openrewrite.java.spring.security6.UpgradeSpringSecurity_6_0
   - org.openrewrite.java.spring.cloud2022.UpgradeSpringCloud_2022
   - org.openrewrite.hibernate.MigrateToHibernate61
@@ -862,3 +863,80 @@ recipeList:
   - org.openrewrite.java.spring.ChangeSpringPropertyKey:
       oldPropertyKey: management.trace.include
       newPropertyKey: management.httpexchanges.recording.include
+---
+type: specs.openrewrite.org/v1beta/recipe
+
+name: org.openrewrite.java.spring.boot3.UpgradeSpringDoc_2
+displayName: Upgrade to springodc-openapi 2
+description: >
+  Migrate applications to the latest spring-doc 2 release. This recipe will modify an
+  application's build files and make changes code changes for removed/updated APIs.
+  See the [upgrade guide](https://springdoc.org/#migrating-from-springdoc-v1)
+tags:
+  - spring
+recipeList:
+  - org.openrewrite.java.dependencies.RemoveDependency:
+      groupId: org.springdoc
+      artifactId: springdoc-openapi-data-rest
+  - org.openrewrite.java.dependencies.RemoveDependency:
+      groupId: org.springdoc
+      artifactId: springdoc-openapi-groovy
+  - org.openrewrite.java.dependencies.RemoveDependency:
+      groupId: org.springdoc
+      artifactId: springdoc-openapi-hateoas
+  - org.openrewrite.java.dependencies.RemoveDependency:
+      groupId: org.springdoc
+      artifactId: springdoc-openapi-javadoc
+  - org.openrewrite.java.dependencies.RemoveDependency:
+      groupId: org.springdoc
+      artifactId: springdoc-openapi-kotlin
+  - org.openrewrite.java.dependencies.RemoveDependency:
+      groupId: org.springdoc
+      artifactId: springdoc-openapi-security
+  - org.openrewrite.java.dependencies.ChangeDependency:
+      oldGroupId: org.springdoc
+      oldArtifactId: springdoc-openapi-common
+      newArtifactId: springdoc-openapi-starter-common
+      newVersion: 2.x
+  - org.openrewrite.java.dependencies.ChangeDependency:
+      oldGroupId: org.springdoc
+      oldArtifactId: springdoc-openapi-webmvc-core
+      newArtifactId: springdoc-openapi-starter-webmvc-api
+      newVersion: 2.x
+  - org.openrewrite.java.dependencies.ChangeDependency:
+      oldGroupId: org.springdoc
+      oldArtifactId: springdoc-openapi-webflux-core
+      newArtifactId: springdoc-openapi-starter-webflux-api
+      newVersion: 2.x
+  - org.openrewrite.java.dependencies.ChangeDependency:
+      oldGroupId: org.springdoc
+      oldArtifactId: springdoc-openapi-ui
+      newArtifactId: springdoc-openapi-starter-webmvc-ui
+      newVersion: 2.x
+  - org.openrewrite.java.dependencies.ChangeDependency:
+      oldGroupId: org.springdoc
+      oldArtifactId: springdoc-openapi-webflux-ui
+      newArtifactId: springdoc-openapi-starter-webflux-ui
+      newVersion: 2.x
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.springdoc.core.SpringDocUtils
+      newFullyQualifiedTypeName: org.springdoc.core.utils.SpringDocUtils
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.springdoc.api.annotations.ParameterObject
+      newFullyQualifiedTypeName: org.springdoc.core.annotations.ParameterObject
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.springdoc.core.GroupedOpenApi
+      newFullyQualifiedTypeName: org.springdoc.core.models.GroupedOpenApi
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.springdoc.core.customizers.OpenApiCustomiser
+      newFullyQualifiedTypeName: org.springdoc.core.customizers.OpenApiCustomizer
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.springdoc.core.Constants
+      newFullyQualifiedTypeName: org.springdoc.core.utils.Constants
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.springdoc.core.SwaggerUiConfigParameters
+      newFullyQualifiedTypeName: org.springdoc.core.properties.SwaggerUiConfigParameters
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: org.springdoc.core.models.GroupedOpenApi.Builder addOpenApiCustomiser(..)
+      newMethodName: addOpenApiCustomizer
+      matchOverrides: true


### PR DESCRIPTION
Closes #430

<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
Add a recipe to upgrade to springdoc-openapi 2 as part of the spring boot 3 upgrade

## What's your motivation?
https://github.com/openrewrite/rewrite-spring/issues/430

### Checklist
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
