### PR TITLE
SAP cloud logging support migration to SB 3.x

### DIFF
--- a/src/main/resources/META-INF/rewrite/spring-boot-30.yml
+++ b/src/main/resources/META-INF/rewrite/spring-boot-30.yml
@@ -159,3 +159,20 @@ recipeList:
       oldArtifactId: metrics-servlets
       newArtifactId: metrics-jakarta-servlets
       newVersion: 4.2.x
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.spring.boot3.MigrateSapCfJavaLoggingSupport
+displayName: Migrate SAP cloud foundry logging support to Spring Boot 3.x
+description: Migrate SAP cloud foundry logging support from cf-java-logging-support-servlet to cf-java-logging-support-servlet-jakarta, to use jakarta with Spring Boot 3.
+tags:
+  - spring
+  - boot
+  - sap
+  - cloudfoundry
+  - logging
+recipeList:
+  - org.openrewrite.java.dependencies.ChangeDependency:
+      oldGroupId: com.sap.hcp.cf.logging
+      oldArtifactId: cf-java-logging-support-servlet
+      newArtifactId: cf-java-logging-support-servlet-jakarta      

--- a/src/main/resources/META-INF/rewrite/spring-boot-30.yml
+++ b/src/main/resources/META-INF/rewrite/spring-boot-30.yml
@@ -165,7 +165,7 @@ recipeList:
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.spring.boot3.MigrateSapCfJavaLoggingSupport
 displayName: Migrate SAP cloud foundry logging support to Spring Boot 3.x
-description: Migrate SAP cloud foundry logging support from cf-java-logging-support-servlet to cf-java-logging-support-servlet-jakarta, to use jakarta with Spring Boot 3.
+description: Migrate SAP cloud foundry logging support from `cf-java-logging-support-servlet` to `cf-java-logging-support-servlet-jakarta`, to use Jakarta with Spring Boot 3.
 tags:
   - spring
   - boot
@@ -176,4 +176,5 @@ recipeList:
   - org.openrewrite.java.dependencies.ChangeDependency:
       oldGroupId: com.sap.hcp.cf.logging
       oldArtifactId: cf-java-logging-support-servlet
-      newArtifactId: cf-java-logging-support-servlet-jakarta      
+      newArtifactId: cf-java-logging-support-servlet-jakarta
+      newVersion: 3.x

--- a/src/main/resources/META-INF/rewrite/spring-boot-30.yml
+++ b/src/main/resources/META-INF/rewrite/spring-boot-30.yml
@@ -177,4 +177,4 @@ recipeList:
       oldGroupId: com.sap.hcp.cf.logging
       oldArtifactId: cf-java-logging-support-servlet
       newArtifactId: cf-java-logging-support-servlet-jakarta
-      newVersion: 3.x
+      newVersion: "[3.7.0,4)"

--- a/src/main/resources/META-INF/rewrite/spring-boot-30.yml
+++ b/src/main/resources/META-INF/rewrite/spring-boot-30.yml
@@ -78,6 +78,7 @@ recipeList:
   - org.openrewrite.java.spring.cloud2022.UpgradeSpringCloud_2022
   - org.openrewrite.java.springdoc.UpgradeSpringDoc_2
   - org.openrewrite.hibernate.MigrateToHibernate61
+
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.spring.boot3.ActuatorEndpointSanitization
@@ -93,7 +94,6 @@ recipeList:
       propertyKey: management.endpoint.env.additional-keys-to-sanitize
 
 ---
-
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.spring.boot3.MigrateMaxHttpHeaderSize
 displayName: Rename `server.max-http-header-size` to `server.max-http-request-header-size`
@@ -133,6 +133,7 @@ recipeList:
       oldGroupId: org.thymeleaf.extras
       oldArtifactId: thymeleaf-extras-springsecurity5
       newArtifactId: thymeleaf-extras-springsecurity6
+
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.spring.boot3.MigrateDropWizardDependencies


### PR DESCRIPTION
this migrates SAP's cloud foundry based java logging support libraries to SB 3.x

## What's changed?
SAP's cloud foundry based logging support on jakarta
See https://github.com/SAP/cf-java-logging-support/

## What's your motivation?
make SB 3.x migrations with SAP and partner code easier

## Anything in particular you'd like reviewers to focus on?
Questions:
- Does org.openrewrite.java.dependencies.ChangeDependency take care of maven AND gradle?
- I ONLY want to change the artifactId, NOT the groupId and the version or anything else - Does that fit?
- I saw no tests in this repo for pom.xml files, so I assume tests are in rewrite-maven/rewrite-gradle?
- Does this step ONLY kick in if the dependency com.sap.hcp.cf.logging:cf-java-logging-support-servlet:<someVersion> is present?
- Is this the right location to put the recipe in?
- The Mr. Monk in me did some formatting - is that OK?

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
