### PR TITLE
Migrate recipe to convert getStatus to getStatusCode with correct types

### DIFF
--- a/src/main/java/org/openrewrite/java/spring/framework/MigrateResponseStatusExceptionGetStatusCodeMethod.java
+++ b/src/main/java/org/openrewrite/java/spring/framework/MigrateResponseStatusExceptionGetStatusCodeMethod.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.spring.framework;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.java.JavaTemplate;
+import org.openrewrite.java.MethodMatcher;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaType;
+import org.openrewrite.java.tree.TypeTree;
+import org.openrewrite.java.tree.TypeUtils;
+
+import static java.util.stream.Collectors.toList;
+
+public class MigrateResponseStatusExceptionGetStatusCodeMethod extends Recipe {
+    private static final MethodMatcher GET_STATUS_METHOD_MATCHER = new MethodMatcher(
+            "org.springframework.web.server.ResponseStatusException getStatus()"
+    );
+    private static final String HTTP_STATUS_CODE_CLASS = "HttpStatusCode";
+    private static final String FULL_HTTP_STATUS_CLASS = "org.springframework.http.HttpStatus";
+    private static final String FULL_HTTP_STATUS_CODE_CLASS = "org.springframework.http.HttpStatusCode";
+
+    @Override
+    public String getDisplayName() {
+        return "Migrate `ResponseStatusException#getStatus()` to `getStatusCode()`";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Migrate Spring Framework 5.3's `ResponseStatusException` method `getStatus()` to Spring Framework 6's `getStatusCode()`.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new JavaIsoVisitor<ExecutionContext>() {
+            @Override
+            public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
+                if (GET_STATUS_METHOD_MATCHER.matches(method)) {
+                    return JavaTemplate.builder("#{any()}.getStatusCode()")
+                            .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "spring-core-6", "spring-beans-6", "spring-web-6"))
+                            .build()
+                            .apply(getCursor(), method.getCoordinates().replace(), method.getSelect());
+                }
+                return super.visitMethodInvocation(method, ctx);
+            }
+
+            @Override
+            public J.VariableDeclarations visitVariableDeclarations(J.VariableDeclarations multiVariable, ExecutionContext ctx) {
+                if (multiVariable.getTypeExpression() != null && TypeUtils.isOfClassType(multiVariable.getTypeExpression().getType(), FULL_HTTP_STATUS_CLASS)) {
+                    multiVariable = changeTypeToHttpStatusCode(multiVariable);
+                    maybeAddImport(FULL_HTTP_STATUS_CODE_CLASS);
+                    maybeRemoveImport(FULL_HTTP_STATUS_CLASS);
+                }
+                return super.visitVariableDeclarations(multiVariable, ctx);
+            }
+        };
+    }
+
+    private static J.VariableDeclarations changeTypeToHttpStatusCode(J.VariableDeclarations variableDeclarations) {
+        final JavaType.ShallowClass httpStatusCodeJavaType = JavaType.ShallowClass.build(FULL_HTTP_STATUS_CODE_CLASS);
+        return variableDeclarations
+                .withTypeExpression(
+                        TypeTree.build(HTTP_STATUS_CODE_CLASS).withType(httpStatusCodeJavaType)
+                ).withVariables(
+                        variableDeclarations.getVariables().stream()
+                                .map(variable -> {
+                                    if (variable.getVariableType() != null && TypeUtils.isAssignableTo(FULL_HTTP_STATUS_CLASS, variable.getType())) {
+                                        return variable
+                                                .withVariableType(variable.getVariableType().withType(httpStatusCodeJavaType))
+                                                .withName(variable.getName().withType(httpStatusCodeJavaType).withFieldType(variable.getName().getFieldType().withType(httpStatusCodeJavaType)));
+                                    }
+                                    return variable;
+                                })
+                                .collect(toList())
+                );
+    }
+}

--- a/src/main/resources/META-INF/rewrite/spring-framework-60.yml
+++ b/src/main/resources/META-INF/rewrite/spring-framework-60.yml
@@ -39,9 +39,7 @@ displayName: Migrate breaking changes in `ResponseStatusException`
 description: Migrate Spring Framework 5.3's `ResponseStatusException` method `getRawStatusCode()` to Spring Framework 6's `getStatusCode().value()` and `ResponseStatusException` method `getStatus()` to Spring Framework 6's `getStatusCode()` .
 recipeList:
   - org.openrewrite.java.spring.framework.MigrateResponseStatusExceptionGetRawStatusCodeMethod
-  - org.openrewrite.java.ChangeMethodName:
-        methodPattern: "org.springframework.web.server.ResponseStatusException getStatus()"
-        newMethodName: "getStatusCode"
+  - org.openrewrite.java.spring.framework.MigrateResponseStatusExceptionGetStatusCodeMethod
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.spring.framework.MigrateSpringAssert

--- a/src/test/java/org/openrewrite/java/spring/framework/MigrateResponseStatusExceptionTest.java
+++ b/src/test/java/org/openrewrite/java/spring/framework/MigrateResponseStatusExceptionTest.java
@@ -43,6 +43,7 @@ class MigrateResponseStatusExceptionTest implements RewriteTest {
             """
               import org.springframework.http.HttpStatus;
               import org.springframework.web.server.ResponseStatusException;
+              
               class A {
                   void foo(ResponseStatusException e) {
                       HttpStatus i = e.getStatus();
@@ -50,11 +51,12 @@ class MigrateResponseStatusExceptionTest implements RewriteTest {
               }
               """,
             """
-              import org.springframework.http.HttpStatus;
+              import org.springframework.http.HttpStatusCode;
               import org.springframework.web.server.ResponseStatusException;
+              
               class A {
                   void foo(ResponseStatusException e) {
-                      HttpStatus i = e.getStatusCode();
+                      HttpStatusCode i = e.getStatusCode();
                   }
               }
               """


### PR DESCRIPTION
## What's changed?
Address migration of `getStatus` to `getStatusCode` with respecting type change from `HttpStatus` to `HttpStatusCode`. 

## What's your motivation?
- https://github.com/openrewrite/rewrite-spring/issues/554

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
