### PR TITLE
Upgrade to Spring Cloud 2023 as part of Spring Boot 3.2

### DIFF
--- a/src/main/resources/META-INF/rewrite/spring-boot-32.yml
+++ b/src/main/resources/META-INF/rewrite/spring-boot-32.yml
@@ -42,6 +42,7 @@ recipeList:
   - org.openrewrite.java.spring.security6.UpgradeSpringSecurity_6_2
   - org.openrewrite.java.spring.boot3.SpringBootProperties_3_2
   - org.openrewrite.java.spring.boot3.EnableVirtualThreads
+  - org.openrewrite.java.spring.cloud2023.UpgradeSpringCloud_2023
 
 ---
 type: specs.openrewrite.org/v1beta/recipe

--- a/src/main/resources/META-INF/rewrite/spring-cloud-2022.yml
+++ b/src/main/resources/META-INF/rewrite/spring-cloud-2022.yml
@@ -22,14 +22,14 @@ tags:
   - spring
   - cloud
 recipeList:
-  - org.openrewrite.java.spring.cloud2022.MavenPomUpgrade
+  - org.openrewrite.java.spring.cloud2022.DependencyUpgrades
   - org.openrewrite.java.spring.cloud2022.MigrateCloudSleuthToMicrometerTracing
 
 ---
 type: specs.openrewrite.org/v1beta/recipe
-name: org.openrewrite.java.spring.cloud2022.MavenPomUpgrade
-displayName: Upgrade Maven POM to Spring Cloud 2022
-description: 'Upgrade Maven POM to Spring Cloud 2022 from prior 2021.x version.'
+name: org.openrewrite.java.spring.cloud2022.DependencyUpgrades
+displayName: Upgrade dependencies to Spring Cloud 2022
+description: Upgrade dependencies to Spring Cloud 2022 from prior 2021.x version.
 tags:
   - spring
   - cloud

--- a/src/main/resources/META-INF/rewrite/spring-cloud-2023.yml
+++ b/src/main/resources/META-INF/rewrite/spring-cloud-2023.yml
@@ -1,0 +1,82 @@
+#
+# Copyright 2023 the original author or authors.
+# <p>
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# <p>
+# https://www.apache.org/licenses/LICENSE-2.0
+# <p>
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.spring.cloud2023.UpgradeSpringCloud_2023
+displayName: Migrate to Spring Cloud 2023
+description: Migrate applications to the latest Spring Cloud 2023 release.
+tags:
+  - spring
+  - cloud
+recipeList:
+  - org.openrewrite.java.spring.cloud2022.UpgradeSpringCloud_2022
+  - org.openrewrite.java.spring.cloud2023.DependencyUpgrades
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.spring.cloud2023.DependencyUpgrades
+displayName: Upgrade dependencies to Spring Cloud 2023
+description: Upgrade dependencies to Spring Cloud 2023 from prior 2022.x version.
+tags:
+  - spring
+  - cloud
+recipeList:
+  - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
+      groupId: org.springframework.cloud
+      artifactId: "*"
+      newVersion: 4.1.x
+      overrideManagedVersion: false
+  - org.openrewrite.maven.UpgradeParentVersion:
+      groupId: org.springframework.cloud
+      artifactId: spring-cloud-starter-parent
+      newVersion: 2023.0.x
+  - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
+      groupId: org.springframework.cloud
+      artifactId: spring-cloud-dependencies
+      newVersion: 2023.0.x
+      overrideManagedVersion: false
+  # circuitbreaker, kubernetes & task follow a different versioning scheme
+  # https://docs.spring.io/spring-cloud-release/reference/2023.0/
+  - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
+      groupId: org.springframework.cloud
+      artifactId: spring-cloud-starter-circuitbreaker-*
+      newVersion: 3.1.x
+      overrideManagedVersion: false
+  - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
+      groupId: org.springframework.cloud
+      artifactId: spring-cloud-circuitbreaker-*
+      newVersion: 3.1.x
+      overrideManagedVersion: false
+  - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
+      groupId: org.springframework.cloud
+      artifactId: spring-cloud-starter-kubernetes-*
+      newVersion: 3.1.x
+      overrideManagedVersion: false
+  - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
+      groupId: org.springframework.cloud
+      artifactId: spring-cloud-kubernetes-*
+      newVersion: 3.1.x
+      overrideManagedVersion: false
+  - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
+      groupId: org.springframework.cloud
+      artifactId: spring-cloud-starter-task-*
+      newVersion: 3.1.x
+      overrideManagedVersion: false
+  - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
+      groupId: org.springframework.cloud
+      artifactId: spring-cloud-task-*
+      newVersion: 3.1.x
+      overrideManagedVersion: false


### PR DESCRIPTION
## What's your motivation?
For Spring Boot 3.2 upgrade.

## Any additional context
- https://spring.io/blog/2023/11/02/spring-cloud-2023-0-0-rc1-aka-leyton-is-now-available
- https://github.com/spring-cloud/spring-cloud-release/wiki/Spring-Cloud-2023.0-Release-Notes
- https://twitter.com/m_halbritter/status/1728052671469216167