### PR TITLE
HttpSecurity - replace `apply` with `with`

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ group = "org.openrewrite.recipe"
 description = "Eliminate legacy Spring patterns and migrate between major Spring Boot versions. Automatically."
 
 val springBootVersions: List<String> = listOf("1_5", "2_1", "2_2", "2_3", "2_4", "2_5", "2_6", "2_7", "3_0")
-val springSecurityVersions: List<String> = listOf("5_7", "5_8")
+val springSecurityVersions: List<String> = listOf("5_7", "5_8", "6_2")
 
 val sourceSetNames: Map<String, List<String>> = mapOf(
         Pair("testWithSpringBoot_", springBootVersions),
@@ -244,6 +244,9 @@ dependencies {
     "testWithSpringSecurity_5_8RuntimeOnly"("org.apache.tomcat.embed:tomcat-embed-core:9.0.+")
     "testWithSpringSecurity_5_8RuntimeOnly"("com.nimbusds:nimbus-jose-jwt:9.13")
     "testWithSpringSecurity_5_8RuntimeOnly"("net.minidev:json-smart")
+
+    "testWithSpringSecurity_6_2RuntimeOnly"("org.springframework.security:spring-security-config:6.2.+")
+    "testWithSpringSecurity_6_2RuntimeOnly"("org.springframework.security:spring-security-web:6.2.+")
 }
 
 

--- a/src/main/java/org/openrewrite/java/spring/security6/ApplyToWithLambdaDsl.java
+++ b/src/main/java/org/openrewrite/java/spring/security6/ApplyToWithLambdaDsl.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.spring.security6;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Preconditions;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.search.UsesType;
+import org.openrewrite.java.spring.boot2.ConvertToSecurityDslVisitor;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+public class ApplyToWithLambdaDsl extends Recipe {
+
+    private static final String FQN_ABSTRACT_CONFIGURED_SECURITY_BUILDER =
+            "org.springframework.security.config.annotation.AbstractConfiguredSecurityBuilder";
+
+    private static final Collection<String> APPLICABLE_METHOD_NAMES = Collections.singletonList("apply");
+
+    private static final Map<String, String> ARG_REPLACEMENTS = new HashMap<String, String>() {{
+        put("apply", null);
+    }};
+
+    private static final Map<String, String> METHOD_RENAMES = new HashMap<String, String>() {{
+        put("apply", "with");
+    }};
+
+    @Override
+    public String getDisplayName() {
+        return "Convert `HttpSecurity::apply` chained calls into `HttpSecurity::with` Lambda DSL";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Converts `HttpSecurity::apply` chained call from Spring Security pre 6.2.x into new lambda DSL style calls and removes `and()` methods.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return Preconditions.check(
+          new UsesType<>(FQN_ABSTRACT_CONFIGURED_SECURITY_BUILDER, true),
+          new ConvertToSecurityDslVisitor<>(FQN_ABSTRACT_CONFIGURED_SECURITY_BUILDER,
+                  APPLICABLE_METHOD_NAMES, ARG_REPLACEMENTS, METHOD_RENAMES)
+        );
+    }
+}

--- a/src/main/resources/META-INF/rewrite/spring-security-62.yml
+++ b/src/main/resources/META-INF/rewrite/spring-security-62.yml
@@ -31,3 +31,4 @@ recipeList:
       artifactId: "*"
       newVersion: 6.2.x
       overrideManagedVersion: false
+  - org.openrewrite.java.spring.security6.ApplyToWithLambdaDsl

--- a/src/testWithSpringSecurity_6_2/java/org/openrewrite/spring/security6/.editorconfig
+++ b/src/testWithSpringSecurity_6_2/java/org/openrewrite/spring/security6/.editorconfig
@@ -1,0 +1,5 @@
+root = true
+
+[*.java]
+indent_size = 4
+ij_continuation_indent_size = 2

--- a/src/testWithSpringSecurity_6_2/java/org/openrewrite/spring/security6/ApplyToWithLambdaDslTest.java
+++ b/src/testWithSpringSecurity_6_2/java/org/openrewrite/spring/security6/ApplyToWithLambdaDslTest.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.spring.security6;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.java.spring.security6.ApplyToWithLambdaDsl;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+class ApplyToWithLambdaDslTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(new ApplyToWithLambdaDsl())
+          .parser(JavaParser.fromJavaVersion()
+            .classpath("spring-security-config", "spring-security-web"));
+    }
+
+    @Test
+    void someConfigAndBuild() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+              import org.springframework.security.config.annotation.web.configurers.SessionManagementConfigurer;
+              import org.springframework.security.web.SecurityFilterChain;
+              
+              public class MySecurityConfig {
+                  public SecurityFilterChain configure(HttpSecurity http) {
+                      return http
+                              .apply(new SessionManagementConfigurer<>())
+                              .invalidSessionUrl("junk").and()
+                              .build();
+                  }
+              }
+              """,
+            """
+              import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+              import org.springframework.security.config.annotation.web.configurers.SessionManagementConfigurer;
+              import org.springframework.security.web.SecurityFilterChain;
+              
+              public class MySecurityConfig {
+                  public SecurityFilterChain configure(HttpSecurity http) {
+                      return http
+                              .with(new SessionManagementConfigurer<>(), configurer -> configurer
+                                      .invalidSessionUrl("junk"))
+                              .build();
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void noAdditionalConfig() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+              import org.springframework.security.config.annotation.web.configurers.SessionManagementConfigurer;
+              import org.springframework.security.web.SecurityFilterChain;
+              
+              public class MySecurityConfig {
+                  public SecurityFilterChain configure(HttpSecurity http) {
+                      return http
+                              .apply(new SessionManagementConfigurer<>())
+                              .and()
+                              .build();
+                  }
+              }
+              """,
+            """
+              import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+              import org.springframework.security.config.annotation.web.configurers.SessionManagementConfigurer;
+              import org.springframework.security.web.SecurityFilterChain;
+              
+              import static org.springframework.security.config.Customizer.withDefaults;
+              
+              public class MySecurityConfig {
+                  public SecurityFilterChain configure(HttpSecurity http) {
+                      return http
+                              .with(new SessionManagementConfigurer<>(), withDefaults())
+                              .build();
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void standaloneApply() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+              import org.springframework.security.config.annotation.web.configurers.SessionManagementConfigurer;
+              import org.springframework.security.web.SecurityFilterChain;
+              
+              public class MySecurityConfig {
+                  public SecurityFilterChain configure(HttpSecurity http) {
+                      http.apply(new SessionManagementConfigurer<>());
+                      return http.build();
+                  }
+              }
+              """,
+            """
+              import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+              import org.springframework.security.config.annotation.web.configurers.SessionManagementConfigurer;
+              import org.springframework.security.web.SecurityFilterChain;
+              
+              import static org.springframework.security.config.Customizer.withDefaults;
+              
+              public class MySecurityConfig {
+                  public SecurityFilterChain configure(HttpSecurity http) {
+                      http.with(new SessionManagementConfigurer<>(), withDefaults());
+                      return http.build();
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void withOtherConfigAfter() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+              import org.springframework.security.config.annotation.web.configurers.SessionManagementConfigurer;
+              import org.springframework.security.web.SecurityFilterChain;
+              
+              public class MySecurityConfig {
+                  public SecurityFilterChain configure(HttpSecurity http) {
+                      return http
+                              .apply(new SessionManagementConfigurer<>())
+                              .invalidSessionUrl("junk").and()
+                              .csrf(csrf -> csrf.disable())
+                              .build();
+                  }
+              }
+              """,
+            """
+              import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+              import org.springframework.security.config.annotation.web.configurers.SessionManagementConfigurer;
+              import org.springframework.security.web.SecurityFilterChain;
+              
+              public class MySecurityConfig {
+                  public SecurityFilterChain configure(HttpSecurity http) {
+                      return http
+                              .with(new SessionManagementConfigurer<>(), configurer -> configurer
+                                      .invalidSessionUrl("junk"))
+                              .csrf(csrf -> csrf.disable())
+                              .build();
+                  }
+              }
+              """
+          )
+        );
+    }
+}


### PR DESCRIPTION
Fixes #449

## Anything in particular you'd like reviewers to focus on?
- Added another SourceSet for Spring Security 6.2
- The overloaded constructor options on `ConvertToSecurityDsl` are starting to feel a little clunky, but I think that with the addition of this recipe we've pretty much covered the full scope of the Lambda DSL migration, so I don't anticipate we'd need to extend this visitor much further
- (not directly related to the PR) I wonder if we could create some generic / fluent API for slicing and dicing a method invocation chain... I feel like I've seen that problem solved several times in individual recipes/visitors, and it tends to be non-trivial, but with the right abstraction, it might be reusable?...

## Anyone you would like to review specifically?
Others who've been in this file a bunch: @shanman190 @BoykoAlex 

### Checklist
- [X] I've added unit tests to cover both positive and negative cases
- [X] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
