### PR TITLE
Periodically generate Spring Boot property migration recipes

### DIFF
--- a/.github/workflows/properties.yml
+++ b/.github/workflows/properties.yml
@@ -1,0 +1,45 @@
+---
+name: Generate Spring Boot property migration recipes
+
+on:
+  workflow_dispatch: {}
+  schedule:
+    - cron: 0 11 * * WED
+
+jobs:
+  update-migrations:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          cache: 'gradle'
+          distribution: 'temurin'
+          java-version: '17'
+
+      # Generate Spring Boot property migrations recipes
+      - name: Create jar and copy dependencies
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: generatePropertyMigrationRecipes
+
+      # Create pull request
+      - name: Timestamp
+        run: echo "NOW=$(date +'%Y-%m-%dT%H%M')" >> $GITHUB_ENV
+      - name: Create Pull Request
+        id: cpr
+        uses: peter-evans/create-pull-request@v5
+        with:
+          base: main
+          branch: migrations/${{ env.NOW }}
+          title: "[Auto] Spring Boot property migration recipes as of ${{ env.NOW }}"
+          body: |
+            [Auto] Old GroupId migrations as of ${{ env.NOW }}.
+          commit-message: "[Auto] Spring Boot property migration recipes as of ${{ env.NOW }}"
+          labels: enhancement
+      - name: Check outputs
+        if: ${{ steps.cpr.outputs.pull-request-number }}
+        run: |
+          echo "Pull Request Number - ${{ steps.cpr.outputs.pull-request-number }}"
+          echo "Pull Request URL - ${{ steps.cpr.outputs.pull-request-url }}"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,8 +9,8 @@ val springBootVersions: List<String> = listOf("1_5", "2_1", "2_2", "2_3", "2_4",
 val springSecurityVersions: List<String> = listOf("5_7", "5_8", "6_2")
 
 val sourceSetNames: Map<String, List<String>> = mapOf(
-        Pair("testWithSpringBoot_", springBootVersions),
-        Pair("testWithSpringSecurity_", springSecurityVersions)
+    Pair("testWithSpringBoot_", springBootVersions),
+    Pair("testWithSpringSecurity_", springSecurityVersions)
 )
 
 sourceSets {
@@ -271,5 +271,14 @@ sourceSetNames.forEach { sourceSet, versions ->
         tasks.check {
             dependsOn(testTask)
         }
+    }
+}
+
+tasks {
+    val generatePropertyMigrationRecipes by registering(JavaExec::class) {
+        group = "generate"
+        description = "Generate Spring Boot property migration recipes."
+        mainClass = "org.openrewrite.java.spring.internal.GeneratePropertiesMigratorConfiguration"
+        classpath = sourceSets.getByName("test").runtimeClasspath
     }
 }


### PR DESCRIPTION
## What's changed?
Added a workflow that calls `GeneratePropertiesMigratorConfiguration` every week and creates a pull request if there are changes.

## What's your motivation?
Create new recipes when new versions of Spring come out automatically, such that it's not forgotten.