### PR TITLE
Refactored ConvertToSecurityDslVisitor to assemble target method type…

### DIFF
--- a/src/main/java/org/openrewrite/java/spring/boot2/ConvertToSecurityDslVisitor.java
+++ b/src/main/java/org/openrewrite/java/spring/boot2/ConvertToSecurityDslVisitor.java
@@ -39,6 +39,9 @@ public class ConvertToSecurityDslVisitor<P> extends JavaIsoVisitor<P> {
 
     public static final String FQN_CUSTOMIZER = "org.springframework.security.config.Customizer";
 
+    private static final JavaType.ShallowClass CUSTOMIZER_SHALLOW_TYPE =
+            (JavaType.ShallowClass) JavaType.buildType(FQN_CUSTOMIZER);
+
     private final String securityFqn;
 
     private final Collection<String> convertableMethods;
@@ -90,7 +93,7 @@ public class ConvertToSecurityDslVisitor<P> extends JavaIsoVisitor<P> {
                                 .withArguments(ListUtils.concat(
                                                 keepArg ? m.getArguments().get(0) : null,
                                                 Collections.singletonList(chain.isEmpty()
-                                                        ? createDefaultsCall(newMethodType.getParameterTypes().get(keepArg ? 1 : 0))
+                                                        ? createDefaultsCall()
                                                         : createLambdaParam(paramName, newMethodType.getParameterTypes().get(keepArg ? 1 : 0), chain))
                                         )
                                 );
@@ -176,16 +179,18 @@ public class ConvertToSecurityDslVisitor<P> extends JavaIsoVisitor<P> {
         if (methodType == null) {
             return Optional.empty();
         }
-        JavaType.FullyQualified httpSecurityType = methodType.getDeclaringType();
+        JavaType.Parameterized customizerArgType = new JavaType.Parameterized(null,
+                CUSTOMIZER_SHALLOW_TYPE, Collections.singletonList(methodType.getReturnType()));
         boolean keepArg = keepArg(m.getSimpleName());
-        int expectedParamCount = keepArg ? 2 : 1;
-        int customizerParamIndex = keepArg ? 1 : 0;
-        return httpSecurityType.getMethods().stream()
-                .filter(availableMethod -> availableMethod.getName().equals(methodRenames.getOrDefault(m.getSimpleName(), m.getSimpleName())) &&
-                        availableMethod.getParameterTypes().size() == expectedParamCount &&
-                        availableMethod.getParameterTypes().get(customizerParamIndex) instanceof JavaType.FullyQualified &&
-                        FQN_CUSTOMIZER.equals(((JavaType.FullyQualified) availableMethod.getParameterTypes().get(customizerParamIndex)).getFullyQualifiedName()))
-                .findFirst();
+        List<String> paramNames = keepArg ? ListUtils.concat(methodType.getParameterNames(), "arg1")
+                : Collections.singletonList("arg0");
+        List<JavaType> paramTypes = keepArg ? ListUtils.concat(methodType.getParameterTypes(), customizerArgType)
+                : Collections.singletonList(customizerArgType);
+        return Optional.of(methodType.withReturnType(methodType.getDeclaringType())
+                .withName(methodRenames.getOrDefault(methodType.getName(), methodType.getName()))
+                .withParameterNames(paramNames)
+                .withParameterTypes(paramTypes)
+        );
     }
 
     private boolean keepArg(String methodName) {
@@ -197,11 +202,10 @@ public class ConvertToSecurityDslVisitor<P> extends JavaIsoVisitor<P> {
         if (methodType == null || !hasHandleableArg(m) || !(methodType.getReturnType() instanceof JavaType.Class)) {
             return Optional.empty();
         }
-        JavaType.Class returnType = (JavaType.Class) methodType.getReturnType();
-        return returnType.getMethods().stream()
-                .filter(availableMethod -> availableMethod.getName().equals(argReplacements.get(m.getSimpleName())) &&
-                        availableMethod.getParameterTypes().size() == 1)
-                .findFirst();
+        return Optional.of(
+                methodType.withName(argReplacements.get(m.getSimpleName()))
+                        .withDeclaringType((JavaType.FullyQualified) methodType.getReturnType())
+        );
     }
 
     // this method is unused in this repo, but, useful in Spring Tool Suite integration
@@ -272,13 +276,10 @@ public class ConvertToSecurityDslVisitor<P> extends JavaIsoVisitor<P> {
         return new MethodMatcher("org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer disable()", true).matches(method);
     }
 
-    private J.MethodInvocation createDefaultsCall(JavaType type) {
-        JavaType.FullyQualified fullyQualified = TypeUtils.asFullyQualified(type);
-        assert fullyQualified != null;
-        JavaType.Method methodType = fullyQualified.getMethods().stream().filter(m -> "withDefaults".equals(m.getName()) && m.getParameterTypes().isEmpty() && m.getFlags().contains(Flag.Static)).findFirst().orElse(null);
-        if (methodType == null) {
-            throw new IllegalStateException();
-        }
+    private J.MethodInvocation createDefaultsCall() {
+        JavaType.Method methodType = new JavaType.Method(null, 9, CUSTOMIZER_SHALLOW_TYPE, "withDefaults",
+                new JavaType.GenericTypeVariable(null, "T", JavaType.GenericTypeVariable.Variance.INVARIANT, null),
+                null, null, null, null);
         maybeAddImport(methodType.getDeclaringType().getFullyQualifiedName(), methodType.getName());
         return new J.MethodInvocation(Tree.randomId(), Space.EMPTY, Markers.EMPTY, null, null,
                 new J.Identifier(Tree.randomId(), Space.EMPTY, Markers.EMPTY, emptyList(), "withDefaults", null, null),


### PR DESCRIPTION
…s "manually" instead of searching for them on some existing type's available methods, to fix a bug where ApplyToWithLambdaDsl did not work for projects parsed with an older version of Spring Security (aka the expected case for apps using the recipe to upgrade)

<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->
- The resultant type information is slightly less robust with this change, but I'm pretty sure it should still be sufficient for the vast majority of recipe usages which might follow this recipe in a chain?

## Anyone you would like to review specifically?
<!-- @mention them here -->


## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->


## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->


### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [X] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [X] I've used the IntelliJ IDEA auto-formatter on affected files
