### PR TITLE
rearranging springdoc/openapi recipes. individual springdoc upgrades …

### DIFF
--- a/src/main/resources/META-INF/rewrite/spring-boot-22.yml
+++ b/src/main/resources/META-INF/rewrite/spring-boot-22.yml
@@ -53,6 +53,10 @@ recipeList:
   - org.openrewrite.gradle.UpdateGradleWrapper:
       version: ^4.10
       addIfMissing: false
+  - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
+      groupId: org.springdoc
+      artifactId: "*"
+      newVersion: 1.3.x
 
   # Use recommended replacements for deprecated APIs
   - org.openrewrite.java.spring.boot2.MigrateApplicationHealthIndicatorToPingHealthIndicator

--- a/src/main/resources/META-INF/rewrite/spring-boot-23.yml
+++ b/src/main/resources/META-INF/rewrite/spring-boot-23.yml
@@ -57,6 +57,10 @@ recipeList:
       version: 2.3.x
       onlyIfUsing: javax.validation.constraints.*
       acceptTransitive: true
+  - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
+      groupId: org.springdoc
+      artifactId: "*"
+      newVersion: 1.4.x
 
   # Use recommended replacements for deprecated APIs
   - org.openrewrite.java.spring.boot2.MigrateRestClientBuilderCustomizerPackageName

--- a/src/main/resources/META-INF/rewrite/spring-boot-26.yml
+++ b/src/main/resources/META-INF/rewrite/spring-boot-26.yml
@@ -46,6 +46,11 @@ recipeList:
   - org.openrewrite.gradle.plugins.UpgradePluginVersion:
       pluginIdPattern: org.springframework.boot
       newVersion: 2.6.x
+  - org.openrewrite.java.springdoc.SpringFoxToSpringDoc
+  - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
+      groupId: org.springdoc
+      artifactId: "*"
+      newVersion: 1.5.x
 
   # Update properties
   - org.openrewrite.java.spring.boot2.SpringBootProperties_2_6

--- a/src/main/resources/META-INF/rewrite/spring-boot-27.yml
+++ b/src/main/resources/META-INF/rewrite/spring-boot-27.yml
@@ -45,6 +45,10 @@ recipeList:
       newVersion: 5.3.x
   - org.openrewrite.java.spring.data.UpgradeSpringData_2_7
   - org.openrewrite.java.spring.security5.UpgradeSpringSecurity_5_7
+  - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
+      groupId: org.springdoc
+      artifactId: "*"
+      newVersion: 1.8.x
   # Use recommended replacements for deprecated APIs
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: org.springframework.boot.web.server.LocalServerPort

--- a/src/main/resources/META-INF/rewrite/spring-boot-30.yml
+++ b/src/main/resources/META-INF/rewrite/spring-boot-30.yml
@@ -74,7 +74,7 @@ recipeList:
   - org.openrewrite.java.spring.framework.UpgradeSpringFramework_6_0
   - org.openrewrite.java.spring.security6.UpgradeSpringSecurity_6_0
   - org.openrewrite.java.spring.cloud2022.UpgradeSpringCloud_2022
-  - org.openrewrite.java.springdoc.SwaggerToSpringDoc
+  - org.openrewrite.java.springdoc.UpgradeSpringDoc_2
   - org.openrewrite.hibernate.MigrateToHibernate61
 ---
 type: specs.openrewrite.org/v1beta/recipe

--- a/src/main/resources/META-INF/rewrite/spring-boot-31.yml
+++ b/src/main/resources/META-INF/rewrite/spring-boot-31.yml
@@ -46,5 +46,9 @@ recipeList:
       newVersion: 3.1.x
   - org.openrewrite.java.spring.security6.UpgradeSpringSecurity_6_1
   - org.openrewrite.java.spring.boot3.SpringBootProperties_3_1
+  - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
+      groupId: org.springdoc
+      artifactId: "*"
+      newVersion: 2.2.x
   - org.openrewrite.hibernate.MigrateToHibernate62
   - org.openrewrite.reactive.reactor.UpgradeReactor_3_5

--- a/src/main/resources/META-INF/rewrite/spring-boot-32.yml
+++ b/src/main/resources/META-INF/rewrite/spring-boot-32.yml
@@ -66,6 +66,10 @@ recipeList:
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: org.springframework.boot.autoconfigure.transaction.PlatformTransactionManagerCustomizer
       newFullyQualifiedTypeName: org.springframework.boot.autoconfigure.transaction.TransactionManagerCustomizer
+  - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
+      groupId: org.springdoc
+      artifactId: "*"
+      newVersion: 2.5.x
   - org.openrewrite.hibernate.MigrateToHibernate63
   - org.openrewrite.java.spring.boot3.RelocateLauncherClasses
 

--- a/src/main/resources/META-INF/rewrite/spring-boot-33.yml
+++ b/src/main/resources/META-INF/rewrite/spring-boot-33.yml
@@ -49,15 +49,17 @@ recipeList:
       pluginIdPattern: org.springframework.boot
       newVersion: 3.3.x
   - org.openrewrite.micrometer.UpgradeMicrometer_1_13
-
   - org.openrewrite.gradle.plugins.UpgradePluginVersion:
       pluginIdPattern: org.graalvm.buildtools.native
       newVersion: 0.10.x
-
   - org.openrewrite.java.dependencies.ChangeDependency:
       oldGroupId: com.datastax.oss
       newGroupId: org.apache.cassandra
       oldArtifactId: "*"
+  - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
+      groupId: org.springdoc
+      artifactId: "*"
+      newVersion: 2.6.x
 
 ---
 type: specs.openrewrite.org/v1beta/recipe

--- a/src/main/resources/META-INF/rewrite/springdoc.yml
+++ b/src/main/resources/META-INF/rewrite/springdoc.yml
@@ -14,6 +14,21 @@
 # limitations under the License.
 #
 
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.springdoc.SpringFoxToSpringDoc
+displayName: Migrate from SpringFox Swagger to SpringDoc and OpenAPI
+description: Migrate from SpringFox Swagger to SpringDoc and OpenAPI.
+tags:
+  - swagger
+  - openapi
+  - springfox
+  - springdoc
+recipeList:
+  - org.openrewrite.java.springdoc.SwaggerToSpringDoc
+  - org.openrewrite.java.springdoc.ReplaceSpringFoxDependencies
+
+---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.springdoc.SwaggerToSpringDoc
 displayName: Migrate from Swagger to SpringDoc and OpenAPI
@@ -24,16 +39,36 @@ tags:
   - openapi
 recipeList:
   - org.openrewrite.openapi.swagger.SwaggerToOpenAPI
-  - org.openrewrite.java.springdoc.UpgradeSpringDoc_2
   - org.openrewrite.java.spring.DeleteSpringProperty:
       propertyKey: swagger.title
   - org.openrewrite.java.spring.DeleteSpringProperty:
       propertyKey: swagger.description
   - org.openrewrite.java.spring.DeleteSpringProperty:
       propertyKey: swagger.contact
-  - org.openrewrite.maven.RemoveDependency:
+  - org.openrewrite.java.dependencies.RemoveDependency:
       groupId: io.swagger.core.v3
       artifactId: swagger-annotations
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.springdoc.ReplaceSpringFoxDependencies
+displayName: Replace SpringFox Dependencies
+description: Replace SpringFox Dependencies.
+tags:
+  - springfox
+  - springdoc
+preconditions:
+  - org.openrewrite.java.dependencies.DependencyInsight:
+      groupIdPattern: io.springfox
+      artifactIdPattern: "*"
+recipeList:
+  - org.openrewrite.java.dependencies.RemoveDependency:
+      groupId: io.springfox
+      artifactId: "*"
+  - org.openrewrite.java.dependencies.AddDependency:
+      groupId: org.springdoc
+      artifactId: springdoc-openapi-starter-webmvc-ui
+      version: 1.5.x # aligns with spring boot 2.6
 
 ---
 type: specs.openrewrite.org/v1beta/recipe
@@ -43,11 +78,8 @@ description: Upgrade to SpringDoc v2.
 tags:
   - springdoc
 recipeList:
+  - org.openrewrite.openapi.swagger.UseJakartaSwaggerArtifacts
   # https://springdoc.org/#migrating-from-springdoc-v1
-  - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
-      groupId: org.springdoc
-      artifactId: "*"
-      newVersion: 2.3.x
   # "classes/annotations changes"
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: org.springdoc.core.SpringDocUtils
@@ -72,43 +104,59 @@ recipeList:
       oldGroupId: org.springdoc
       oldArtifactId: springdoc-openapi-common
       newArtifactId: springdoc-openapi-starter-common
+      newVersion: 2.1.x
   - org.openrewrite.java.dependencies.ChangeDependency:
       oldGroupId: org.springdoc
       oldArtifactId: springdoc-openapi-data-rest
       newArtifactId: springdoc-openapi-starter-common
+      newVersion: 2.1.x
   - org.openrewrite.java.dependencies.ChangeDependency:
       oldGroupId: org.springdoc
       oldArtifactId: springdoc-openapi-groovy
       newArtifactId: springdoc-openapi-starter-common
+      newVersion: 2.1.x
   - org.openrewrite.java.dependencies.ChangeDependency:
       oldGroupId: org.springdoc
       oldArtifactId: springdoc-openapi-hateoas
       newArtifactId: springdoc-openapi-starter-common
+      newVersion: 2.1.x
   - org.openrewrite.java.dependencies.ChangeDependency:
       oldGroupId: org.springdoc
       oldArtifactId: springdoc-openapi-javadoc
       newArtifactId: springdoc-openapi-starter-common
+      newVersion: 2.1.x
   - org.openrewrite.java.dependencies.ChangeDependency:
       oldGroupId: org.springdoc
       oldArtifactId: springdoc-openapi-kotlin
       newArtifactId: springdoc-openapi-starter-common
+      newVersion: 2.1.x
   - org.openrewrite.java.dependencies.ChangeDependency:
       oldGroupId: org.springdoc
       oldArtifactId: springdoc-openapi-security
       newArtifactId: springdoc-openapi-starter-common
+      newVersion: 2.1.x
   - org.openrewrite.java.dependencies.ChangeDependency:
       oldGroupId: org.springdoc
       oldArtifactId: springdoc-openapi-webmvc-core
       newArtifactId: springdoc-openapi-starter-webmvc-api
+      newVersion: 2.1.x
   - org.openrewrite.java.dependencies.ChangeDependency:
       oldGroupId: org.springdoc
       oldArtifactId: springdoc-openapi-webflux-core
       newArtifactId: springdoc-openapi-starter-webflux-api
+      newVersion: 2.1.x
   - org.openrewrite.java.dependencies.ChangeDependency:
       oldGroupId: org.springdoc
       oldArtifactId: springdoc-openapi-ui
       newArtifactId: springdoc-openapi-starter-webmvc-ui
+      newVersion: 2.1.x
   - org.openrewrite.java.dependencies.ChangeDependency:
       oldGroupId: org.springdoc
       oldArtifactId: springdoc-openapi-webflux-ui
       newArtifactId: springdoc-openapi-starter-webflux-ui
+      newVersion: 2.1.x
+  # upgrade all remaining non-renamed modules
+  - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
+      groupId: org.springdoc
+      artifactId: "*"
+      newVersion: 2.1.x

--- a/src/test/java/org/openrewrite/java/springdoc/UpgradeSpringDoc2Test.java
+++ b/src/test/java/org/openrewrite/java/springdoc/UpgradeSpringDoc2Test.java
@@ -24,10 +24,10 @@ import java.util.regex.Pattern;
 
 import static org.openrewrite.maven.Assertions.pomXml;
 
-class SwaggerToSpringDocTest implements RewriteTest {
+class UpgradeSpringDoc2Test implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
-        spec.recipeFromResources("org.openrewrite.java.springdoc.SwaggerToSpringDoc");
+        spec.recipeFromResources("org.openrewrite.java.springdoc.UpgradeSpringDoc_2");
     }
 
     @Test
@@ -48,11 +48,16 @@ class SwaggerToSpringDocTest implements RewriteTest {
                           <artifactId>springdoc-openapi</artifactId>
                           <version>1.5.13</version>
                       </dependency>
+                      <dependency>
+                          <groupId>org.springdoc</groupId>
+                          <artifactId>springdoc-openapi-common</artifactId>
+                          <version>1.5.13</version>
+                      </dependency>
                   </dependencies>
               </project>
               """,
             after -> after.after(actual -> {
-                String version = Pattern.compile("<version>(2\\.3\\..*)</version>")
+                String version = Pattern.compile("<version>(2\\.1\\..*)</version>")
                   .matcher(actual)
                   .results()
                   .map(m -> m.group(1))
@@ -68,7 +73,12 @@ class SwaggerToSpringDocTest implements RewriteTest {
                           <dependency>
                               <groupId>org.springdoc</groupId>
                               <artifactId>springdoc-openapi</artifactId>
-                              <version>%s</version>
+                              <version>%1$s</version>
+                          </dependency>
+                          <dependency>
+                              <groupId>org.springdoc</groupId>
+                              <artifactId>springdoc-openapi-starter-common</artifactId>
+                              <version>%1$s</version>
                           </dependency>
                       </dependencies>
                   </project>


### PR DESCRIPTION
…now occur with relevant spring boot upgrades. SB 2.6 now includes migration from springfox (which was popular for a while and then abandoned in ~2020) to springdoc. this bumps the swagger 2 -> openapi 3 migration to be a little sooner. the springdoc 2 upgrade with SB 3 now better-handles versions for renamed modules, and includes a swap to jakarta swagger artifacts (if apps are referencing those directly)

<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->
springfox stops working for the most part on spring boot 2.6:
https://stackoverflow.com/questions/70178343/springfox-3-0-0-is-not-working-with-spring-boot-2-6-0
meanwhile springdoc is the de facto replacement.
even a partial migration from springfox to springdoc at 2.6 is probably helpful and leaves you no-worse-off.

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->
a future iteration could try to be more clever about whether to add the SpringDoc `webflux` starter instead of the `webmvc` starter; I started on it then set it aside when I realized I would want a precondition which looks for the *non-presence* of `spring-webmvc`, which I didn't see an obvious way to do.

a future iteration could also tackle the final code changes in the "migrating from springfox" guide: https://springdoc.org/#migrating-from-springfox

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [X] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [X] I've used the IntelliJ IDEA auto-formatter on affected files
