### PR TITLE
Attempt not to run boot upgrade 1.x -> 2.x for projects on 2.x already

### DIFF
--- a/src/main/resources/META-INF/rewrite/spring-boot-20.yml
+++ b/src/main/resources/META-INF/rewrite/spring-boot-20.yml
@@ -28,6 +28,11 @@ description: >
 tags:
   - spring
   - boot
+preconditions:
+  - org.openrewrite.java.dependencies.DependencyInsight:
+      groupIdPattern: org.springframework
+      artifactIdPattern: spring-core
+      version: 4.x
 recipeList:
   # Upgrade 2.0.x from 1.x
   - org.openrewrite.java.dependencies.UpgradeDependencyVersion:

--- a/src/testWithSpringBoot_2_7/java/org/openrewrite/java/spring/boot2/Boot3UpgradeTest.java
+++ b/src/testWithSpringBoot_2_7/java/org/openrewrite/java/spring/boot2/Boot3UpgradeTest.java
@@ -95,21 +95,8 @@ class Boot3UpgradeTest implements RewriteTest {
                   <properties>
                     <java.version>17</java.version>
                   </properties>
-                  <dependencyManagement>
-                    <dependencies>
-                      <dependency>
-                        <groupId>jakarta.validation</groupId>
-                        <artifactId>jakarta.validation-api</artifactId>
-                        <version>3.1.0</version>
-                      </dependency>
-                    </dependencies>
-                  </dependencyManagement>
 
                   <dependencies>
-                    <dependency>
-                      <groupId>jakarta.validation</groupId>
-                      <artifactId>jakarta.validation-api</artifactId>
-                    </dependency>
                     <dependency>
                       <groupId>jakarta.xml.bind</groupId>
                       <artifactId>jakarta.xml.bind-api</artifactId>


### PR DESCRIPTION
Fixes #542

Used `preconditions` if **spring-core** is 4.x then we can upgrade to boot 2.x