### PR TITLE
Update missing maven.compiler.* properties

### DIFF
--- a/src/main/resources/META-INF/rewrite/spring-boot-31.yml
+++ b/src/main/resources/META-INF/rewrite/spring-boot-31.yml
@@ -37,6 +37,12 @@ recipeList:
       groupId: org.springframework.boot
       artifactId: spring-boot-starter-parent
       newVersion: 3.1.x
+  - org.openrewrite.maven.RenamePropertyKey:
+      oldKey: maven.compiler.source
+      newKey: java.version
+  - org.openrewrite.maven.RenamePropertyKey:
+      oldKey: maven.compiler.target
+      newKey: maven.compiler.release
   - org.openrewrite.gradle.plugins.UpgradePluginVersion:
       pluginIdPattern: org.springframework.boot
       newVersion: 3.1.x

--- a/src/testWithSpringBoot_3_0/java/org/openrewrite/java/spring/boot3/MavenCompilerPropertiesTest.java
+++ b/src/testWithSpringBoot_3_0/java/org/openrewrite/java/spring/boot3/MavenCompilerPropertiesTest.java
@@ -1,10 +1,28 @@
-package org.openrewrite.java.spring.boot3;
-
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import org.openrewrite.DocumentExample;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.junit.jupiter.api.Test;
-import org.openrewrite.config.Environment;
+class MavenCompilerPropertiesTest implements RewriteTest {
+    @DocumentExample
+    @Test
+    void upgradeGradleWrapperAndPlugins() {
+		  pomXml(
+                """
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.maven.MavenParser;
 import org.openrewrite.test.RecipeSpec;

--- a/src/testWithSpringBoot_3_0/java/org/openrewrite/java/spring/boot3/MavenCompilerPropertiesTest.java
+++ b/src/testWithSpringBoot_3_0/java/org/openrewrite/java/spring/boot3/MavenCompilerPropertiesTest.java
@@ -1,0 +1,74 @@
+package org.openrewrite.java.spring.boot3;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.config.Environment;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.maven.MavenParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.openrewrite.maven.Assertions.pomXml;
+import static org.openrewrite.properties.Assertions.properties;
+import static org.openrewrite.test.SourceSpecs.other;
+import static org.openrewrite.test.SourceSpecs.text;
+
+public class MavenCompilerPropertiesTest implements RewriteTest {
+
+	@Test
+	void upgradeGradleWrapperAndPlugins() {
+		rewriteRun(spec -> spec.recipe(Environment.builder()
+			.scanRuntimeClasspath("org.openrewrite.java.spring")
+			.build()
+			.activateRecipes("org.openrewrite.java.spring.boot3.UpgradeSpringBoot_3_1")
+		  ),
+		  pomXml("""
+			<?xml version="1.0" encoding="UTF-8"?>
+			<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+			  <modelVersion>4.0.0</modelVersion>
+			  <groupId>org.springframework.samples</groupId>
+			  <artifactId>test-project</artifactId>
+			  <version>2.7.3</version>
+			   
+			  <parent>
+			    <groupId>org.springframework.boot</groupId>
+			    <artifactId>spring-boot-starter-parent</artifactId>
+			    <version>2.7.3</version>
+			  </parent>
+			  <name>petclinic</name>
+			   
+			  <properties>
+			    <compiler-version>${maven.compiler.source}</compiler-version>
+			    <target-version>${maven.compiler.target}</target-version>
+			  </properties>
+			   
+			</project>
+			""", """
+			<?xml version="1.0" encoding="UTF-8"?>
+			<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+			  <modelVersion>4.0.0</modelVersion>
+			  <groupId>org.springframework.samples</groupId>
+			  <artifactId>test-project</artifactId>
+			  <version>2.7.3</version>
+			   
+			  <parent>
+			    <groupId>org.springframework.boot</groupId>
+			    <artifactId>spring-boot-starter-parent</artifactId>
+			    <version>2.7.3</version>
+			  </parent>
+			  <name>petclinic</name>
+			   
+			  <properties>
+			    <compiler-version>${java.version}</compiler-version>
+			    <target-version>${maven.compiler.release}</target-version>
+			  </properties>
+			   
+			</project>
+			""")
+		);
+	}
+
+}


### PR DESCRIPTION
From `org.springframework.boot:spring-boot-starter-parent:2.7.3` to `org.springframework.boot:spring-boot-starter-parent:3.1.x` the properties  `maven.compiler.source` and `maven.compiler.target` are missing.

Inspecting Spring boot 3.1 projects, the new properties are `java.version` and `maven.compiler.release`

## What's changed?

The recipe `spring-boot-31.yml` will replace the affected properties by the new properties used in Spring boot 3.1

```
# Since JDK 17 `release` is used and defined in Spring Boot parent project
- org.openrewrite.maven.RenamePropertyKey:
    oldKey: maven.compiler.target
    newKey: maven.compiler.release
# Remove from the project <properties> section
- org.openrewrite.maven.RemoveProperty:
    propertyName: maven.compiler.source
# Then, replace any usage with `release` coming from parent
- org.openrewrite.maven.RenamePropertyKey:
    oldKey: maven.compiler.source
    newKey: maven.compiler.release
```

## What's your motivation?

I want to upgrade some Spring Boot applications whose parent is `org.springframework.boot:spring-boot-starter-parent:2.7.3`

## Anyone you would like to review specifically?

@timtebeek 

### Checklist

- [ ] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
