### PR TITLE
Relocate Launcher classes renamed in Spring Boot 3.2

### DIFF
--- a/src/main/resources/META-INF/rewrite/spring-boot-32.yml
+++ b/src/main/resources/META-INF/rewrite/spring-boot-32.yml
@@ -63,6 +63,7 @@ recipeList:
       oldFullyQualifiedTypeName: org.springframework.boot.autoconfigure.transaction.PlatformTransactionManagerCustomizer
       newFullyQualifiedTypeName: org.springframework.boot.autoconfigure.transaction.TransactionManagerCustomizer
   - org.openrewrite.hibernate.MigrateToHibernate63
+  - org.openrewrite.java.spring.boot3.RelocateLauncherClasses
 
 ---
 type: specs.openrewrite.org/v1beta/recipe
@@ -76,3 +77,19 @@ recipeList:
   - org.openrewrite.java.spring.AddSpringProperty:
       property: spring.threads.virtual.enabled
       value: true
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.spring.boot3.RelocateLauncherClasses
+displayName: Relocate Launcher Classes
+description: Relocate classes that have been moved to different packages in Spring Boot 3.2.
+recipeList:
+  - org.openrewrite.text.FindAndReplace:
+      find: org.springframework.boot.loader.JarLauncher
+      replace: org.springframework.boot.loader.launch.JarLauncher
+  - org.openrewrite.text.FindAndReplace:
+      find: org.springframework.boot.loader.PropertiesLauncher
+      replace: org.springframework.boot.loader.launch.PropertiesLauncher
+  - org.openrewrite.text.FindAndReplace:
+      find: org.springframework.boot.loader.WarLauncher
+      replace: org.springframework.boot.loader.launch.WarLauncher


### PR DESCRIPTION
## What's your motivation?
- https://github.com/spring-projects/spring-boot/issues/37667
- https://github.com/spring-projects/spring-boot/commit/c22548982abf0b9c5c02406fe789b0423fcfa02d

## Anything in particular you'd like reviewers to focus on?
References to these classes could occur anywhere, but in particular in Dockerfiles & manifest files.
References from Java files should be rare; as such I didn't feel a need to add a precondition to limit where we match and replace.
We could still add a precondition if this proves troublesome, for instance when it affects pom.xml files that might refer to these classes.