### PR TITLE
Remove `SimpleClientHttpRequestFactory.setOutputStreaming(boolean)` in SF 6.1

### DIFF
--- a/src/main/resources/META-INF/rewrite/spring-framework-61.yml
+++ b/src/main/resources/META-INF/rewrite/spring-framework-61.yml
@@ -1,0 +1,31 @@
+#
+# Copyright 2024 the original author or authors.
+# <p>
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# <p>
+# https://www.apache.org/licenses/LICENSE-2.0
+# <p>
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+########################################################################################################################
+# Spring Framework 6.1
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.spring.framework.UpgradeSpringFramework_6_1
+displayName: Migrate to Spring Framework 6.1
+description: Migrate applications to the latest Spring Framework 6.1 release.
+recipeList:
+  - org.openrewrite.java.spring.framework.UpgradeSpringFramework_6_0
+  - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
+      groupId: org.springframework
+      artifactId: "*"
+      newVersion: 6.1.x
+  - org.openrewrite.java.migrate.RemoveMethodInvocation:
+      methodPattern: org.springframework.http.client.SimpleClientHttpRequestFactory setOutputStreaming(boolean)


### PR DESCRIPTION
Deprecated for removal in 6.1: Requests are now always streaming.
> as of 6.1 requests are always streamed, as if this property is {@code true}

https://github.com/spring-projects/spring-framework/blob/29dce74fcdd62c6c877973378368fe342afb5fbd/spring-web/src/main/java/org/springframework/http/client/SimpleClientHttpRequestFactory.java#L145-L148