### PR TITLE
Include Spring Batch in Spring Boot 3 upgrade

### DIFF
--- a/src/main/java/org/openrewrite/java/spring/batch/MigrateItemWriterWrite.java
+++ b/src/main/java/org/openrewrite/java/spring/batch/MigrateItemWriterWrite.java
@@ -23,6 +23,7 @@ import org.openrewrite.java.JavaParser;
 import org.openrewrite.java.JavaTemplate;
 import org.openrewrite.java.MethodMatcher;
 import org.openrewrite.java.search.DeclaresMethod;
+import org.openrewrite.java.service.AnnotationService;
 import org.openrewrite.java.tree.*;
 import org.openrewrite.marker.Markers;
 
@@ -40,7 +41,7 @@ public class MigrateItemWriterWrite extends Recipe {
 
     @Override
     public String getDescription() {
-        return "`JobBuilderFactory` was deprecated in Springbatch 5.x : replaced by `JobBuilder`.";
+        return "`JobBuilderFactory` was deprecated in spring-batch 5.x: replaced by `JobBuilder`.";
     }
 
     private static final MethodMatcher ITEM_WRITER_MATCHER = new MethodMatcher("org.springframework.batch.item.ItemWriter write(java.util.List)", true);
@@ -66,8 +67,11 @@ public class MigrateItemWriterWrite extends Recipe {
                 String paramName = parameter.getVariables().get(0).getSimpleName();
 
                 // @Override may or may not already be present
+
                 String annotationsWithOverride = Stream.concat(
-                                m.getAllAnnotations().stream().map(it -> it.print(getCursor())),
+                                service(AnnotationService.class)
+                                        .getAllAnnotations(getCursor()).stream()
+                                        .map(it -> it.print(getCursor())),
                                 Stream.of("@Override"))
                         .distinct()
                         .collect(Collectors.joining("\n"));

--- a/src/main/java/org/openrewrite/java/spring/batch/ReplaceSupportClassWithItsInterface.java
+++ b/src/main/java/org/openrewrite/java/spring/batch/ReplaceSupportClassWithItsInterface.java
@@ -38,16 +38,16 @@ public class ReplaceSupportClassWithItsInterface extends Recipe {
 
     @Override
     public String getDescription() {
-        return "As of Spring-Batch 5.0 Listeners has default methods (made possible by a Java 8 baseline) and can be " +
+        return "As of spring-batch 5.x Listeners has default methods (made possible by a Java 8 baseline) and can be " +
                 "implemented directly without the need for this adapter.";
     }
 
-    @Option(displayName = "Fully Qualified Class Name",
+    @Option(displayName = "Fully qualified class name",
             description = "A fully-qualified class name to be replaced.",
             example = "org.springframework.batch.core.listener.JobExecutionListenerSupport")
     String fullyQualifiedClassName;
 
-    @Option(displayName = "Fully Qualified Interface Name",
+    @Option(displayName = "Fully qualified interface name",
             description = "A fully-qualified Interface name to replace by.",
             example = "org.springframework.batch.core.JobExecutionListener")
     String fullyQualifiedInterfaceName;

--- a/src/main/resources/META-INF/rewrite/spring-boot-30.yml
+++ b/src/main/resources/META-INF/rewrite/spring-boot-30.yml
@@ -65,6 +65,7 @@ recipeList:
   - org.openrewrite.java.spring.boot3.MigrateThymeleafDependencies
   - org.openrewrite.java.spring.boot3.UpgradeSpringDoc_2
   - org.openrewrite.java.spring.boot3.MigrateDropWizardDependencies
+  - org.openrewrite.java.spring.boot3.SpringBatch4To5Migration
   - org.openrewrite.java.spring.framework.UpgradeSpringFramework_6_0
   - org.openrewrite.java.spring.security6.UpgradeSpringSecurity_6_0
   - org.openrewrite.java.spring.cloud2022.UpgradeSpringCloud_2022


### PR DESCRIPTION
As reported we missed including these recipes, even though Spring Batch 5 requires Java 17 & Spring Framework 6:
https://docs.spring.io/spring-batch/docs/5.0.6/reference/html/whatsnew.html#whatsNew

