### PR TITLE
Add Micrometer 1.13.x upgrade to Spring Boot 3.3.x migration

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -126,6 +126,7 @@ dependencies {
     runtimeOnly("org.openrewrite.recipe:rewrite-migrate-java:$rewriteVersion")
     runtimeOnly("org.openrewrite.recipe:rewrite-openapi:${rewriteVersion}")
     runtimeOnly("org.openrewrite.recipe:rewrite-testing-frameworks:$rewriteVersion")
+    runtimeOnly("org.openrewrite.recipe:rewrite-micrometer:$rewriteVersion")
 
     testRuntimeOnly("ch.qos.logback:logback-classic:1.+")
     testRuntimeOnly(gradleApi())

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -123,10 +123,10 @@ dependencies {
 
     runtimeOnly("org.openrewrite:rewrite-java-17")
     runtimeOnly("org.openrewrite.recipe:rewrite-hibernate:$rewriteVersion")
+    runtimeOnly("org.openrewrite.recipe:rewrite-micrometer:$rewriteVersion")
     runtimeOnly("org.openrewrite.recipe:rewrite-migrate-java:$rewriteVersion")
     runtimeOnly("org.openrewrite.recipe:rewrite-openapi:${rewriteVersion}")
     runtimeOnly("org.openrewrite.recipe:rewrite-testing-frameworks:$rewriteVersion")
-    runtimeOnly("org.openrewrite.recipe:rewrite-micrometer:$rewriteVersion")
 
     testRuntimeOnly("ch.qos.logback:logback-classic:1.+")
     testRuntimeOnly(gradleApi())

--- a/src/main/resources/META-INF/rewrite/spring-boot-33.yml
+++ b/src/main/resources/META-INF/rewrite/spring-boot-33.yml
@@ -54,7 +54,6 @@ recipeList:
       newGroupId: org.apache.cassandra
       oldArtifactId: "*"
 
-  # https://github.com/openrewrite/rewrite-micrometer/pull/11#issuecomment-2225187584
   - org.openrewrite.micrometer.UpgradeMicrometer13
 ---
 type: specs.openrewrite.org/v1beta/recipe

--- a/src/main/resources/META-INF/rewrite/spring-boot-33.yml
+++ b/src/main/resources/META-INF/rewrite/spring-boot-33.yml
@@ -54,6 +54,8 @@ recipeList:
       newGroupId: org.apache.cassandra
       oldArtifactId: "*"
 
+  # https://github.com/openrewrite/rewrite-micrometer/pull/11#issuecomment-2225187584
+  - org.openrewrite.micrometer.UpgradeMicrometer13
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.spring.boot3.SpringBoot3BestPractices


### PR DESCRIPTION
Partially resolves #526

## What's changed?
* Add Micrometer 1.13.x upgrade to Spring Boot 3.3.x migration: https://github.com/openrewrite/rewrite-micrometer/pull/11

## What's your motivation?
* Spring Boot 3.3.x includes Micrometer 1.13.x which introduced [breaking changes](https://github.com/micrometer-metrics/micrometer/wiki/1.13-Migration-Guide)

## Anything in particular you'd like reviewers to focus on?
* [As Tim suggested](https://github.com/openrewrite/rewrite-micrometer/pull/11#issuecomment-2225187584) I specifically included the migration to verison 1.13.x in the recipe list as opposed to the generic micrometer upgrade recipe to avoid "surprises" with regards to versions in the future

## Anyone you would like to review specifically?
@timtebeek 

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
