### PR TITLE
Replace conversion to `ObjectUtils.isEmpty` with `!StringUtils.hasLength`

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -145,6 +145,7 @@ dependencies {
         exclude("com.google.auto.service", "auto-service-annotations")
     }
     implementation("org.mongodb:mongo-java-driver:3.12.+")
+    implementation("org.springframework:spring-core:5.3.+")
     implementation("org.springframework.data:spring-data-mongodb:2.2.+"){
         because("We only require the classes (for refaster style recipes), not the dependencies")
         exclude(group = "org.springframework")

--- a/src/main/java/org/openrewrite/java/spring/StringOptimization.java
+++ b/src/main/java/org/openrewrite/java/spring/StringOptimization.java
@@ -1,0 +1,27 @@
+package org.openrewrite.java.spring;
+
+import com.google.errorprone.refaster.annotation.AfterTemplate;
+import com.google.errorprone.refaster.annotation.BeforeTemplate;
+import org.openrewrite.java.template.RecipeDescriptor;
+import org.springframework.util.StringUtils;
+
+@SuppressWarnings("ALL")
+public class StringOptimization {
+
+    @RecipeDescriptor(
+            name = "Use `!StringUtils.hasLength`",
+            description = "Replace usage of deprecated `StringUtils.isEmpty` with `!StringUtils.hasLength` https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/util/StringUtils.html#isEmpty(java.lang.Object).")
+    static class ReplaceDeprecatedStringUtilsIsEmpty {
+
+
+        @BeforeTemplate
+        boolean before(String s) {
+            return StringUtils.isEmpty(s);
+        }
+
+        @AfterTemplate
+        boolean after(String s) {
+            return !StringUtils.hasLength(s);
+        }
+    }
+}

--- a/src/main/resources/META-INF/rewrite/spring-framework-53.yml
+++ b/src/main/resources/META-INF/rewrite/spring-framework-53.yml
@@ -32,7 +32,7 @@ recipeList:
       artifactId: "*"
       newVersion: 5.3.x
       overrideManagedVersion: false
-  - org.openrewrite.java.spring.framework.UseObjectUtilsIsEmpty
+  - org.openrewrite.java.spring.StringOptimizationRecipes.ReplaceDeprecatedStringUtilsIsEmptyRecipe
   - org.openrewrite.java.spring.framework.MigrateHandlerInterceptor
   - org.openrewrite.java.spring.framework.MigrateInstantiationAwareBeanPostProcessorAdapter
   - org.openrewrite.java.spring.framework.JdbcTemplateObjectArrayArgToVarArgs
@@ -51,11 +51,4 @@ recipeList:
       groupId: cglib
       artifactId: cglib
 ---
-type: specs.openrewrite.org/v1beta/recipe
-name: org.openrewrite.java.spring.framework.UseObjectUtilsIsEmpty
-displayName: Use `ObjectUtils#isEmpty(Object)`
-description: '`StringUtils#isEmpty(Object)` was deprecated in 5.3.'
-recipeList:
-  - org.openrewrite.java.ChangeMethodTargetToStatic:
-      methodPattern: org.springframework.util.StringUtils isEmpty(Object)
-      fullyQualifiedTargetTypeName: org.springframework.util.ObjectUtils
+

--- a/src/test/java/org/openrewrite/java/spring/ReplaceDeprecatedStringUtilsIsEmptyTest.java
+++ b/src/test/java/org/openrewrite/java/spring/ReplaceDeprecatedStringUtilsIsEmptyTest.java
@@ -1,0 +1,45 @@
+package org.openrewrite.java.spring;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.InMemoryExecutionContext;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+class ReplaceDeprecatedStringUtilsIsEmptyTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec){
+        spec.recipe(new StringOptimizationRecipes()).parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(),"spring-core-5.+"));
+    }
+
+    @DocumentExample
+    @Test
+    @SuppressWarnings("deprecation")
+    void replaceStringUtilsIsEmpty() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import org.springframework.util.StringUtils;
+              class Test {
+                    void test(String s) {
+                      return StringUtils.isEmpty(s);
+                    }
+              }
+              """,
+            """
+              import org.springframework.util.StringUtils;
+              class Test {
+                    void test(String s) {
+                      return !StringUtils.hasLength(s);
+                    }
+              }
+              """
+          )
+        );
+    }
+}


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->
`StringUtils.isEmpty()` is deprecated currently openrewrite replaces it with `ObjectUtils.isEmpty()` which is stricter
and led to this issue:
- https://github.com/openrewrite/rewrite-spring/issues/475

According to the official suggestions: https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/util/StringUtils.html#isEmpty(java.lang.Object)

I replaced it with `!StringUtils.hasLength`
## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->
- Fixes https://github.com/openrewrite/rewrite-spring/issues/475

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->
@Laurens-W 

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
