### PR TITLE
Remove classifier on dependency added migrating LocalServerPort

### DIFF
--- a/src/main/java/org/openrewrite/java/spring/boot2/MigrateLocalServerPortAnnotation.java
+++ b/src/main/java/org/openrewrite/java/spring/boot2/MigrateLocalServerPortAnnotation.java
@@ -68,7 +68,7 @@ public class MigrateLocalServerPortAnnotation extends Recipe {
             "2.0.x",
             null,
             "org.springframework.boot.web.server.LocalServerPort",
-            "org.springframework.boot.web.server.LocalServerPort",
+            null,
             null,
             null, null, null, null, null, null, null));
     }

--- a/src/testWithSpringBoot_1_5/java/org/openrewrite/java/spring/boot2/MigrateLocalServerPortAnnotationTest.java
+++ b/src/testWithSpringBoot_1_5/java/org/openrewrite/java/spring/boot2/MigrateLocalServerPortAnnotationTest.java
@@ -21,9 +21,7 @@ import org.openrewrite.java.JavaParser;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
-import static org.openrewrite.java.Assertions.java;
-import static org.openrewrite.java.Assertions.mavenProject;
-import static org.openrewrite.java.Assertions.srcTestJava;
+import static org.openrewrite.java.Assertions.*;
 import static org.openrewrite.maven.Assertions.pomXml;
 
 class MigrateLocalServerPortAnnotationTest implements RewriteTest {
@@ -35,7 +33,7 @@ class MigrateLocalServerPortAnnotationTest implements RewriteTest {
 
     @Issue("https://github.com/openrewrite/rewrite-spring/issues/116")
     @Test
-    void givenHasStringVariableWhenRemovingDeprecatedThenReplacesAddEnvironmentWithSetProperties() {
+    void shouldReplaceType() {
         //language=java
         rewriteRun(
           java(
@@ -49,7 +47,7 @@ class MigrateLocalServerPortAnnotationTest implements RewriteTest {
               """,
             """
               import org.springframework.boot.web.server.LocalServerPort;
-                            
+
               public class RandomTestClass {
                   @LocalServerPort
                   private int port;
@@ -63,14 +61,15 @@ class MigrateLocalServerPortAnnotationTest implements RewriteTest {
     @Test
     void shouldAddDependencyCorrectly() {
         rewriteRun(
+          spec -> spec.expectedCyclesThatMakeChanges(2),
           mavenProject("project",
-            srcTestJava(
+            srcMainJava(
               //language=Java
               java(
                 """
                   import org.springframework.boot.context.embedded.LocalServerPort;
 
-                  public class RandomTestClass {
+                  class RandomTestClass {
                       @LocalServerPort
                       private int port;
                   }
@@ -78,35 +77,59 @@ class MigrateLocalServerPortAnnotationTest implements RewriteTest {
                 """
                   import org.springframework.boot.web.server.LocalServerPort;
 
-                  public class RandomTestClass {
+                  class RandomTestClass {
                       @LocalServerPort
                       private int port;
                   }
                   """
-              ),
-              //language=XML
-              pomXml(
-                """
-                  <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
-                      <modelVersion>4.0.0</modelVersion>
-                      <parent>
-                          <groupId>org.springframework.boot</groupId>
-                          <artifactId>spring-boot-starter-parent</artifactId>
-                          <version>2.0.9.RELEASE</version>
-                          <relativePath/>
-                      </parent>
-                      <groupId>com.example</groupId>
-                      <artifactId>acme</artifactId>
-                      <version>0.0.1-SNAPSHOT</version>
-                      <dependencies>
-                          <dependency>
-                              <groupId>org.springframework.boot</groupId>
-                              <artifactId>spring-boot-starter-web</artifactId>
-                          </dependency>
-                      </dependencies>
-                  </project>
-                  """
               )
+            ),
+            //language=XML
+            pomXml(
+              """
+                <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+                    <modelVersion>4.0.0</modelVersion>
+                    <parent>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-parent</artifactId>
+                        <version>2.0.9.RELEASE</version>
+                        <relativePath/>
+                    </parent>
+                    <groupId>com.example</groupId>
+                    <artifactId>acme</artifactId>
+                    <version>0.0.1-SNAPSHOT</version>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.springframework.boot</groupId>
+                            <artifactId>spring-boot-starter</artifactId>
+                        </dependency>
+                    </dependencies>
+                </project>
+                """,
+              """
+                <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+                    <modelVersion>4.0.0</modelVersion>
+                    <parent>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-parent</artifactId>
+                        <version>2.0.9.RELEASE</version>
+                        <relativePath/>
+                    </parent>
+                    <groupId>com.example</groupId>
+                    <artifactId>acme</artifactId>
+                    <version>0.0.1-SNAPSHOT</version>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.springframework.boot</groupId>
+                            <artifactId>spring-boot-starter</artifactId>
+                        </dependency>
+                        <dependency>
+                            <groupId>org.springframework.boot</groupId>
+                            <artifactId>spring-boot-starter-web</artifactId>
+                        </dependency>
+                    </dependencies>
+                </project>
+                """
             )
           )
         );

--- a/src/testWithSpringBoot_1_5/java/org/openrewrite/java/spring/boot2/MigrateLocalServerPortAnnotationTest.java
+++ b/src/testWithSpringBoot_1_5/java/org/openrewrite/java/spring/boot2/MigrateLocalServerPortAnnotationTest.java
@@ -22,6 +22,9 @@ import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.java.Assertions.java;
+import static org.openrewrite.java.Assertions.mavenProject;
+import static org.openrewrite.java.Assertions.srcTestJava;
+import static org.openrewrite.maven.Assertions.pomXml;
 
 class MigrateLocalServerPortAnnotationTest implements RewriteTest {
     @Override
@@ -46,12 +49,65 @@ class MigrateLocalServerPortAnnotationTest implements RewriteTest {
               """,
             """
               import org.springframework.boot.web.server.LocalServerPort;
-              
+                            
               public class RandomTestClass {
                   @LocalServerPort
                   private int port;
               }
               """
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite-spring/issues/541")
+    @Test
+    void shouldAddDependencyCorrectly() {
+        rewriteRun(
+          mavenProject("project",
+            srcTestJava(
+              //language=Java
+              java(
+                """
+                  import org.springframework.boot.context.embedded.LocalServerPort;
+
+                  public class RandomTestClass {
+                      @LocalServerPort
+                      private int port;
+                  }
+                  """,
+                """
+                  import org.springframework.boot.web.server.LocalServerPort;
+
+                  public class RandomTestClass {
+                      @LocalServerPort
+                      private int port;
+                  }
+                  """
+              ),
+              //language=XML
+              pomXml(
+                """
+                  <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+                      <modelVersion>4.0.0</modelVersion>
+                      <parent>
+                          <groupId>org.springframework.boot</groupId>
+                          <artifactId>spring-boot-starter-parent</artifactId>
+                          <version>2.0.9.RELEASE</version>
+                          <relativePath/>
+                      </parent>
+                      <groupId>com.example</groupId>
+                      <artifactId>acme</artifactId>
+                      <version>0.0.1-SNAPSHOT</version>
+                      <dependencies>
+                          <dependency>
+                              <groupId>org.springframework.boot</groupId>
+                              <artifactId>spring-boot-starter-web</artifactId>
+                          </dependency>
+                      </dependencies>
+                  </project>
+                  """
+              )
+            )
           )
         );
     }


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->
Removes classifier setting on dependency added when migrating LocalServerPort

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->
Fixes https://github.com/openrewrite/rewrite-spring/issues/541


### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
