### PR TITLE
Migrate Swagger to SpringDoc

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -110,18 +110,20 @@ recipeDependencies {
 val rewriteVersion = rewriteRecipe.rewriteVersion.get()
 
 dependencies {
-    implementation("org.openrewrite:rewrite-java:${rewriteVersion}")
-    implementation("org.openrewrite:rewrite-xml:${rewriteVersion}")
-    implementation("org.openrewrite:rewrite-properties:${rewriteVersion}")
-    implementation("org.openrewrite:rewrite-yaml:${rewriteVersion}")
-    implementation("org.openrewrite:rewrite-gradle:${rewriteVersion}")
-    implementation("org.openrewrite:rewrite-maven:${rewriteVersion}")
+    implementation(platform("org.openrewrite:rewrite-bom:${rewriteVersion}"))
+    implementation("org.openrewrite:rewrite-java")
+    implementation("org.openrewrite:rewrite-xml")
+    implementation("org.openrewrite:rewrite-properties")
+    implementation("org.openrewrite:rewrite-yaml")
+    implementation("org.openrewrite:rewrite-gradle")
+    implementation("org.openrewrite:rewrite-maven")
     implementation("org.openrewrite.recipe:rewrite-java-dependencies:${rewriteVersion}")
     implementation("org.openrewrite.gradle.tooling:model:${rewriteVersion}")
 
-    runtimeOnly("org.openrewrite:rewrite-java-17:$rewriteVersion")
+    runtimeOnly("org.openrewrite:rewrite-java-17")
     runtimeOnly("org.openrewrite.recipe:rewrite-hibernate:$rewriteVersion")
     runtimeOnly("org.openrewrite.recipe:rewrite-migrate-java:$rewriteVersion")
+    runtimeOnly("org.openrewrite.recipe:rewrite-openapi:${rewriteVersion}")
     runtimeOnly("org.openrewrite.recipe:rewrite-testing-frameworks:$rewriteVersion")
 
     testRuntimeOnly("ch.qos.logback:logback-classic:1.+")
@@ -133,7 +135,7 @@ dependencies {
 
     // for generating properties migration configurations
     testImplementation("io.github.classgraph:classgraph:latest.release")
-    testImplementation("org.openrewrite:rewrite-java-17:${rewriteVersion}")
+    testImplementation("org.openrewrite:rewrite-java-17")
     testImplementation("org.openrewrite.recipe:rewrite-migrate-java:$rewriteVersion")
     testImplementation("org.openrewrite.recipe:rewrite-testing-frameworks:$rewriteVersion")
 

--- a/src/main/resources/META-INF/rewrite/springdoc.yml
+++ b/src/main/resources/META-INF/rewrite/springdoc.yml
@@ -67,32 +67,43 @@ recipeList:
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: org.springdoc.core.SwaggerUiConfigParameters
       newFullyQualifiedTypeName: org.springdoc.core.properties.SwaggerUiConfigParameters
-  # "The following modules are not anymore needed and can be removed"
-  - org.openrewrite.java.dependencies.RemoveDependency:
-      groupId: org.springdoc
-      artifactId: springdoc-openapi-javadoc
-  - org.openrewrite.java.dependencies.RemoveDependency:
-      groupId: org.springdoc
-      artifactId: springdoc-openapi-kotlin
-  - org.openrewrite.java.dependencies.RemoveDependency:
-      groupId: org.springdoc
-      artifactId: springdoc-openapi-data-rest
-  - org.openrewrite.java.dependencies.RemoveDependency:
-      groupId: org.springdoc
-      artifactId: springdoc-openapi-security
-  - org.openrewrite.java.dependencies.RemoveDependency:
-      groupId: org.springdoc
-      artifactId: springdoc-openapi-webmvc-core
-  - org.openrewrite.java.dependencies.RemoveDependency:
-      groupId: org.springdoc
-      artifactId: springdoc-openapi-webflux-core
-  - org.openrewrite.java.dependencies.RemoveDependency:
-      groupId: org.springdoc
-      artifactId: springdoc-openapi-hateoas
-  - org.openrewrite.java.dependencies.RemoveDependency:
-      groupId: org.springdoc
-      artifactId: springdoc-openapi-groovy
-  # "In addition replace"
+  # "The following table describes the main modules changes"
+  - org.openrewrite.java.dependencies.ChangeDependency:
+      oldGroupId: org.springdoc
+      oldArtifactId: springdoc-openapi-common
+      newArtifactId: springdoc-openapi-starter-common
+  - org.openrewrite.java.dependencies.ChangeDependency:
+      oldGroupId: org.springdoc
+      oldArtifactId: springdoc-openapi-data-rest
+      newArtifactId: springdoc-openapi-starter-common
+  - org.openrewrite.java.dependencies.ChangeDependency:
+      oldGroupId: org.springdoc
+      oldArtifactId: springdoc-openapi-groovy
+      newArtifactId: springdoc-openapi-starter-common
+  - org.openrewrite.java.dependencies.ChangeDependency:
+      oldGroupId: org.springdoc
+      oldArtifactId: springdoc-openapi-hateoas
+      newArtifactId: springdoc-openapi-starter-common
+  - org.openrewrite.java.dependencies.ChangeDependency:
+      oldGroupId: org.springdoc
+      oldArtifactId: springdoc-openapi-javadoc
+      newArtifactId: springdoc-openapi-starter-common
+  - org.openrewrite.java.dependencies.ChangeDependency:
+      oldGroupId: org.springdoc
+      oldArtifactId: springdoc-openapi-kotlin
+      newArtifactId: springdoc-openapi-starter-common
+  - org.openrewrite.java.dependencies.ChangeDependency:
+      oldGroupId: org.springdoc
+      oldArtifactId: springdoc-openapi-security
+      newArtifactId: springdoc-openapi-starter-common
+  - org.openrewrite.java.dependencies.ChangeDependency:
+      oldGroupId: org.springdoc
+      oldArtifactId: springdoc-openapi-webmvc-core
+      newArtifactId: springdoc-openapi-starter-webmvc-api
+  - org.openrewrite.java.dependencies.ChangeDependency:
+      oldGroupId: org.springdoc
+      oldArtifactId: springdoc-openapi-webflux-core
+      newArtifactId: springdoc-openapi-starter-webflux-api
   - org.openrewrite.java.dependencies.ChangeDependency:
       oldGroupId: org.springdoc
       oldArtifactId: springdoc-openapi-ui

--- a/src/main/resources/META-INF/rewrite/springdoc.yml
+++ b/src/main/resources/META-INF/rewrite/springdoc.yml
@@ -15,7 +15,7 @@
 #
 
 type: specs.openrewrite.org/v1beta/recipe
-name: org.openrewrite.openapi.SwaggerToSpringDoc
+name: org.openrewrite.java.springdoc.SwaggerToSpringDoc
 displayName: Migrate from Swagger to SpringDoc and OpenAPI
 description: Migrate from Swagger to SpringDoc and OpenAPI.
 tags:
@@ -23,7 +23,7 @@ tags:
   - springdoc
   - openapi
 recipeList:
-  - org.openrewrite.openapi.SwaggerToOpenAPI
+  - org.openrewrite.openapi.swagger.SwaggerToOpenAPI
   - org.openrewrite.java.springdoc.UpgradeSpringDoc_2
   - org.openrewrite.java.spring.DeleteSpringProperty:
       propertyKey: swagger.title
@@ -45,7 +45,7 @@ tags:
 recipeList:
   # https://springdoc.org/#migrating-from-springdoc-v1
   - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
-      groupId: org.
+      groupId: org.springdoc
       artifactId: "*"
       newVersion: 2.3.x
   # "classes/annotations changes"

--- a/src/main/resources/META-INF/rewrite/springdoc.yml
+++ b/src/main/resources/META-INF/rewrite/springdoc.yml
@@ -1,0 +1,103 @@
+#
+# Copyright 2024 the original author or authors.
+# <p>
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# <p>
+# https://www.apache.org/licenses/LICENSE-2.0
+# <p>
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.openapi.SwaggerToSpringDoc
+displayName: Migrate from Swagger to SpringDoc and OpenAPI
+description: Migrate from Swagger to SpringDoc and OpenAPI.
+tags:
+  - swagger
+  - springdoc
+  - openapi
+recipeList:
+  - org.openrewrite.openapi.SwaggerToOpenAPI
+  - org.openrewrite.java.springdoc.UpgradeSpringDoc_2
+  - org.openrewrite.java.spring.DeleteSpringProperty:
+      propertyKey: swagger.title
+  - org.openrewrite.java.spring.DeleteSpringProperty:
+      propertyKey: swagger.description
+  - org.openrewrite.java.spring.DeleteSpringProperty:
+      propertyKey: swagger.contact
+  - org.openrewrite.maven.RemoveDependency:
+      groupId: io.swagger.core.v3
+      artifactId: swagger-annotations
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.springdoc.UpgradeSpringDoc_2
+displayName: Upgrade SpringDoc
+description: Upgrade to SpringDoc v2.
+tags:
+  - springdoc
+recipeList:
+  # https://springdoc.org/#migrating-from-springdoc-v1
+  - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
+      groupId: org.
+      artifactId: "*"
+      newVersion: 2.3.x
+  # "classes/annotations changes"
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.springdoc.core.SpringDocUtils
+      newFullyQualifiedTypeName: org.springdoc.core.utils.SpringDocUtils
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.springdoc.api.annotations.ParameterObject
+      newFullyQualifiedTypeName: org.springdoc.core.annotations.ParameterObject
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.springdoc.core.GroupedOpenApi
+      newFullyQualifiedTypeName: org.springdoc.core.models.GroupedOpenApi
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.springdoc.core.customizers.OpenApiCustomiser
+      newFullyQualifiedTypeName: org.springdoc.core.customizers.OpenApiCustomizer
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.springdoc.core.Constants
+      newFullyQualifiedTypeName: org.springdoc.core.utils.Constants
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.springdoc.core.SwaggerUiConfigParameters
+      newFullyQualifiedTypeName: org.springdoc.core.properties.SwaggerUiConfigParameters
+  # "The following modules are not anymore needed and can be removed"
+  - org.openrewrite.java.dependencies.RemoveDependency:
+      groupId: org.springdoc
+      artifactId: springdoc-openapi-javadoc
+  - org.openrewrite.java.dependencies.RemoveDependency:
+      groupId: org.springdoc
+      artifactId: springdoc-openapi-kotlin
+  - org.openrewrite.java.dependencies.RemoveDependency:
+      groupId: org.springdoc
+      artifactId: springdoc-openapi-data-rest
+  - org.openrewrite.java.dependencies.RemoveDependency:
+      groupId: org.springdoc
+      artifactId: springdoc-openapi-security
+  - org.openrewrite.java.dependencies.RemoveDependency:
+      groupId: org.springdoc
+      artifactId: springdoc-openapi-webmvc-core
+  - org.openrewrite.java.dependencies.RemoveDependency:
+      groupId: org.springdoc
+      artifactId: springdoc-openapi-webflux-core
+  - org.openrewrite.java.dependencies.RemoveDependency:
+      groupId: org.springdoc
+      artifactId: springdoc-openapi-hateoas
+  - org.openrewrite.java.dependencies.RemoveDependency:
+      groupId: org.springdoc
+      artifactId: springdoc-openapi-groovy
+  # "In addition replace"
+  - org.openrewrite.java.dependencies.ChangeDependency:
+      oldGroupId: org.springdoc
+      oldArtifactId: springdoc-openapi-ui
+      newArtifactId: springdoc-openapi-starter-webmvc-ui
+  - org.openrewrite.java.dependencies.ChangeDependency:
+      oldGroupId: org.springdoc
+      oldArtifactId: springdoc-openapi-webflux-ui
+      newArtifactId: springdoc-openapi-starter-webflux-ui

--- a/src/test/java/org/openrewrite/java/springdoc/SwaggerToSpringDocTest.java
+++ b/src/test/java/org/openrewrite/java/springdoc/SwaggerToSpringDocTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 the original author or authors.
+ * Copyright 2024 the original author or authors.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@ package org.openrewrite.java.springdoc;
 
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
-import org.openrewrite.java.JavaParser;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
@@ -25,14 +24,10 @@ import java.util.regex.Pattern;
 
 import static org.openrewrite.maven.Assertions.pomXml;
 
-class UpgradeOpenAPI3Test implements RewriteTest {
-
+class SwaggerToSpringDocTest implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
-        spec.recipeFromResources("org.openrewrite.openapi.UpgradeOpenAPI3")
-          .parser(JavaParser.fromJavaVersion()
-//            .classpathFromResources(new InMemoryExecutionContext(),"todo")
-          );
+        spec.recipeFromResources("org.openrewrite.java.springdoc.SwaggerToSpringDoc");
     }
 
     @Test
@@ -57,7 +52,7 @@ class UpgradeOpenAPI3Test implements RewriteTest {
               </project>
               """,
             after -> after.after(actual -> {
-                String version = Pattern.compile("<version>(1\\.7\\..*)</version>")
+                String version = Pattern.compile("<version>(2\\.3\\..*)</version>")
                   .matcher(actual)
                   .results()
                   .map(m -> m.group(1))

--- a/src/test/java/org/openrewrite/java/springdoc/UpgradeOpenAPI3Test.java
+++ b/src/test/java/org/openrewrite/java/springdoc/UpgradeOpenAPI3Test.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.springdoc;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import java.util.regex.Pattern;
+
+import static org.openrewrite.maven.Assertions.pomXml;
+
+class UpgradeOpenAPI3Test implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipeFromResources("org.openrewrite.openapi.UpgradeOpenAPI3")
+          .parser(JavaParser.fromJavaVersion()
+//            .classpathFromResources(new InMemoryExecutionContext(),"todo")
+          );
+    }
+
+    @Test
+    @DocumentExample
+    void upgradeMaven() {
+        rewriteRun(
+          // language=xml
+          pomXml(
+            """
+              <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>org.example</groupId>
+                  <artifactId>example</artifactId>
+                  <version>1.0-SNAPSHOT</version>
+                  <dependencies>
+                      <dependency>
+                          <groupId>org.springdoc</groupId>
+                          <artifactId>springdoc-openapi</artifactId>
+                          <version>1.5.13</version>
+                      </dependency>
+                  </dependencies>
+              </project>
+              """,
+            after -> after.after(actual -> {
+                String version = Pattern.compile("<version>(1\\.7\\..*)</version>")
+                  .matcher(actual)
+                  .results()
+                  .map(m -> m.group(1))
+                  .findFirst()
+                  .orElseThrow();
+                return """
+                  <project>
+                      <modelVersion>4.0.0</modelVersion>
+                      <groupId>org.example</groupId>
+                      <artifactId>example</artifactId>
+                      <version>1.0-SNAPSHOT</version>
+                      <dependencies>
+                          <dependency>
+                              <groupId>org.springdoc</groupId>
+                              <artifactId>springdoc-openapi</artifactId>
+                              <version>%s</version>
+                          </dependency>
+                      </dependencies>
+                  </project>
+                  """.formatted(version);
+            })
+          )
+        );
+    }
+}


### PR DESCRIPTION
## What's changed?
Added recipe to migrate from Swagger to SpringDoc, and upgrade SpringDoc itself.

## What's your motivation?
Required for a complete migration to Spring Boot 3, which was not covered up to now.
Informally shared and tested; now adopted here to help folks that still need to migrate.

## Any additional context
- https://github.com/openrewrite/rewrite-openapi/issue/1
- https://github.com/openrewrite/rewrite-openapi/pull/2

## TODO

- [x] Merge rewrite-openapi as it's needed here
- [x] add rough regression tests that load yaml recipes to spot validation issues
- [ ] consider whether migration is strong enough to be included with Spring Boot 3 upgrade
