### PR TITLE
`org.openrewrite.gradle.Assertions#withToolingModel` moved to `org.openrewrite.gradle.toolingapi.Assertions`

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -136,6 +136,8 @@ dependencies {
 
     testImplementation("com.github.marschall:memoryfilesystem:latest.release")
 
+    testImplementation("org.openrewrite.gradle.tooling:model:$rewriteVersion")
+
     // for generating properties migration configurations
     testImplementation("io.github.classgraph:classgraph:latest.release")
     testImplementation("org.openrewrite:rewrite-java-17")

--- a/src/main/java/org/openrewrite/java/spring/boot3/DowngradeServletApiWhenUsingJetty.java
+++ b/src/main/java/org/openrewrite/java/spring/boot3/DowngradeServletApiWhenUsingJetty.java
@@ -47,7 +47,7 @@ public class DowngradeServletApiWhenUsingJetty extends Recipe {
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
-        return Preconditions.check(new FindDependency("org.springframework.boot", "spring-boot-starter-jetty"), new MavenVisitor<ExecutionContext>() {
+        return Preconditions.check(new FindDependency("org.springframework.boot", "spring-boot-starter-jetty", null, null), new MavenVisitor<ExecutionContext>() {
             @Override
             public @Nullable Xml visit(@Nullable Tree tree, ExecutionContext ctx) {
                 if (tree == null) {

--- a/src/testWithSpringBoot_2_5/java/org/openrewrite/java/spring/boot2/UpdateMysqlDriverArtifactIdTest.java
+++ b/src/testWithSpringBoot_2_5/java/org/openrewrite/java/spring/boot2/UpdateMysqlDriverArtifactIdTest.java
@@ -28,7 +28,7 @@ import java.util.regex.Pattern;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.openrewrite.gradle.Assertions.buildGradle;
-import static org.openrewrite.gradle.Assertions.withToolingApi;
+import static org.openrewrite.gradle.toolingapi.Assertions.withToolingApi;
 import static org.openrewrite.maven.Assertions.pomXml;
 
 @Issue("https://github.com/openrewrite/rewrite-spring/issues/274")

--- a/src/testWithSpringBoot_2_7/java/org/openrewrite/gradle/spring/UpdateGradleTest.java
+++ b/src/testWithSpringBoot_2_7/java/org/openrewrite/gradle/spring/UpdateGradleTest.java
@@ -27,7 +27,7 @@ import java.util.regex.Pattern;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.openrewrite.gradle.Assertions.buildGradle;
-import static org.openrewrite.gradle.Assertions.withToolingApi;
+import static org.openrewrite.gradle.toolingapi.Assertions.withToolingApi;
 import static org.openrewrite.properties.Assertions.properties;
 import static org.openrewrite.test.SourceSpecs.other;
 import static org.openrewrite.test.SourceSpecs.text;


### PR DESCRIPTION
Use this link to re-run the recipe: https://app.moderne.io/recipes/org.openrewrite.java.ChangeMethodTargetToStatic?organizationId=T3BlblJld3JpdGU%3D