### PR TITLE
Add recipe to migrate JUnit 4's ExpectedException

### DIFF
--- a/src/main/java/org/openrewrite/java/spring/test/ExpectedExceptionToAssertThrows.java
+++ b/src/main/java/org/openrewrite/java/spring/test/ExpectedExceptionToAssertThrows.java
@@ -1,0 +1,19 @@
+package org.openrewrite.java.spring.test;
+
+import org.openrewrite.NlsRewrite.Description;
+import org.openrewrite.NlsRewrite.DisplayName;
+import org.openrewrite.Recipe;
+
+public class ExpectedExceptionToAssertThrows extends Recipe {
+
+    @Override
+    public @DisplayName String getDisplayName() {
+        return "Migrate JUnit 4's ExpectedException";
+    }
+
+    @Override
+    public @Description String getDescription() {
+        return "Replace JUnit 4's ExpectedException with JUnit 5's assertThrows.";
+    }
+    
+}

--- a/src/main/java/org/openrewrite/java/spring/test/ExpectedExceptionToAssertThrows.java
+++ b/src/main/java/org/openrewrite/java/spring/test/ExpectedExceptionToAssertThrows.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openrewrite.java.spring.test;
 
 import org.openrewrite.NlsRewrite.Description;

--- a/src/test/java/org/openrewrite/java/spring/test/ExpectedExceptionToAssertThrowsTest.java
+++ b/src/test/java/org/openrewrite/java/spring/test/ExpectedExceptionToAssertThrowsTest.java
@@ -1,6 +1,19 @@
-package org.openrewrite.java.spring.test;
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
-import static org.openrewrite.java.Assertions.java;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.InMemoryExecutionContext;
@@ -8,7 +21,9 @@ import org.openrewrite.java.JavaParser;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
-public class ExpectedExceptionToAssertThrowsTest implements RewriteTest {
+import static org.openrewrite.java.Assertions.java;
+
+class ExpectedExceptionToAssertThrowsTest implements RewriteTest {
 
     @Override
     public void defaults(RecipeSpec spec) {

--- a/src/test/java/org/openrewrite/java/spring/test/ExpectedExceptionToAssertThrowsTest.java
+++ b/src/test/java/org/openrewrite/java/spring/test/ExpectedExceptionToAssertThrowsTest.java
@@ -1,0 +1,64 @@
+package org.openrewrite.java.spring.test;
+
+import static org.openrewrite.java.Assertions.java;
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.InMemoryExecutionContext;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+public class ExpectedExceptionToAssertThrowsTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(new ExpectedExceptionToAssertThrows())
+          .parser(JavaParser.fromJavaVersion()
+            .classpathFromResources(new InMemoryExecutionContext(), "spring-boot-test", "spring-test")
+          );
+    }
+
+    @Test
+    @DocumentExample
+    void thatExpectedExceptionIsMigratedToAssertThrows() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import org.junit.Rule;
+              import org.junit.Test;
+              import org.junit.rules.ExpectedException;
+
+              class SomeTest {
+
+                  @Rule
+                  public ExpectedException thrown = ExpectedException.none();
+
+                  @Test
+                  public void test() {
+                      thrown.expectMessage("exception");
+                      throw new RuntimeException("exception");
+                  }
+              } 
+              """,
+            """
+              import org.junit.Rule;
+              import org.junit.Test;
+              import org.junit.rules.ExpectedException;
+
+              class SomeTest {
+
+                  @Rule
+                  public ExpectedException thrown = ExpectedException.none();
+
+                  @Test
+                  public void test() {
+                      thrown.expectMessage("exception");
+                      throw new RuntimeException("exception");
+                  }
+              }    
+              """
+          )
+        );
+    }
+}


### PR DESCRIPTION
## What's changed?
Add a `ExpectedExceptionToAssertThrows` recipe that migrates JUnit4's `ExpectedException` class.

## What's your motivation?
- This fixes openrewrite/rewrite-testing-frameworks#581.

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
