### PR TITLE
adding a test case for MigrateWebMvcTagsToObservationConvention for t…

### DIFF
--- a/src/main/java/org/openrewrite/java/spring/boot3/MigrateWebMvcTagsToObservationConvention.java
+++ b/src/main/java/org/openrewrite/java/spring/boot3/MigrateWebMvcTagsToObservationConvention.java
@@ -24,7 +24,7 @@ import org.openrewrite.java.JavaParser;
 import org.openrewrite.java.JavaTemplate;
 import org.openrewrite.java.JavaVisitor;
 import org.openrewrite.java.MethodMatcher;
-import org.openrewrite.java.search.UsesType;
+import org.openrewrite.java.search.FindImplementations;
 import org.openrewrite.java.tree.*;
 
 import java.util.ArrayList;
@@ -68,7 +68,7 @@ public class MigrateWebMvcTagsToObservationConvention extends Recipe {
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
-        return Preconditions.check(new UsesType<>(WEBMVCTAGSPROVIDER_FQ, true), new JavaVisitor<ExecutionContext>() {
+        return Preconditions.check(new FindImplementations(WEBMVCTAGSPROVIDER_FQ), new JavaVisitor<ExecutionContext>() {
             @Override
             public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration classDecl, ExecutionContext ctx) {
                 J.MethodDeclaration getTagsMethod = null;

--- a/src/main/java/org/openrewrite/java/spring/boot3/MigrateWebMvcTagsToObservationConvention.java
+++ b/src/main/java/org/openrewrite/java/spring/boot3/MigrateWebMvcTagsToObservationConvention.java
@@ -251,7 +251,7 @@ public class MigrateWebMvcTagsToObservationConvention extends Recipe {
                             }
                             return getMultiKeyValueStatement(ctx, coords, args, returnIdentifier);
                         } else if (TAGS_AND_TAG_ITERABLE.matches(init) || TAGS_OF_TAG_ITERABLE.matches(init)) {
-                            J.Identifier iterable = (J.Identifier) init.getArguments().get(0);
+                            Expression iterable = init.getArguments().get(0);
                             String template = "for (Tag tag : #{any()}) {\n" +
                                               "    #{any()}.and(KeyValue.of(tag.getKey(), tag.getValue()));\n" +
                                               "}\n";

--- a/src/testWithSpringBoot_3_0/java/org/openrewrite/java/spring/boot3/MigrateWebMvcTagsToObservationConventionTest.java
+++ b/src/testWithSpringBoot_3_0/java/org/openrewrite/java/spring/boot3/MigrateWebMvcTagsToObservationConventionTest.java
@@ -182,7 +182,12 @@ class MigrateWebMvcTagsToObservationConventionTest implements RewriteTest {
                       tags = tags.and("a", "b", "c", "d");
                       tags = Tags.and(Tag.of("a", "b"), staticTag);
                       tags = tags.and(staticTags);
+                      tags = tags.and(methodTags());
                       return tags;
+                  }
+              
+                  private Tags methodTags() {
+                      return staticTags;
                   }
               }
               """,
@@ -219,7 +224,14 @@ class MigrateWebMvcTagsToObservationConventionTest implements RewriteTest {
                       for (Tag tag : staticTags) {
                           values.and(KeyValue.of(tag.getKey(), tag.getValue()));
                       }
+                      for (Tag tag : methodTags()) {
+                          values.and(KeyValue.of(tag.getKey(), tag.getValue()));
+                      }
                       return values;
+                  }
+              
+                  private Tags methodTags() {
+                      return staticTags;
                   }
               }
               """


### PR DESCRIPTION
…he case where the iterable passed to `Tags.and(...)` is *not* an identifier, and partially fixing it, BUT this commit still has a strange test failure with cyclically duplicating http request/response variables

<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->
see subject

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->
currently, the scenario in the test case yields a classcast exception and breaks the recipe process

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->
here's the result of running this test case.

it seems that these lines are getting added again in a second cycle?
```java
        HttpServletRequest request = context.getCarrier();
        HttpServletResponse response = context.getResponse();
```

test result:
```
org.opentest4j.AssertionFailedError: [Expected recipe to complete in 1 cycle, but took at least one more cycle. Between the last two executed cycles there were changes to "CustomWebMvcTagsProvider.java"] 
expected: "import io.micrometer.common.KeyValue;
import io.micrometer.common.KeyValues;
import io.micrometer.core.instrument.Tag;
import io.micrometer.core.instrument.Tags;
import jakarta.servlet.http.HttpServletRequest;
import jakarta.servlet.http.HttpServletResponse;
import org.springframework.http.server.observation.DefaultServerRequestObservationConvention;
import org.springframework.http.server.observation.ServerRequestObservationContext;

class CustomWebMvcTagsProvider extends DefaultServerRequestObservationConvention {

    Tags staticTags = Tags.of("a", "b", "c", "d");
    Tag staticTag = Tag.of("a", "b");

    @Override
    public KeyValues getHighCardinalityKeyValues(ServerRequestObservationContext context) {
        HttpServletRequest request = context.getCarrier();
        HttpServletResponse response = context.getResponse();
        KeyValues values = super.getHighCardinalityKeyValues(context);

        String customHeader = request.getHeader("X-Custom-Header");
        if (customHeader != null) {
            values.and(KeyValue.of("custom.header", customHeader));
        }
        if (response.getStatus() >= 400) {
            values.and(KeyValue.of("error", "true"));
        }
        values.and(KeyValue.of("a", "b"), KeyValue.of("c", "d"));
        values.and(KeyValue.of("a", "b"), KeyValue.of(staticTag.getKey(), staticTag.getValue()));
        for (Tag tag : staticTags) {
            values.and(KeyValue.of(tag.getKey(), tag.getValue()));
        }
        for (Tag tag : methodTags()) {
            values.and(KeyValue.of(tag.getKey(), tag.getValue()));
        }
        return values;
    }

    private Tags methodTags() {
        return staticTags;
    }
}"

 but was:

"import io.micrometer.common.KeyValue;
import io.micrometer.common.KeyValues;
import io.micrometer.core.instrument.Tag;
import io.micrometer.core.instrument.Tags;
import jakarta.servlet.http.HttpServletRequest;
import jakarta.servlet.http.HttpServletResponse;
import org.springframework.http.server.observation.DefaultServerRequestObservationConvention;
import org.springframework.http.server.observation.ServerRequestObservationContext;

class CustomWebMvcTagsProvider extends DefaultServerRequestObservationConvention {

    Tags staticTags = Tags.of("a", "b", "c", "d");
    Tag staticTag = Tag.of("a", "b");

    @Override
    public KeyValues getHighCardinalityKeyValues(ServerRequestObservationContext context) {
        HttpServletRequest request = context.getCarrier();
        HttpServletResponse response = context.getResponse();
        HttpServletRequest request = context.getCarrier();
        HttpServletResponse response = context.getResponse();
        KeyValues values = super.getHighCardinalityKeyValues(context);

        String customHeader = request.getHeader("X-Custom-Header");
        if (customHeader != null) {
            values.and(KeyValue.of("custom.header", customHeader));
        }
        if (response.getStatus() >= 400) {
            values.and(KeyValue.of("error", "true"));
        }
        values.and(KeyValue.of("a", "b"), KeyValue.of("c", "d"));
        values.and(KeyValue.of("a", "b"), KeyValue.of(staticTag.getKey(), staticTag.getValue()));
        for (Tag tag : staticTags) {
            values.and(KeyValue.of(tag.getKey(), tag.getValue()));
        }
        for (Tag tag : methodTags()) {
            values.and(KeyValue.of(tag.getKey(), tag.getValue()));
        }
        return values;
    }

    private Tags methodTags() {
        return staticTags;
    }
}"
```

## Anyone you would like to review specifically?
<!-- @mention them here -->
@Laurens-W 
@timtebeek 

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->
looks like there's some cursor messaging which tries to control against duplicating these lines; not sure why it's breaking. probably simpler for the original developer to look since it was only a week ago :)

### Checklist
- [X] I've added unit tests to cover both positive and negative cases
- [X] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [X] I've used the IntelliJ IDEA auto-formatter on affected files
