### PR TITLE
Fix typo in Spring snapshot repo url

### DIFF
--- a/src/main/java/org/openrewrite/maven/spring/UpgradeExplicitSpringBootDependencies.java
+++ b/src/main/java/org/openrewrite/maven/spring/UpgradeExplicitSpringBootDependencies.java
@@ -167,7 +167,7 @@ public class UpgradeExplicitSpringBootDependencies extends Recipe {
                             .build());
                     repositories.add(MavenRepository.builder()
                             .id("spring-snapshot")
-                            .uri("https://repo.spring.io/snapshote")
+                            .uri("https://repo.spring.io/snapshot")
                             .releases(false)
                             .snapshots(true)
                             .build());


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
Updated link used for Spring snapshot repo from [https://repo.spring.io/snapshote](https://repo.spring.io/snapshote) (invalid link) to [https://repo.spring.io/snapshot](https://repo.spring.io/snapshot).

## What's your motivation?
Obvious typo

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
