### PR TITLE
Fix mysql dependency in 2.5 already

### DIFF
--- a/src/main/resources/META-INF/rewrite/spring-boot-25.yml
+++ b/src/main/resources/META-INF/rewrite/spring-boot-25.yml
@@ -44,6 +44,15 @@ recipeList:
       addIfMissing: false
   - org.openrewrite.java.spring.boot2.MigrateDatabaseCredentials
 
+  # Spring Boot 2.5 mismanages a pom-only redirect pom of mysql:mysql-connector-java:8.0.33
+  # From 2.6 onwards the managed dependency is com.mysql:mysql-connector-j:8.0.33
+  - org.openrewrite.java.dependencies.ChangeDependency:
+      oldGroupId: mysql
+      newGroupId: com.mysql
+      oldArtifactId: mysql-connector-java
+      newArtifactId: mysql-connector-j
+      newVersion: 8.0.x
+
   # Use recommended replacements for deprecated APIs
   - org.openrewrite.java.spring.boot2.MigrateActuatorMediaTypeToApiVersion
   - org.openrewrite.java.ChangeType:

--- a/src/main/resources/META-INF/rewrite/spring-boot-26.yml
+++ b/src/main/resources/META-INF/rewrite/spring-boot-26.yml
@@ -43,14 +43,6 @@ recipeList:
       pluginIdPattern: org.springframework.boot
       newVersion: 2.6.x
 
-  # From 2.6 onwards the managed dependency is com.mysql:mysql-connector-j:8.0.33
-  - org.openrewrite.java.dependencies.ChangeDependency:
-      oldGroupId: mysql
-      newGroupId: com.mysql
-      oldArtifactId: mysql-connector-java
-      newArtifactId: mysql-connector-j
-      newVersion: 8.0.x
-
   # Update properties
   - org.openrewrite.java.spring.boot2.SpringBootProperties_2_6
 

--- a/src/testWithSpringBoot_2_5/java/org/openrewrite/java/spring/boot2/UpdateMysqlDriverArtifactIdTest.java
+++ b/src/testWithSpringBoot_2_5/java/org/openrewrite/java/spring/boot2/UpdateMysqlDriverArtifactIdTest.java
@@ -33,13 +33,12 @@ import static org.openrewrite.maven.Assertions.pomXml;
 
 @Issue("https://github.com/openrewrite/rewrite-spring/issues/274")
 class UpdateMysqlDriverArtifactIdTest implements RewriteTest {
-
     @Override
     public void defaults(RecipeSpec spec) {
         spec.recipe(Environment.builder()
           .scanRuntimeClasspath("org.openrewrite.java.spring")
           .build()
-          .activateRecipes("org.openrewrite.java.spring.boot2.UpgradeSpringBoot_2_7"));
+          .activateRecipes("org.openrewrite.java.spring.boot2.UpgradeSpringBoot_2_5"));
     }
 
     @Nested
@@ -189,7 +188,7 @@ class UpdateMysqlDriverArtifactIdTest implements RewriteTest {
                 """
                   plugins {
                     id 'java'
-                    id 'org.springframework.boot' version '2.6.1'
+                    id 'org.springframework.boot' version '2.5.14'
                     id 'io.spring.dependency-management' version '1.0.11.RELEASE'
                   }
                   
@@ -201,8 +200,8 @@ class UpdateMysqlDriverArtifactIdTest implements RewriteTest {
                       runtimeOnly 'mysql:mysql-connector-java'
                   }
                   """, spec -> spec.after(gradle -> {
-                    Matcher version = Pattern.compile("2\\.7\\.\\d+").matcher(gradle);
-                    assertThat(version.find()).describedAs("Expected 2.7.x in %s", gradle).isTrue();
+                    Matcher version = Pattern.compile("2\\.5\\.\\d+").matcher(gradle);
+                    assertThat(version.find()).describedAs("Expected 2.5.x in %s", gradle).isTrue();
                     //language=gradle
                     return """
                   plugins {


### PR DESCRIPTION
## What's changed?
[Spring Boot 2.5.15](https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-dependencies/2.5.15/spring-boot-dependencies-2.5.15.pom) mismanages a [pom-only redirect pom of mysql:mysql-connector-java:8.0.33](https://repo1.maven.org/maven2/mysql/mysql-connector-java/8.0.33/)
From 2.6 onwards the managed dependency is com.mysql:mysql-connector-j:8.0.33

## What's your motivation?
Broken migration.