### PR TITLE
Remove `JUnit5BestPractices` from `RemoveObsoleteRunners`

### DIFF
--- a/src/main/resources/META-INF/rewrite/spring-boot-24.yml
+++ b/src/main/resources/META-INF/rewrite/spring-boot-24.yml
@@ -135,4 +135,3 @@ recipeList:
         # There is a third variant of this class in spring-cloud-commons and there is not yet a suitable migration
         # path. Once one exists, this can likely be added for removal as well.
         #- org.springframework.cloud.test.ModifiedClassPathRunner
-  - org.openrewrite.java.testing.junit5.JUnit5BestPractices

--- a/src/testWithSpringBoot_2_3/java/org/openrewrite/java/spring/boot2/SpringBoot2JUnit4to5MigrationTest.java
+++ b/src/testWithSpringBoot_2_3/java/org/openrewrite/java/spring/boot2/SpringBoot2JUnit4to5MigrationTest.java
@@ -68,10 +68,10 @@ class SpringBoot2JUnit4to5MigrationTest implements RewriteTest {
               import org.springframework.boot.test.context.SpringBootTest;
                             
               @SpringBootTest
-              class ProductionConfigurationTests {
+              public class ProductionConfigurationTests {
                             
                   @Test
-                  void findAll() {
+                  public void testFindAll() {
                   }
               }
               """
@@ -115,10 +115,10 @@ class SpringBoot2JUnit4to5MigrationTest implements RewriteTest {
               import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
               @SpringJUnitConfig(classes = ProductionConfigurationTests.CustomConfiguration.class)
-              class ProductionConfigurationTests {
+              public class ProductionConfigurationTests {
 
                   @Test
-                  void findAll() {
+                  public void testFindAll() {
                   }
 
                   @Configuration


### PR DESCRIPTION
As that includes `TestsShouldNotBePublic`, which is an opinionated recipe that results in a lot of (optional) changes.

As reported via Slack: https://rewriteoss.slack.com/archives/C01A843MWG5/p1705404676460549
