### PR TITLE
feat: `MoveAutoConfigurationToImportsFile` improvements 

### DIFF
--- a/src/main/java/org/openrewrite/java/spring/boot2/MoveAutoConfigurationToImportsFile.java
+++ b/src/main/java/org/openrewrite/java/spring/boot2/MoveAutoConfigurationToImportsFile.java
@@ -29,16 +29,7 @@ import org.openrewrite.text.PlainText;
 import org.openrewrite.text.PlainTextParser;
 
 import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.TreeSet;
+import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 

--- a/src/main/java/org/openrewrite/java/spring/boot2/MoveAutoConfigurationToImportsFile.java
+++ b/src/main/java/org/openrewrite/java/spring/boot2/MoveAutoConfigurationToImportsFile.java
@@ -17,12 +17,7 @@ package org.openrewrite.java.spring.boot2;
 
 import lombok.EqualsAndHashCode;
 import lombok.Value;
-import org.openrewrite.ExecutionContext;
-import org.openrewrite.Option;
-import org.openrewrite.ScanningRecipe;
-import org.openrewrite.SourceFile;
-import org.openrewrite.Tree;
-import org.openrewrite.TreeVisitor;
+import org.openrewrite.*;
 import org.openrewrite.internal.ListUtils;
 import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.java.JavaIsoVisitor;

--- a/src/testWithSpringBoot_2_7/java/org/openrewrite/java/spring/boot2/MoveAutoConfigurationToImportsFileTest.java
+++ b/src/testWithSpringBoot_2_7/java/org/openrewrite/java/spring/boot2/MoveAutoConfigurationToImportsFileTest.java
@@ -155,8 +155,8 @@ class MoveAutoConfigurationToImportsFileTest implements RewriteTest {
                 .parser(JavaParser.fromJavaVersion().classpath("spring-context")),
           text(
             """
-              org.springframework.boot.autoconfigure.EnableAutoConfiguration=\\
-              org.springframework.boot.autoconfigure.admin.SpringApplicationAdminJmxAutoConfiguration
+            org.springframework.boot.autoconfigure.EnableAutoConfiguration=\\
+            org.springframework.boot.autoconfigure.admin.SpringApplicationAdminJmxAutoConfiguration
             """,
             spec -> spec.path("src/main/resources/META-INF/spring.factories")
           ),

--- a/src/testWithSpringBoot_2_7/java/org/openrewrite/java/spring/boot2/MoveAutoConfigurationToImportsFileTest.java
+++ b/src/testWithSpringBoot_2_7/java/org/openrewrite/java/spring/boot2/MoveAutoConfigurationToImportsFileTest.java
@@ -132,8 +132,8 @@ class MoveAutoConfigurationToImportsFileTest implements RewriteTest {
         rewriteRun(
           text(
             """
-              org.springframework.boot.autoconfigure.EnableAutoConfiguration=\\
-              org.springframework.boot.autoconfigure.admin.SpringApplicationAdminJmxAutoConfiguration
+            org.springframework.boot.autoconfigure.EnableAutoConfiguration=\\
+            org.springframework.boot.autoconfigure.admin.SpringApplicationAdminJmxAutoConfiguration
             """,
             null,
             spec -> spec.path("src/main/resources/META-INF/spring.factories")

--- a/src/testWithSpringBoot_2_7/java/org/openrewrite/java/spring/boot2/MoveAutoConfigurationToImportsFileTest.java
+++ b/src/testWithSpringBoot_2_7/java/org/openrewrite/java/spring/boot2/MoveAutoConfigurationToImportsFileTest.java
@@ -249,7 +249,6 @@ class MoveAutoConfigurationToImportsFileTest implements RewriteTest {
     }
 
     @Test
-    //todo: fix for inner class
     void dontChangeAnnotationsOnAutoConfigurationClasses() {
         rewriteRun(
           spec -> spec.parser(JavaParser.fromJavaVersion().classpath("spring-boot-autoconfigure", "spring-context")),

--- a/src/testWithSpringBoot_2_7/java/org/openrewrite/java/spring/boot2/MoveAutoConfigurationToImportsFileTest.java
+++ b/src/testWithSpringBoot_2_7/java/org/openrewrite/java/spring/boot2/MoveAutoConfigurationToImportsFileTest.java
@@ -17,6 +17,7 @@ package org.openrewrite.java.spring.boot2;
 
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
+import org.openrewrite.Issue;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
@@ -41,20 +42,20 @@ class MoveAutoConfigurationToImportsFileTest implements RewriteTest {
               org.springframework.context.ApplicationContextInitializer=\\
               org.springframework.boot.autoconfigure.SharedMetadataReaderFactoryContextInitializer,\\
               org.springframework.boot.autoconfigure.logging.ConditionEvaluationReportLoggingListener
-                               
+
               #Sprinkle in some comments
               org.springframework.context.ApplicationListener=\\
               org.springframework.boot.autoconfigure.BackgroundPreinitializer
-                                      
+
               #Sprinkle in some comments
               org.springframework.boot.autoconfigure.AutoConfigurationImportListener=\\
               org.springframework.boot.autoconfigure.condition.ConditionEvaluationReportAutoConfigurationImportListener
-                                      
+
               org.springframework.boot.autoconfigure.AutoConfigurationImportFilter=\\
               org.springframework.boot.autoconfigure.condition.OnBeanCondition,\\
               org.springframework.boot.autoconfigure.condition.OnClassCondition,\\
               org.springframework.boot.autoconfigure.condition.OnWebApplicationCondition
-                                      
+
               org.springframework.boot.autoconfigure.EnableAutoConfiguration=\\
               org.springframework.boot.autoconfigure.admin.SpringApplicationAdminJmxAutoConfiguration,\\
               org.springframework.boot.autoconfigure.aop.AopAutoConfiguration,\\
@@ -69,7 +70,7 @@ class MoveAutoConfigurationToImportsFileTest implements RewriteTest {
               org.springframework.boot.autoconfigure.jooq.NoDslContextBeanFailureAnalyzer,\\
               org.springframework.boot.autoconfigure.r2dbc.ConnectionFactoryBeanCreationFailureAnalyzer,\\
               org.springframework.boot.autoconfigure.session.NonUniqueSessionRepositoryFailureAnalyzer
-                                      
+
               org.springframework.boot.autoconfigure.template.TemplateAvailabilityProvider=\\
               org.springframework.boot.autoconfigure.freemarker.FreeMarkerTemplateAvailabilityProvider,\\
               org.springframework.boot.autoconfigure.mustache.MustacheTemplateAvailabilityProvider,\\
@@ -81,20 +82,20 @@ class MoveAutoConfigurationToImportsFileTest implements RewriteTest {
               org.springframework.context.ApplicationContextInitializer=\\
               org.springframework.boot.autoconfigure.SharedMetadataReaderFactoryContextInitializer,\\
               org.springframework.boot.autoconfigure.logging.ConditionEvaluationReportLoggingListener
-                               
+
               #Sprinkle in some comments
               org.springframework.context.ApplicationListener=\\
               org.springframework.boot.autoconfigure.BackgroundPreinitializer
-                                      
+
               #Sprinkle in some comments
               org.springframework.boot.autoconfigure.AutoConfigurationImportListener=\\
               org.springframework.boot.autoconfigure.condition.ConditionEvaluationReportAutoConfigurationImportListener
-                                      
+
               org.springframework.boot.autoconfigure.AutoConfigurationImportFilter=\\
               org.springframework.boot.autoconfigure.condition.OnBeanCondition,\\
               org.springframework.boot.autoconfigure.condition.OnClassCondition,\\
               org.springframework.boot.autoconfigure.condition.OnWebApplicationCondition
-                                      
+
               #Sprinkle in some comments
               org.springframework.boot.diagnostics.FailureAnalyzer=\\
               org.springframework.boot.autoconfigure.data.redis.RedisUrlSyntaxFailureAnalyzer,\\
@@ -105,7 +106,7 @@ class MoveAutoConfigurationToImportsFileTest implements RewriteTest {
               org.springframework.boot.autoconfigure.jooq.NoDslContextBeanFailureAnalyzer,\\
               org.springframework.boot.autoconfigure.r2dbc.ConnectionFactoryBeanCreationFailureAnalyzer,\\
               org.springframework.boot.autoconfigure.session.NonUniqueSessionRepositoryFailureAnalyzer
-                                      
+
               org.springframework.boot.autoconfigure.template.TemplateAvailabilityProvider=\\
               org.springframework.boot.autoconfigure.freemarker.FreeMarkerTemplateAvailabilityProvider,\\
               org.springframework.boot.autoconfigure.mustache.MustacheTemplateAvailabilityProvider,\\
@@ -228,7 +229,7 @@ class MoveAutoConfigurationToImportsFileTest implements RewriteTest {
           java(
             """
               package org.springframework.boot.autoconfigure.amqp;
-              
+
               import org.springframework.context.annotation.Configuration;
 
               @Configuration
@@ -237,7 +238,7 @@ class MoveAutoConfigurationToImportsFileTest implements RewriteTest {
               """,
             """
               package org.springframework.boot.autoconfigure.amqp;
-              
+
               import org.springframework.boot.autoconfigure.AutoConfiguration;
 
               @AutoConfiguration
@@ -249,6 +250,7 @@ class MoveAutoConfigurationToImportsFileTest implements RewriteTest {
     }
 
     @Test
+    @Issue("https://github.com/openrewrite/rewrite-spring/issues/548")
     void dontChangeAnnotationsOnAutoConfigurationClasses() {
         rewriteRun(
           spec -> spec.parser(JavaParser.fromJavaVersion().classpath("spring-boot-autoconfigure", "spring-context")),
@@ -278,13 +280,13 @@ class MoveAutoConfigurationToImportsFileTest implements RewriteTest {
           java(
             """
               package org.springframework.boot.autoconfigure.amqp;
-              
+
               import org.springframework.boot.autoconfigure.AutoConfiguration;
               import org.springframework.context.annotation.Configuration;
 
               @AutoConfiguration
               public class RabbitAutoConfiguration {
-              
+
                 @Configuration
                 public static class InnerConfig {
                 }


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
* Previously, there was a bug where a second `@AutoConfiguration` was added to the class, even though an existing one was present. This has been fixed
* A new optional parameter to preserve old `spring.factories` file was added, defaults to false. This is for instances where backward compatibility is desired.
* fix bug where the nested `@Configuration` classes get their annotation removed.

closes #548 