### PR TITLE
Include Apache Httpclient4 to 5 in Spring Framework 6 upgrade

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -112,7 +112,6 @@ val rewriteVersion = rewriteRecipe.rewriteVersion.get()
 
 dependencies {
     implementation(platform("org.openrewrite:rewrite-bom:${rewriteVersion}"))
-    implementation("org.openrewrite:rewrite-apache")
     implementation("org.openrewrite:rewrite-java")
     implementation("org.openrewrite:rewrite-xml")
     implementation("org.openrewrite:rewrite-properties")
@@ -123,6 +122,7 @@ dependencies {
     implementation("org.openrewrite.gradle.tooling:model:${rewriteVersion}")
 
     runtimeOnly("org.openrewrite:rewrite-java-17")
+    runtimeOnly("org.openrewrite.recipe:rewrite-apache:$rewriteVersion")
     runtimeOnly("org.openrewrite.recipe:rewrite-hibernate:$rewriteVersion")
     runtimeOnly("org.openrewrite.recipe:rewrite-micrometer:$rewriteVersion")
     runtimeOnly("org.openrewrite.recipe:rewrite-migrate-java:$rewriteVersion")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -112,6 +112,7 @@ val rewriteVersion = rewriteRecipe.rewriteVersion.get()
 
 dependencies {
     implementation(platform("org.openrewrite:rewrite-bom:${rewriteVersion}"))
+    implementation("org.openrewrite:rewrite-apache")
     implementation("org.openrewrite:rewrite-java")
     implementation("org.openrewrite:rewrite-xml")
     implementation("org.openrewrite:rewrite-properties")

--- a/src/main/resources/META-INF/rewrite/spring-framework-60.yml
+++ b/src/main/resources/META-INF/rewrite/spring-framework-60.yml
@@ -28,6 +28,7 @@ recipeList:
       artifactId: "*"
       newVersion: 6.0.x
   - org.openrewrite.java.spring.framework.MigrateSpringAssert
+  - org.openrewrite.apache.httpclient5.UpgradeApacheHttpClient_5
 
 ---
 type: specs.openrewrite.org/v1beta/recipe


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->
Include Apache HttpClient4 to HttpClient5 migration with Spring framework 6 migration 

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->
https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-3.1-Release-Notes#dependency-management-for-apache-httpclient-4

> Support for Apache HttpClient 4 with RestTemplate was [removed in Spring Framework 6](https://github.com/spring-projects/spring-framework/issues/28925), in favor of Apache HttpClient 5. Spring Boot 3.0 includes dependency management for both HttpClient 4 and 5. Applications that continue to use HttpClient 4 can experience [errors when using RestTemplate](https://github.com/spring-projects/spring-boot/issues/33515) that are difficult to diagnose.
> 
> Spring Boot 3.1 removes dependency management for HttpClient 4 to encourage users to move to HttpClient 5 instead.
> 

## Have you considered any alternatives or workarounds?
While technically this would only be required when using Apache HttpClient with RestTemplate, the 3.1 release notes already hint at dependency management being dropped for httpclient 4.x

## Any additional context
https://docs.spring.io/spring-boot/3.3/appendix/dependency-versions/coordinates.html
![image](https://github.com/user-attachments/assets/d8a2a3d7-8fe4-488c-86e2-391420e4f538)
