### PR TITLE
Restore curly brace in PathUtils#matchesGlob

### DIFF
--- a/src/main/java/org/openrewrite/java/spring/PropertiesToKebabCase.java
+++ b/src/main/java/org/openrewrite/java/spring/PropertiesToKebabCase.java
@@ -62,9 +62,8 @@ public class PropertiesToKebabCase extends Recipe {
 
         @Override
         public TreeVisitor<?, ExecutionContext> getVisitor() {
-            return Preconditions.check(Preconditions.or(
-                            new FindSourceFiles("**/application*.yml").getVisitor(),
-                            new FindSourceFiles("**/application*.yaml").getVisitor()),
+            return Preconditions.check(
+                    new FindSourceFiles("**/application*.{yml,yaml}").getVisitor(),
                     new YamlIsoVisitor<ExecutionContext>() {
                         @Override
                         public Yaml.Mapping.Entry visitMappingEntry(Yaml.Mapping.Entry entry, ExecutionContext ctx) {


### PR DESCRIPTION
Following https://github.com/openrewrite/rewrite/commit/3ad716352c9bc5a12417aa4d5c36b3f3aff322f9 Reverts https://github.com/openrewrite/rewrite-spring/commit/fa4e1c9c20d7373ea1d5d3bf1fdf44a29ab6c537
