### PR TITLE
updating RenameBean to make the `type` optional, as bean names are un…

### DIFF
--- a/src/main/java/org/openrewrite/java/spring/RenameBean.java
+++ b/src/main/java/org/openrewrite/java/spring/RenameBean.java
@@ -17,7 +17,9 @@ package org.openrewrite.java.spring;
 
 import lombok.EqualsAndHashCode;
 import lombok.Value;
+import org.jetbrains.annotations.NotNull;
 import org.openrewrite.ExecutionContext;
+import org.openrewrite.Option;
 import org.openrewrite.Preconditions;
 import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
@@ -32,6 +34,7 @@ import org.openrewrite.java.search.FindAnnotations;
 import org.openrewrite.java.search.UsesType;
 import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaType;
 import org.openrewrite.java.tree.Statement;
 import org.openrewrite.java.tree.TypeUtils;
 
@@ -43,24 +46,31 @@ import static org.openrewrite.java.MethodMatcher.methodPattern;
 @Value
 public class RenameBean extends Recipe {
 
+    @Option(required = false)
+    @Nullable
     String type;
 
+    @Option
     String oldName;
 
+    @Option
     String newName;
 
-    private static final String QUALIFIER = "org.springframework.beans.factory.annotation.Qualifier";
+    private static final String FQN_QUALIFIER = "org.springframework.beans.factory.annotation.Qualifier";
 
-    private static final Set<String> JUST_QUALIFIER = Collections.singleton(QUALIFIER);
+    private static final String FQN_BEAN = "org.springframework.context.annotation.Bean";
 
+    private static final String FQN_COMPONENT = "org.springframework.stereotype.Component";
+
+    private static final Set<String> JUST_QUALIFIER = Collections.singleton(FQN_QUALIFIER);
     private static final Set<String> BEAN_METHOD_ANNOTATIONS = new HashSet<String>() {{
-        add(QUALIFIER);
-        add("org.springframework.context.annotation.Bean");
+        add(FQN_QUALIFIER);
+        add(FQN_BEAN);
     }};
 
     private static final Set<String> BEAN_TYPE_ANNOTATIONS = new HashSet<String>() {{
-        add(QUALIFIER);
-        add("org.springframework.stereotype.Component");
+        add(FQN_QUALIFIER);
+        add(FQN_COMPONENT);
     }};
 
     @Override
@@ -73,6 +83,7 @@ public class RenameBean extends Recipe {
         return "Renames a Spring bean, both declaration and references.";
     }
 
+
     /**
      * @param methodDeclaration, which may or may not declare a bean
      * @param newName,           for the potential bean
@@ -80,14 +91,25 @@ public class RenameBean extends Recipe {
      */
     @Nullable
     public static RenameBean fromDeclaration(J.MethodDeclaration methodDeclaration, String newName) {
+        return methodDeclaration.getMethodType() == null ? null
+                : fromDeclaration(methodDeclaration, newName, methodDeclaration.getMethodType().getReturnType().toString());
+    }
+
+    /**
+     * @param methodDeclaration, which may or may not declare a bean
+     * @param newName,           for the potential bean
+     * @param type,              to override the type field on the returned RenameBean instance
+     * @return a recipe for this methodDeclaration if it declares a bean, or null if it does not declare a bean
+     */
+    @Nullable
+    public static RenameBean fromDeclaration(J.MethodDeclaration methodDeclaration, String newName, @Nullable String type) {
         BeanSearchResult beanSearchResult = isBean(methodDeclaration.getAllAnnotations(), BEAN_METHOD_ANNOTATIONS);
         if (!beanSearchResult.isBean || methodDeclaration.getMethodType() == null) {
             return null;
         }
         String beanName =
                 beanSearchResult.beanName != null ? beanSearchResult.beanName : methodDeclaration.getSimpleName();
-        return beanName.equals(newName) ? null :
-                new RenameBean(methodDeclaration.getMethodType().getReturnType().toString(), beanName, newName);
+        return beanName.equals(newName) ? null : new RenameBean(type, beanName, newName);
     }
 
     /**
@@ -97,14 +119,25 @@ public class RenameBean extends Recipe {
      */
     @Nullable
     public static RenameBean fromDeclaration(J.ClassDeclaration classDeclaration, String newName) {
+        return classDeclaration.getType() == null ? null
+                : fromDeclaration(classDeclaration, newName, classDeclaration.getType().toString());
+    }
+
+    /**
+     * @param classDeclaration, which may or may not declare a bean
+     * @param newName,          for the potential bean
+     * @param type,             to override the type field on the returned RenameBean instance
+     * @return a recipe for this classDeclaration if it declares a bean, or null if it does not declare a bean
+     */
+    @Nullable
+    public static RenameBean fromDeclaration(J.ClassDeclaration classDeclaration, String newName, @Nullable String type) {
         BeanSearchResult beanSearchResult = isBean(classDeclaration.getAllAnnotations(), BEAN_TYPE_ANNOTATIONS);
         if (!beanSearchResult.isBean || classDeclaration.getType() == null) {
             return null;
         }
         String beanName =
                 beanSearchResult.beanName != null ? beanSearchResult.beanName : classDeclaration.getSimpleName();
-        return beanName.equals(newName) ? null :
-                new RenameBean(classDeclaration.getType().toString(), beanName, newName);
+        return beanName.equals(newName) ? null : new RenameBean(type, beanName, newName);
     }
 
     private static BeanSearchResult isBean(Collection<J.Annotation> annotations, Set<String> types) {
@@ -162,19 +195,26 @@ public class RenameBean extends Recipe {
         }
     }
 
+    @NotNull
+    private TreeVisitor<?, ExecutionContext> precondition() {
+        return type == null
+                ? Preconditions.or(
+                        new FindAnnotations("@" + FQN_QUALIFIER, false).getVisitor(),
+                        new FindAnnotations("@" + FQN_BEAN, false).getVisitor(),
+                        new FindAnnotations("@" + FQN_COMPONENT, true).getVisitor())
+                : Preconditions.or(new UsesType<>(type, false), new DeclaresType<>(type));
+    }
+
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
-        return Preconditions.check(Preconditions.or(
-                new UsesType<>(type, false),
-                new DeclaresType<>(type)
-        ), new JavaIsoVisitor<ExecutionContext>() {
+        return Preconditions.check(precondition(), new JavaIsoVisitor<ExecutionContext>() {
             @Override
             public J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration method,
                                                               ExecutionContext executionContext) {
                 J.MethodDeclaration m = super.visitMethodDeclaration(method, executionContext);
 
                 // handle bean declarations
-                if (m.getMethodType() != null && TypeUtils.isOfClassType(m.getMethodType().getReturnType(), type)) {
+                if (m.getMethodType() != null && isRelevantType(m.getMethodType().getReturnType())) {
                     boolean maybeRenameMethodDeclaration = maybeRenameBean(m.getAllAnnotations(),
                             BEAN_METHOD_ANNOTATIONS);
                     if (maybeRenameMethodDeclaration && m.getSimpleName().equals(oldName)) {
@@ -196,7 +236,7 @@ public class RenameBean extends Recipe {
                 J.ClassDeclaration cd = super.visitClassDeclaration(classDecl, executionContext);
 
                 // handle bean declarations
-                if (cd.getType() != null && TypeUtils.isOfClassType(cd.getType(), type)) {
+                if (cd.getType() != null && isRelevantType(cd.getType())) {
                     boolean maybeRenameClass = maybeRenameBean(cd.getAllAnnotations(), BEAN_TYPE_ANNOTATIONS);
                     if (maybeRenameClass && StringUtils.uncapitalize(cd.getSimpleName()).equals(oldName)) {
                         String newFullyQualifiedTypeName = cd.getType().getFullyQualifiedName()
@@ -217,7 +257,7 @@ public class RenameBean extends Recipe {
                 if (statement instanceof J.VariableDeclarations) {
                     J.VariableDeclarations varDecls = (J.VariableDeclarations) statement;
                     for (J.VariableDeclarations.NamedVariable namedVar : varDecls.getVariables()) {
-                        if (namedVar.getType() != null && TypeUtils.isOfClassType(namedVar.getType(), type)) {
+                        if (isRelevantType(namedVar.getType())) {
                             maybeRenameBean(varDecls.getAllAnnotations(), JUST_QUALIFIER);
                             break;
                         }
@@ -349,5 +389,9 @@ public class RenameBean extends Recipe {
             return false;
         }
         return false;
+    }
+
+    private boolean isRelevantType(@Nullable JavaType javaType) {
+        return this.type == null || TypeUtils.isOfClassType(javaType, this.type);
     }
 }

--- a/src/test/java/org/openrewrite/java/spring/RenameBeanTest.java
+++ b/src/test/java/org/openrewrite/java/spring/RenameBeanTest.java
@@ -88,6 +88,40 @@ class RenameBeanTest implements RewriteTest {
             }
 
             @Test
+            void impliedNameNullType() {
+                rewriteRun(
+                  spec -> spec.recipe(new RenameBean(null, "foo", "bar")),
+                  java(
+                    """
+                    package sample;
+                    
+                    import org.springframework.context.annotation.Bean;
+                    import sample.MyType;
+                    
+                    class A {
+                        @Bean
+                        public MyType foo() {
+                            return new MyType();
+                        }
+                    }
+                    """, """
+                    package sample;
+                    
+                    import org.springframework.context.annotation.Bean;
+                    import sample.MyType;
+                    
+                    class A {
+                        @Bean
+                        public MyType bar() {
+                            return new MyType();
+                        }
+                    }
+                    """
+                  )
+                );
+            }
+
+            @Test
             void explicitNameValueParam() {
                 rewriteRun(
                   java(
@@ -222,6 +256,44 @@ class RenameBeanTest implements RewriteTest {
             @Test
             void qualifierName() {
                 rewriteRun(
+                  java(
+                    """
+                    package sample;
+                    
+                    import org.springframework.beans.factory.annotation.Qualifier;
+                    import org.springframework.context.annotation.Bean;
+                    import sample.MyType;
+                    
+                    class A {
+                        @Bean
+                        @Qualifier("foo")
+                        public MyType myType() {
+                            return new MyType();
+                        }
+                    }
+                    """, """
+                    package sample;
+                    
+                    import org.springframework.beans.factory.annotation.Qualifier;
+                    import org.springframework.context.annotation.Bean;
+                    import sample.MyType;
+                    
+                    class A {
+                        @Bean
+                        @Qualifier("bar")
+                        public MyType myType() {
+                            return new MyType();
+                        }
+                    }
+                    """
+                  )
+                );
+            }
+
+            @Test
+            void qualifierNameNullType() {
+                rewriteRun(
+                  spec -> spec.recipe(new RenameBean(null, "foo", "bar")),
                   java(
                     """
                     package sample;
@@ -418,9 +490,65 @@ class RenameBeanTest implements RewriteTest {
             }
 
             @Test
+            void impliedNameNullType() {
+                rewriteRun(
+                  spec -> spec.recipe(new RenameBean(null, "foo", "bar")),
+                  java(
+                    """
+                    package sample;
+                    
+                    import org.springframework.context.annotation.Configuration;
+                    import sample.MyType;
+                    
+                    @Configuration
+                    class Foo {
+                    }
+                    """, """
+                    package sample;
+                    
+                    import org.springframework.context.annotation.Configuration;
+                    import sample.MyType;
+                    
+                    @Configuration
+                    class Bar {
+                    }
+                    """
+                  )
+                );
+            }
+
+            @Test
             void explicitName() {
                 rewriteRun(
                   spec -> spec.recipe(new RenameBean("sample.Foo", "foo", "bar")),
+                  java(
+                    """
+                    package sample;
+                    
+                    import org.springframework.context.annotation.Configuration;
+                    import sample.MyType;
+                    
+                    @Configuration("foo")
+                    class Foo {
+                    }
+                    """, """
+                    package sample;
+                    
+                    import org.springframework.context.annotation.Configuration;
+                    import sample.MyType;
+                    
+                    @Configuration("bar")
+                    class Foo {
+                    }
+                    """
+                  )
+                );
+            }
+
+            @Test
+            void explicitNameNullType() {
+                rewriteRun(
+                  spec -> spec.recipe(new RenameBean(null, "foo", "bar")),
                   java(
                     """
                     package sample;
@@ -547,6 +675,46 @@ class RenameBeanTest implements RewriteTest {
         @Test
         void parameterUsage() {
             rewriteRun(
+              java(
+                """
+                package sample;
+                
+                import org.springframework.beans.factory.annotation.Qualifier;
+                import org.springframework.context.annotation.Bean;
+                import org.springframework.context.annotation.Configuration;
+                import sample.MyType;
+                
+                @Configuration
+                class A {
+                    @Bean
+                    public String myBean(@Qualifier("foo") MyType myType) {
+                        return "";
+                    }
+                }
+                """, """
+                package sample;
+                
+                import org.springframework.beans.factory.annotation.Qualifier;
+                import org.springframework.context.annotation.Bean;
+                import org.springframework.context.annotation.Configuration;
+                import sample.MyType;
+                
+                @Configuration
+                class A {
+                    @Bean
+                    public String myBean(@Qualifier("bar") MyType myType) {
+                        return "";
+                    }
+                }
+                """
+              )
+            );
+        }
+
+        @Test
+        void parameterUsageNullType() {
+            rewriteRun(
+              spec -> spec.recipe(new RenameBean(null, "foo", "bar")),
               java(
                 """
                 package sample;


### PR DESCRIPTION
…ique in a spring application context regardless of type (and if you're queueing up RenameBean instances using `fromDeclaration` in a ScanningRecipe scanner, then the type might change by the time the visitor actually runs)