### PR TITLE
Add recipe to migrate `ResponseStatusException` changes

### DIFF
--- a/src/main/java/org/openrewrite/java/spring/framework/MigrateResponseStatusExceptionGetRawStatusCodeMethod.java
+++ b/src/main/java/org/openrewrite/java/spring/framework/MigrateResponseStatusExceptionGetRawStatusCodeMethod.java
@@ -42,7 +42,6 @@ public class MigrateResponseStatusExceptionGetRawStatusCodeMethod extends Recipe
                     MethodCall tree = mc.getTree();
                     if (tree instanceof J.MethodInvocation) {
                         return JavaTemplate.builder("#{any()}.getStatusCode().value()")
-                                .contextSensitive()
                                 .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "spring-core-6", "spring-beans-6", "spring-web-6"))
                                 .build().apply(mc.getCursor(), tree.getCoordinates().replace(), ((J.MethodInvocation) tree).getSelect());
                     }

--- a/src/main/java/org/openrewrite/java/spring/framework/MigrateResponseStatusExceptionGetRawStatusCodeMethod.java
+++ b/src/main/java/org/openrewrite/java/spring/framework/MigrateResponseStatusExceptionGetRawStatusCodeMethod.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openrewrite.java.spring.framework;
 
 import org.openrewrite.ExecutionContext;

--- a/src/main/java/org/openrewrite/java/spring/framework/MigrateResponseStatusExceptionGetRawStatusCodeMethod.java
+++ b/src/main/java/org/openrewrite/java/spring/framework/MigrateResponseStatusExceptionGetRawStatusCodeMethod.java
@@ -1,0 +1,37 @@
+package org.openrewrite.java.spring.framework;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.java.JavaTemplate;
+import org.openrewrite.java.trait.Traits;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.MethodCall;
+
+public class MigrateResponseStatusExceptionGetRawStatusCodeMethod extends Recipe {
+    @Override
+    public String getDisplayName() {
+        return "Migrate `ResponseStatusException#getRawStatusCode()` to `getStatusCode().value()`";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Migrate Spring Framework 5.3's `ResponseStatusException` method `getRawStatusCode()` to Spring Framework 6's `getStatusCode().value()`.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return Traits.methodAccess("org.springframework.web.server.ResponseStatusException getRawStatusCode()")
+                .asVisitor((mc, ctx) -> {
+                    MethodCall tree = mc.getTree();
+                    if (tree instanceof J.MethodInvocation) {
+                        return JavaTemplate.builder("#{any()}.getStatusCode().value()")
+                                .contextSensitive()
+                                .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "spring-core-6", "spring-beans-6", "spring-web-6"))
+                                .build().apply(mc.getCursor(), tree.getCoordinates().replace(), ((J.MethodInvocation) tree).getSelect());
+                    }
+                    return tree;
+                });
+    }
+}

--- a/src/main/resources/META-INF/rewrite/spring-framework-60.yml
+++ b/src/main/resources/META-INF/rewrite/spring-framework-60.yml
@@ -31,7 +31,16 @@ recipeList:
   - org.openrewrite.apache.httpclient5.UpgradeApacheHttpClient_5
   - org.openrewrite.java.spring.framework.HttpComponentsClientHttpRequestFactoryReadTimeout
   - org.openrewrite.java.spring.framework.MigrateResponseEntityExceptionHandlerHttpStatusToHttpStatusCode
-
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.spring.framework.MigrateResponseStatusException
+displayName: Migrate breaking changes in `ResponseStatusException`
+description: Migrate Spring Framework 5.3's `ResponseStatusException` method `getRawStatusCode()` to Spring Framework 6's `getStatusCode().value()` and `ResponseStatusException` method `getStatus()` to Spring Framework 6's `getStatusCode()` .
+recipeList:
+  - org.openrewrite.java.spring.framework.MigrateResponseStatusExceptionGetRawStatusCodeMethod
+  - org.openrewrite.java.ChangeMethodName:
+        methodPattern: "org.springframework.web.server.ResponseStatusException getStatus()"
+        newMethodName: "getStatusCode"
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.spring.framework.MigrateSpringAssert

--- a/src/main/resources/META-INF/rewrite/spring-framework-60.yml
+++ b/src/main/resources/META-INF/rewrite/spring-framework-60.yml
@@ -31,6 +31,7 @@ recipeList:
   - org.openrewrite.apache.httpclient5.UpgradeApacheHttpClient_5
   - org.openrewrite.java.spring.framework.HttpComponentsClientHttpRequestFactoryReadTimeout
   - org.openrewrite.java.spring.framework.MigrateResponseEntityExceptionHandlerHttpStatusToHttpStatusCode
+  - org.openrewrite.java.spring.framework.MigrateResponseStatusException
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.spring.framework.MigrateResponseStatusException

--- a/src/test/java/org/openrewrite/java/spring/framework/MigrateResponseStatusExceptionTest.java
+++ b/src/test/java/org/openrewrite/java/spring/framework/MigrateResponseStatusExceptionTest.java
@@ -1,0 +1,77 @@
+package org.openrewrite.java.spring.framework;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.InMemoryExecutionContext;
+import org.openrewrite.Issue;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+class MigrateResponseStatusExceptionTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipeFromResources("org.openrewrite.java.spring.framework.MigrateResponseStatusException")
+          .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(),  "spring-core-5.3", "spring-beans-5.3", "spring-web-5.3"));
+    }
+
+    @DocumentExample
+    @Issue("https://github.com/openrewrite/rewrite-spring/issues/554")
+    @Test
+    void migrateResponseStatusExceptionGetStatusMethod() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import org.springframework.http.HttpStatus;
+              import org.springframework.web.server.ResponseStatusException;
+              class A {
+                  void foo(ResponseStatusException e) {
+                      HttpStatus i = e.getStatus();
+                  }
+              }
+              """,
+            """
+              import org.springframework.http.HttpStatus;
+              import org.springframework.web.server.ResponseStatusException;
+              class A {
+                  void foo(ResponseStatusException e) {
+                      HttpStatus i = e.getStatusCode();
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @DocumentExample
+    @Issue("https://github.com/openrewrite/rewrite-spring/issues/554")
+    @Test
+    void migrateResponseStatusExceptionGetRawStatusCodeMethod() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import org.springframework.web.server.ResponseStatusException;
+              class A {
+                  void foo(ResponseStatusException e) {
+                      int i = e.getRawStatusCode();
+                  }
+              }
+              """,
+            """
+              import org.springframework.web.server.ResponseStatusException;
+              class A {
+                  void foo(ResponseStatusException e) {
+                      int i = e.getStatusCode().value();
+                  }
+              }
+              """
+          )
+        );
+    }
+
+}

--- a/src/test/java/org/openrewrite/java/spring/framework/MigrateResponseStatusExceptionTest.java
+++ b/src/test/java/org/openrewrite/java/spring/framework/MigrateResponseStatusExceptionTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openrewrite.java.spring.framework;
 
 import org.junit.jupiter.api.Test;

--- a/src/test/java/org/openrewrite/java/spring/framework/MigrateResponseStatusExceptionTest.java
+++ b/src/test/java/org/openrewrite/java/spring/framework/MigrateResponseStatusExceptionTest.java
@@ -30,7 +30,7 @@ class MigrateResponseStatusExceptionTest implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
         spec.recipeFromResources("org.openrewrite.java.spring.framework.MigrateResponseStatusException")
-          .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(),  "spring-core-5.3", "spring-beans-5.3", "spring-web-5.3"));
+          .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(), "spring-core-5.3", "spring-beans-5.3", "spring-web-5.3"));
     }
 
     @DocumentExample


### PR DESCRIPTION
## What's changed?
Add recipe to migrate breaking changes introduced in Spring Framework 6.0 touching `ResponseStatusException` class. 

## What's your motivation?
- https://github.com/openrewrite/rewrite-spring/issues/554

## Anything in particular you'd like reviewers to focus on?
Was not sure where to put the recipes - I added them to `spring-framework-60.yml` as another group (? - let me know correct naming here)

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
