### PR TITLE
Spring Framework 6.0 recipe with migration for Spring `Assert`

### DIFF
--- a/src/main/resources/META-INF/rewrite/spring-boot-30.yml
+++ b/src/main/resources/META-INF/rewrite/spring-boot-30.yml
@@ -66,6 +66,7 @@ recipeList:
   - org.openrewrite.java.spring.boot3.MigrateThymeleafDependencies
   - org.openrewrite.java.spring.boot3.UpgradeSpringDoc_2
   - org.openrewrite.java.spring.boot3.MigrateDropWizardDependencies
+  - org.openrewrite.java.spring.framework.UpgradeSpringFramework_6_0
   - org.openrewrite.java.spring.security6.UpgradeSpringSecurity_6_0
   - org.openrewrite.java.spring.cloud2022.UpgradeSpringCloud_2022
   - org.openrewrite.hibernate.MigrateToHibernate61

--- a/src/main/resources/META-INF/rewrite/spring-framework-60.yml
+++ b/src/main/resources/META-INF/rewrite/spring-framework-60.yml
@@ -1,0 +1,81 @@
+#
+# Copyright 2023 the original author or authors.
+# <p>
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# <p>
+# https://www.apache.org/licenses/LICENSE-2.0
+# <p>
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+########################################################################################################################
+# Spring Framework 6.0
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.spring.framework.UpgradeSpringFramework_6_0
+displayName: Migrate to Spring Framework 6.0
+description: Migrate applications to the latest Spring Framework 6.0 release.
+recipeList:
+  - org.openrewrite.java.spring.framework.UpgradeSpringFramework_5_3
+  - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
+      groupId: org.springframework
+      artifactId: "*"
+      newVersion: 6.0.x
+  - org.openrewrite.java.spring.framework.MigrateSpringAssert
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.spring.framework.MigrateSpringAssert
+displayName: Migrate removed Spring `Assert` methods
+description: Assert methods without a message argument have been removed in Spring Framework 6.0.
+recipeList:
+  - org.openrewrite.java.AddLiteralMethodArgument:
+      methodPattern: org.springframework.util.Assert state(boolean)
+      argumentIndex: 1
+      literal: must be true
+  - org.openrewrite.java.AddLiteralMethodArgument:
+      methodPattern: org.springframework.util.Assert isTrue(boolean)
+      argumentIndex: 1
+      literal: must be true
+  - org.openrewrite.java.AddLiteralMethodArgument:
+      methodPattern: org.springframework.util.Assert isNull(java.lang.Object)
+      argumentIndex: 1
+      literal: must be null
+  - org.openrewrite.java.AddLiteralMethodArgument:
+      methodPattern: org.springframework.util.Assert notNull(java.lang.Object)
+      argumentIndex: 1
+      literal: must not be null
+  - org.openrewrite.java.AddLiteralMethodArgument:
+      methodPattern: org.springframework.util.Assert hasLength(java.lang.String)
+      argumentIndex: 1
+      literal: must have length; it must not be null or empty
+  - org.openrewrite.java.AddLiteralMethodArgument:
+      methodPattern: org.springframework.util.Assert hasText(java.lang.String)
+      argumentIndex: 1
+      literal: must have text; it must not be null, empty, or blank
+  - org.openrewrite.java.AddLiteralMethodArgument:
+      methodPattern: org.springframework.util.Assert doesNotContain(java.lang.String, java.lang.String)
+      argumentIndex: 2
+      literal: must not contain the substring
+  - org.openrewrite.java.AddLiteralMethodArgument:
+      methodPattern: org.springframework.util.Assert notEmpty(java.lang.Object[])
+      argumentIndex: 1
+      literal: must not be empty
+  - org.openrewrite.java.AddLiteralMethodArgument:
+      methodPattern: org.springframework.util.Assert noNullElements(java.lang.Object[])
+      argumentIndex: 1
+      literal: must not contain any null elements
+  - org.openrewrite.java.AddLiteralMethodArgument:
+      methodPattern: org.springframework.util.Assert noNullElements(java.util.Collection)
+      argumentIndex: 1
+      literal: must not be empty
+  - org.openrewrite.java.AddLiteralMethodArgument:
+      methodPattern: org.springframework.util.Assert notEmpty(java.util.Map)
+      argumentIndex: 1
+      literal: must not be empty

--- a/src/main/resources/META-INF/rewrite/spring-framework-60.yml
+++ b/src/main/resources/META-INF/rewrite/spring-framework-60.yml
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 the original author or authors.
+# Copyright 2024 the original author or authors.
 # <p>
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/test/java/org/openrewrite/java/spring/framework/MigrateSpringAssertTest.java
+++ b/src/test/java/org/openrewrite/java/spring/framework/MigrateSpringAssertTest.java
@@ -16,6 +16,7 @@
 package org.openrewrite.java.spring.framework;
 
 import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
 import org.openrewrite.InMemoryExecutionContext;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.test.RecipeSpec;
@@ -32,6 +33,7 @@ class MigrateSpringAssertTest implements RewriteTest {
     }
 
     @Test
+    @DocumentExample
     void migrateSpringAssert() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/java/spring/framework/MigrateSpringAssertTest.java
+++ b/src/test/java/org/openrewrite/java/spring/framework/MigrateSpringAssertTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.spring.framework;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.InMemoryExecutionContext;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+class MigrateSpringAssertTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipeFromResources("org.openrewrite.java.spring.framework.MigrateSpringAssert")
+          .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(), "spring-core-5"));
+    }
+
+    @Test
+    void migrateSpringAssert() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class A {
+                  void test() {
+                      org.springframework.util.Assert.state(true);
+                      org.springframework.util.Assert.isTrue(true);
+                  }
+              }
+              """,
+            """
+              class A {
+                  void test() {
+                      org.springframework.util.Assert.state(true, "must be true");
+                      org.springframework.util.Assert.isTrue(true, "must be true");
+                  }
+              }
+              """
+          )
+        );
+    }
+}


### PR DESCRIPTION
## What's changed?
Added a base recipe for migrating to Spring Framework 6.
This is not a complete migration, but can serve as a place to put Spring-related migrations necessary (as opposed to changes related to only Spring Boot).

## What's your motivation?
https://github.com/openrewrite/rewrite-spring/issues/521

## Anything in particular you'd like reviewers to focus on?
I copied the format from the earlier `UpgradeSpringFramework_5_3`.

## Any additional context
I have tested the changes under `MigrateSpringAssert` in our internal migration and it seems to work fine.
I have taken the literal text added from the Spring class and reformatted them a bit.

Ideally, the message contain variable name but that would be a harder change to write automatically.
Usage of this is probably not too common anyway as the functions have been deprecated for a long time.

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
