### PR TITLE
Include new reactor migration as of springboot 3.2

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -123,6 +123,7 @@ dependencies {
 
     runtimeOnly("org.openrewrite:rewrite-java-17")
     runtimeOnly("org.openrewrite.recipe:rewrite-hibernate:$rewriteVersion")
+    runtimeOnly("org.openrewrite.recipe:rewrite-reactive-streams:$rewriteVersion")
     runtimeOnly("org.openrewrite.recipe:rewrite-migrate-java:$rewriteVersion")
     runtimeOnly("org.openrewrite.recipe:rewrite-openapi:${rewriteVersion}")
     runtimeOnly("org.openrewrite.recipe:rewrite-testing-frameworks:$rewriteVersion")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -123,9 +123,9 @@ dependencies {
 
     runtimeOnly("org.openrewrite:rewrite-java-17")
     runtimeOnly("org.openrewrite.recipe:rewrite-hibernate:$rewriteVersion")
-    runtimeOnly("org.openrewrite.recipe:rewrite-reactive-streams:$rewriteVersion")
     runtimeOnly("org.openrewrite.recipe:rewrite-migrate-java:$rewriteVersion")
     runtimeOnly("org.openrewrite.recipe:rewrite-openapi:${rewriteVersion}")
+    runtimeOnly("org.openrewrite.recipe:rewrite-reactive-streams:$rewriteVersion")
     runtimeOnly("org.openrewrite.recipe:rewrite-testing-frameworks:$rewriteVersion")
 
     testRuntimeOnly("ch.qos.logback:logback-classic:1.+")

--- a/src/main/resources/META-INF/rewrite/spring-boot-31.yml
+++ b/src/main/resources/META-INF/rewrite/spring-boot-31.yml
@@ -47,3 +47,4 @@ recipeList:
   - org.openrewrite.java.spring.security6.UpgradeSpringSecurity_6_1
   - org.openrewrite.java.spring.boot3.SpringBootProperties_3_1
   - org.openrewrite.hibernate.MigrateToHibernate62
+  - org.openrewrite.reactive.reactor.UpgradeReactor_3_5

--- a/src/main/resources/META-INF/rewrite/spring-boot-32.yml
+++ b/src/main/resources/META-INF/rewrite/spring-boot-32.yml
@@ -68,6 +68,7 @@ recipeList:
       newFullyQualifiedTypeName: org.springframework.boot.autoconfigure.transaction.TransactionManagerCustomizer
   - org.openrewrite.hibernate.MigrateToHibernate63
   - org.openrewrite.java.spring.boot3.RelocateLauncherClasses
+  - org.openrewrite.reactive.reactor.UpgradeReactor_3_5
 
 ---
 type: specs.openrewrite.org/v1beta/recipe

--- a/src/main/resources/META-INF/rewrite/spring-boot-32.yml
+++ b/src/main/resources/META-INF/rewrite/spring-boot-32.yml
@@ -68,7 +68,6 @@ recipeList:
       newFullyQualifiedTypeName: org.springframework.boot.autoconfigure.transaction.TransactionManagerCustomizer
   - org.openrewrite.hibernate.MigrateToHibernate63
   - org.openrewrite.java.spring.boot3.RelocateLauncherClasses
-  - org.openrewrite.reactive.reactor.UpgradeReactor_3_5
 
 ---
 type: specs.openrewrite.org/v1beta/recipe


### PR DESCRIPTION
Spring boot upgrade to 3.2.4 also upgrades io.projectreactor/reactor-bom from 2020.0.27 to 2023.0.4. This in turn upgrades reactor-core module from 3.4.26 to 3.6.5.

<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->
@timtebeek 

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
