### PR TITLE
Spring Boot 2.0 - moving the precondition to run in more cases

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -144,6 +144,7 @@ dependencies {
     "testWithSpringBoot_1_5RuntimeOnly"("org.springframework.boot:spring-boot:1.5.+")
     "testWithSpringBoot_1_5RuntimeOnly"("org.springframework.boot:spring-boot-autoconfigure:1.5.+")
     "testWithSpringBoot_1_5RuntimeOnly"("org.springframework.boot:spring-boot-test:1.5.+")
+    "testWithSpringBoot_1_5RuntimeOnly"("org.hibernate.validation:hibernate-validator:1.5.+")
     "testWithSpringBoot_1_5RuntimeOnly"("org.hamcrest:hamcrest:2.2")
     "testWithSpringBoot_1_5RuntimeOnly"("junit:junit:latest.release")
 
@@ -158,6 +159,7 @@ dependencies {
     "testWithSpringBoot_2_1RuntimeOnly"("org.springframework.security:spring-security-web:5.1.+")
 
     "testWithSpringBoot_2_2RuntimeOnly"("org.springframework.boot:spring-boot:2.2.+")
+    "testWithSpringBoot_2_2RuntimeOnly"("org.springframework.boot:spring-boot-starter-validation:2.2.+")
 
     "testWithSpringBoot_2_3RuntimeOnly"("org.springframework:spring-test:5.3.+")
     "testWithSpringBoot_2_3RuntimeOnly"("junit:junit:latest.release")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -144,7 +144,7 @@ dependencies {
     "testWithSpringBoot_1_5RuntimeOnly"("org.springframework.boot:spring-boot:1.5.+")
     "testWithSpringBoot_1_5RuntimeOnly"("org.springframework.boot:spring-boot-autoconfigure:1.5.+")
     "testWithSpringBoot_1_5RuntimeOnly"("org.springframework.boot:spring-boot-test:1.5.+")
-    "testWithSpringBoot_1_5RuntimeOnly"("org.hibernate.validation:hibernate-validator:1.5.+")
+    "testWithSpringBoot_1_5RuntimeOnly"("org.springframework.boot:spring-boot-starter-validation:1.5.+")
     "testWithSpringBoot_1_5RuntimeOnly"("org.hamcrest:hamcrest:2.2")
     "testWithSpringBoot_1_5RuntimeOnly"("junit:junit:latest.release")
 

--- a/src/main/resources/META-INF/rewrite/spring-boot-20.yml
+++ b/src/main/resources/META-INF/rewrite/spring-boot-20.yml
@@ -68,6 +68,14 @@ recipeList:
   - org.openrewrite.java.spring.boot2.MigrateLocalServerPortAnnotation
   # Update properties
   - org.openrewrite.java.spring.boot2.SpringBootProperties_2_0
+  - org.openrewrite.java.spring.ChangeSpringPropertyValue:
+      propertyKey: spring.main.banner-mode
+      oldValue: true
+      newValue: console
+  - org.openrewrite.java.spring.ChangeSpringPropertyValue:
+      propertyKey: spring.main.banner-mode
+      oldValue: false
+      newValue: "off"
   - org.openrewrite.java.spring.boot2.SpringBoot2BestPractices
 ---
 type: specs.openrewrite.org/v1beta/recipe
@@ -133,14 +141,6 @@ recipeList:
       oldFullyQualifiedTypeName: org.hibernate.validator.constraints.NotEmpty
       newFullyQualifiedTypeName: javax.validation.constraints.NotEmpty
   - org.openrewrite.java.spring.boot2.MaybeAddJavaxValidationApi
-  - org.openrewrite.java.spring.ChangeSpringPropertyValue:
-      propertyKey: spring.main.banner-mode
-      oldValue: true
-      newValue: console
-  - org.openrewrite.java.spring.ChangeSpringPropertyValue:
-      propertyKey: spring.main.banner-mode
-      oldValue: false
-      newValue: "off"
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.spring.boot2.MaybeAddJavaxValidationApi

--- a/src/main/resources/META-INF/rewrite/spring-boot-20.yml
+++ b/src/main/resources/META-INF/rewrite/spring-boot-20.yml
@@ -28,11 +28,6 @@ description: >
 tags:
   - spring
   - boot
-preconditions:
-  - org.openrewrite.java.dependencies.DependencyInsight:
-      groupIdPattern: org.springframework
-      artifactIdPattern: spring-core
-      version: 4.x
 recipeList:
   # Upgrade 2.0.x from 1.x
   - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
@@ -137,11 +132,7 @@ recipeList:
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: org.hibernate.validator.constraints.NotEmpty
       newFullyQualifiedTypeName: javax.validation.constraints.NotEmpty
-  - org.openrewrite.java.dependencies.AddDependency:
-      groupId: javax.validation
-      artifactId: validation-api
-      version: 2.x
-      onlyIfUsing: javax.validation.constraints.*
+  - org.openrewrite.java.spring.boot2.MaybeAddJavaxValidationApi
   - org.openrewrite.java.spring.ChangeSpringPropertyValue:
       propertyKey: spring.main.banner-mode
       oldValue: true
@@ -150,6 +141,27 @@ recipeList:
       propertyKey: spring.main.banner-mode
       oldValue: false
       newValue: "off"
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.spring.boot2.MaybeAddJavaxValidationApi
+displayName: Add `javax.validation-api` dependency
+description: Conditional on the application using a version of Spring Boot which uses javax but provides a hibernate-validator version which exports the jakarta.validation-api instead
+preconditions:
+  - org.openrewrite.java.dependencies.DependencyInsight:
+      groupIdPattern: org.springframework.boot
+      artifactIdPattern: spring-boot-starter
+      version: "[2.2,2.7)"
+recipeList:
+  - org.openrewrite.java.dependencies.AddDependency:
+      groupId: javax.validation
+      artifactId: validation-api
+      version: 2.x
+      onlyIfUsing: javax.validation.constraints.*
+  - org.openrewrite.java.dependencies.AddDependency:
+      groupId: javax.validation
+      artifactId: validation-api
+      version: 2.x
+      onlyIfUsing: org.hibernate.validator.constraints.*
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.spring.boot2.SpringBoot2BestPractices

--- a/src/testWithSpringBoot_1_5/java/org/openrewrite/java/spring/boot2/Boot2UpgradeTest.java
+++ b/src/testWithSpringBoot_1_5/java/org/openrewrite/java/spring/boot2/Boot2UpgradeTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.spring.boot2;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.*;
+import static org.openrewrite.maven.Assertions.pomXml;
+
+class Boot2UpgradeTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec
+          .recipeFromResources("org.openrewrite.java.spring.boot2.UpgradeSpringBoot_2_0")
+          .parser(JavaParser.fromJavaVersion()
+            .classpath("hibernate-validator"));
+    }
+
+    @Test
+    void addJavaxValidationApi() {
+        rewriteRun(
+          mavenProject("project",
+            //language=xml
+            pomXml(
+              """
+                <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>org.springframework.samples</groupId>
+                  <artifactId>spring-petclinic</artifactId>
+                  <version>1.5.22.RELEASE</version>
+
+                  <parent>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-starter-parent</artifactId>
+                    <version>1.5.22.RELEASE</version>
+                  </parent>
+                  <name>petclinic</name>
+
+                  <properties>
+                    <java.version>1.8</java.version>
+                  </properties>
+
+                  <dependencies>
+                    <dependency>
+                      <groupId>org.springframework.boot</groupId>
+                      <artifactId>spring-boot-starter-validation</artifactId>
+                    </dependency>
+                  </dependencies>
+                </project>
+                """,
+              """
+                <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>org.springframework.samples</groupId>
+                  <artifactId>spring-petclinic</artifactId>
+                  <version>1.5.22.RELEASE</version>
+
+                  <parent>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-starter-parent</artifactId>
+                    <version>2.0.9.RELEASE</version>
+                  </parent>
+                  <name>petclinic</name>
+
+                  <properties>
+                    <java.version>1.8</java.version>
+                  </properties>
+
+                  <dependencies>
+                    <dependency>
+                      <groupId>org.springframework.boot</groupId>
+                      <artifactId>spring-boot-starter-validation</artifactId>
+                    </dependency>
+                  </dependencies>
+                </project>
+                """
+            ),
+            //language=java
+            srcMainJava(
+              java(
+                """
+                  package org.springframework.samples.petclinic.vet;
+                  
+                  import org.hibernate.validator.constraints.NotEmpty;
+                  
+                  public class Vet {
+                      @NotEmpty
+                      private String lastName;
+                  }
+                  """,
+                """
+                  package org.springframework.samples.petclinic.vet;
+                  
+                  import javax.validation.constraints.NotEmpty;
+                  
+                  public class Vet {
+                      @NotEmpty
+                      private String lastName;
+                  }
+                  """
+              )
+            )
+          )
+        );
+    }
+}

--- a/src/testWithSpringBoot_2_2/java/org/openrewrite/java/spring/boot2/Boot2UpgradeTest.java
+++ b/src/testWithSpringBoot_2_2/java/org/openrewrite/java/spring/boot2/Boot2UpgradeTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.spring.boot2;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.*;
+import static org.openrewrite.maven.Assertions.pomXml;
+
+class Boot2UpgradeTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec
+          .recipeFromResources("org.openrewrite.java.spring.boot2.UpgradeSpringBoot_2_3")
+          .parser(JavaParser.fromJavaVersion()
+            .classpath("hibernate-validator"));
+    }
+
+    @Test
+    void addJavaxValidationApi() {
+        rewriteRun(
+          mavenProject("project",
+            //language=xml
+            pomXml(
+              """
+                <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>org.springframework.samples</groupId>
+                  <artifactId>spring-petclinic</artifactId>
+                  <version>2.2.13.RELEASE</version>
+
+                  <parent>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-starter-parent</artifactId>
+                    <version>2.2.13.RELEASE</version>
+                  </parent>
+                  <name>petclinic</name>
+
+                  <properties>
+                    <java.version>1.8</java.version>
+                  </properties>
+
+                  <dependencies>
+                    <dependency>
+                      <groupId>org.springframework.boot</groupId>
+                      <artifactId>spring-boot-starter-validation</artifactId>
+                    </dependency>
+                  </dependencies>
+                </project>
+                """,
+              """
+                <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>org.springframework.samples</groupId>
+                  <artifactId>spring-petclinic</artifactId>
+                  <version>2.2.13.RELEASE</version>
+
+                  <parent>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-starter-parent</artifactId>
+                    <version>2.3.12.RELEASE</version>
+                  </parent>
+                  <name>petclinic</name>
+
+                  <properties>
+                    <java.version>1.8</java.version>
+                  </properties>
+
+                  <dependencies>
+                    <dependency>
+                      <groupId>javax.validation</groupId>
+                      <artifactId>validation-api</artifactId>
+                    </dependency>
+                    <dependency>
+                      <groupId>org.springframework.boot</groupId>
+                      <artifactId>spring-boot-starter-validation</artifactId>
+                    </dependency>
+                  </dependencies>
+                </project>
+                """
+            ),
+            //language=java
+            srcMainJava(
+              java(
+                """
+                  package org.springframework.samples.petclinic.vet;
+                  
+                  import org.hibernate.validator.constraints.NotEmpty;
+                  
+                  public class Vet {
+                      @NotEmpty
+                      private String lastName;
+                  }
+                  """,
+                """
+                  package org.springframework.samples.petclinic.vet;
+                  
+                  import javax.validation.constraints.NotEmpty;
+                  
+                  public class Vet {
+                      @NotEmpty
+                      private String lastName;
+                  }
+                  """
+              )
+            )
+          )
+        );
+    }
+}


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->
narrowing the precondition on the SB 2.0 recipe to ensure it runs more consistently.

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->
https://github.com/openrewrite/rewrite-spring/pull/543/files#r1678212731

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->
the new precondition is better, but does have a false positive if running the 2.2 recipe on a 2.2 project and a false negative if running the 2.7 recipe on a 2.7 project. this is hard to avoid. the javax.validation-api dep is necessary for SB 2.3 (when hibernate-validator 6.1 swaps its transitive dep from javax to jakarta) through SB 2.7 until SB 3.0 (when spring swaps to jakarta). and with this recipe's placement, it has to make an educated guess about the "final" version of SB for the project after all other recipes in the chain complete while only knowing the current version.

## Anyone you would like to review specifically?
<!-- @mention them here -->
@BoykoAlex 

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->
a nice counterbalance to this recipe might be if the `rewrite-migrate-java` javax->jakarta migration removed direct jakarta deps which are also available transitively, after it converts javax deps to jakarta. this would help untangle a pom which previously used `spring-boot-starter-validation` plus `javax.validation-api`. in the current state, the javax->jakarta recipe leaves such a pom with a redundant `jakarta.validation-api` which the starter already has covered.

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [X] I've added unit tests to cover both positive and negative cases
- [X] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [X] I've used the IntelliJ IDEA auto-formatter on affected files
