### PR TITLE
Include upgrading `jakarta.annotation-api` to 2.1.x

### DIFF
--- a/src/main/resources/META-INF/rewrite/spring-boot-30.yml
+++ b/src/main/resources/META-INF/rewrite/spring-boot-30.yml
@@ -29,6 +29,7 @@ recipeList:
   - org.openrewrite.java.spring.boot2.UpgradeSpringBoot_2_7
   - org.openrewrite.java.spring.boot3.RemoveEnableBatchProcessing
   - org.openrewrite.java.migrate.UpgradeToJava17
+  - org.openrewrite.java.migrate.jakarta.UpdateJakartaAnnotations2
   - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
       groupId: org.springframework.boot
       artifactId: "*"


### PR DESCRIPTION
Applies `jakarta.annotation-api` update recipe added here:
* https://github.com/openrewrite/rewrite-migrate-java/pull/579

## Anyone you would like to review specifically?
<!-- @mention them here -->
@timtebeek 

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->
Spring Boot 3 uses 2.1: https://github.com/spring-projects/spring-boot/blob/3.0.x/spring-boot-project/spring-boot-dependencies/build.gradle#L462-L468
Whereas Springboot 2.7 uses 1.3.5: https://github.com/spring-projects/spring-boot/blob/2.7.x/spring-boot-project/spring-boot-dependencies/build.gradle#L614-L624

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
