### PR TITLE
Remove `SolrAutoConfiguration` from `@SpringBootApplication` exclusions

### DIFF
--- a/src/main/java/org/openrewrite/java/spring/boot3/RemoveSolrAutoConfigurationExclude.java
+++ b/src/main/java/org/openrewrite/java/spring/boot3/RemoveSolrAutoConfigurationExclude.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.spring.boot3;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Preconditions;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.internal.ListUtils;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.search.UsesType;
+import org.openrewrite.java.tree.Expression;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.TypeUtils;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
+
+public class RemoveSolrAutoConfigurationExclude extends Recipe {
+
+    @Override
+    public String getDisplayName() {
+        return "Remove `SolrAutoConfiguration` exclusion";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Remove `SolrAutoConfiguration` exclusion from Spring Boot application annotation.";
+    }
+
+    private static final String SPRING_BOOT_APPLICATION = "org.springframework.boot.autoconfigure.SpringBootApplication";
+    private static final String SOLR_AUTOCONFIGURATION = "SolrAutoConfiguration";
+    private static final String SOLR_AUTOCONFIGURATION_FQ = "org.springframework.boot.autoconfigure.solr." + SOLR_AUTOCONFIGURATION;
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return Preconditions.check(new UsesType<>(SPRING_BOOT_APPLICATION, true), new JavaIsoVisitor<ExecutionContext>() {
+            @Override
+            public J.Annotation visitAnnotation(J.Annotation a, ExecutionContext ctx) {
+                if (!TypeUtils.isOfClassType(a.getType(), SPRING_BOOT_APPLICATION)) {
+                    return a;
+                }
+
+                AtomicBoolean changedAnnotation = new AtomicBoolean(false);
+                List<Expression> currentArgs = a.getArguments();
+                if (currentArgs == null || currentArgs.isEmpty() || currentArgs.stream().anyMatch(arg -> arg instanceof J.Empty)) {
+                    return a;
+                }
+                List<Expression> newArgs = ListUtils.map(currentArgs, it -> {
+                    if (it instanceof J.Assignment) {
+                        J.Assignment as = (J.Assignment) it;
+                        J.Identifier var = (J.Identifier) as.getVariable();
+                        if (!var.getSimpleName().equals("exclude")) {
+                            return it;
+                        }
+                        if (as.getAssignment() != null) {
+                            if (as.getAssignment() instanceof J.NewArray) {
+                                J.NewArray value = (J.NewArray) as.getAssignment();
+                                if (value.getInitializer().stream().noneMatch(expr -> expr instanceof J.FieldAccess && ((J.Identifier) ((J.FieldAccess) expr).getTarget()).getSimpleName().equals(SOLR_AUTOCONFIGURATION))) {
+                                    return it;
+                                } else {
+                                    List<Expression> values = value.getPadding().getInitializer().getElements().stream().filter(expr -> expr instanceof J.FieldAccess && !((J.Identifier) ((J.FieldAccess) expr).getTarget()).getSimpleName().equals(SOLR_AUTOCONFIGURATION)).collect(Collectors.toList());
+                                    if (values.isEmpty()) {
+                                        maybeRemoveImport(SOLR_AUTOCONFIGURATION_FQ);
+                                        changedAnnotation.set(true);
+                                        return null;
+                                    } else {
+                                        maybeRemoveImport(SOLR_AUTOCONFIGURATION_FQ);
+                                        changedAnnotation.set(true);
+                                        return as.withAssignment(((J.NewArray) as.getAssignment()).withInitializer(values));
+                                    }
+                                }
+
+
+                            } else if (as.getAssignment() instanceof J.FieldAccess) {
+                                J.FieldAccess value = (J.FieldAccess) as.getAssignment();
+                                if (value.getTarget() instanceof J.Identifier && ((J.Identifier) value.getTarget()).getSimpleName().equals(SOLR_AUTOCONFIGURATION)) {
+                                    maybeRemoveImport(SOLR_AUTOCONFIGURATION_FQ);
+                                    changedAnnotation.set(true);
+                                    return null;
+                                }
+                            }
+                        }
+                    }
+                    return it;
+                });
+                if (changedAnnotation.get()) {
+                    return a.withArguments(newArgs);
+                }
+                return super.visitAnnotation(a, ctx);
+            }
+        });
+    }
+}

--- a/src/testWithSpringBoot_2_7/java/org/openrewrite/java/spring/boot2/RemoveSolrAutoConfigurationExcludeTest.java
+++ b/src/testWithSpringBoot_2_7/java/org/openrewrite/java/spring/boot2/RemoveSolrAutoConfigurationExcludeTest.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.spring.boot2;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.java.spring.boot3.RemoveSolrAutoConfigurationExclude;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+class RemoveSolrAutoConfigurationExcludeTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(new RemoveSolrAutoConfigurationExclude())
+          .parser(JavaParser.fromJavaVersion().classpath("spring-boot"));
+    }
+
+    @Test
+    @DocumentExample
+        // Padding doesn't stay (array initializer loses empty space at the end) intact so test fails
+    void removeSolrAutoConfigurationExcludeList() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import org.springframework.boot.autoconfigure.SpringBootApplication;
+              import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+              import org.springframework.boot.autoconfigure.solr.SolrAutoConfiguration;
+
+              @SpringBootApplication(exclude = { SecurityAutoConfiguration.class, SolrAutoConfiguration.class })
+              public class Application {
+              }
+              """,
+            """
+              import org.springframework.boot.autoconfigure.SpringBootApplication;
+              import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+
+              @SpringBootApplication(exclude = { SecurityAutoConfiguration.class })
+              public class Application {
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void removeSolrAutoConfigurationExcludeListSingleElement() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import org.springframework.boot.autoconfigure.SpringBootApplication;
+              import org.springframework.boot.autoconfigure.solr.SolrAutoConfiguration;
+
+              @SpringBootApplication(exclude = { SolrAutoConfiguration.class })
+              public class Application {
+              }
+              """,
+            """
+              import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+              @SpringBootApplication
+              public class Application {
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void removeSolrAutoConfigurationExclude() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import org.springframework.boot.autoconfigure.SpringBootApplication;
+              import org.springframework.boot.autoconfigure.solr.SolrAutoConfiguration;
+
+              @SpringBootApplication(exclude = SolrAutoConfiguration.class)
+              public class Application {
+              }
+              """,
+            """
+              import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+              @SpringBootApplication
+              public class Application {
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void shouldRemain() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import org.springframework.boot.autoconfigure.SpringBootApplication;
+              import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+
+              @SpringBootApplication(exclude = SecurityAutoConfiguration.class)
+              public class Application {
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void shouldRemainList() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import org.springframework.boot.autoconfigure.SpringBootApplication;
+              import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+
+              @SpringBootApplication(exclude = { SecurityAutoConfiguration.class })
+              public class Application {
+              }
+              """
+          )
+        );
+    }
+
+}


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->
Added recipe to specifically remove the `SolrAutoConfiguration` from a `@SpringBootApplication` exclusions element

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->
@timtebeek 

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
