### PR TITLE
Add new migration case of WebMvcConfigurer

### DIFF
--- a/src/main/java/org/openrewrite/java/spring/framework/MigrateWebMvcConfigurerAdapter.java
+++ b/src/main/java/org/openrewrite/java/spring/framework/MigrateWebMvcConfigurerAdapter.java
@@ -27,7 +27,6 @@ import org.openrewrite.java.MethodMatcher;
 import org.openrewrite.java.search.UsesType;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaType;
-import org.openrewrite.java.tree.TypeTree;
 import org.openrewrite.java.tree.TypeUtils;
 
 public class MigrateWebMvcConfigurerAdapter extends Recipe {

--- a/src/main/java/org/openrewrite/java/spring/framework/MigrateWebMvcConfigurerAdapter.java
+++ b/src/main/java/org/openrewrite/java/spring/framework/MigrateWebMvcConfigurerAdapter.java
@@ -42,7 +42,7 @@ public class MigrateWebMvcConfigurerAdapter extends Recipe {
     @Override
     public String getDescription() {
         return "As of 5.0 `WebMvcConfigurer` has default methods (made possible by a Java 8 baseline) and can be " +
-          "implemented directly without the need for this adapter.";
+               "implemented directly without the need for this adapter.";
     }
 
     @Override
@@ -64,11 +64,11 @@ public class MigrateWebMvcConfigurerAdapter extends Recipe {
                         updateCursor(cd);
                     }
                     cd = JavaTemplate.builder("WebMvcConfigurer")
-                      .contextSensitive()
-                      .imports(WEB_MVC_CONFIGURER)
-                      .javaParser(JavaParser.fromJavaVersion()
-                        .classpathFromResources(ctx, "spring-webmvc-5.*"))
-                      .build().apply(getCursor(), cd.getCoordinates().addImplementsClause());
+                            .contextSensitive()
+                            .imports(WEB_MVC_CONFIGURER)
+                            .javaParser(JavaParser.fromJavaVersion()
+                                    .classpathFromResources(ctx, "spring-webmvc-5"))
+                            .build().apply(getCursor(), cd.getCoordinates().addImplementsClause());
                     updateCursor(cd);
                     cd = (J.ClassDeclaration) new RemoveSuperStatementVisitor().visitNonNull(cd, ctx, getCursor().getParentOrThrow());
                     maybeRemoveImport(WEB_MVC_CONFIGURER_ADAPTER);
@@ -83,14 +83,14 @@ public class MigrateWebMvcConfigurerAdapter extends Recipe {
                     if (newClass.getClazz() instanceof J.Identifier) {
                         J.Identifier identifier = (J.Identifier) newClass.getClazz();
                         newClass = newClass.withClazz(identifier
-                          .withType(WEB_MVC_CONFIGURER_TYPE)
-                          .withSimpleName(((JavaType.ShallowClass) WEB_MVC_CONFIGURER_TYPE).getClassName())
+                                .withType(WEB_MVC_CONFIGURER_TYPE)
+                                .withSimpleName(((JavaType.ShallowClass) WEB_MVC_CONFIGURER_TYPE).getClassName())
                         );
                     } else if (newClass.getClazz() instanceof J.ParameterizedType) {
                         J.ParameterizedType parameterizedType = (J.ParameterizedType) newClass.getClazz();
                         newClass = newClass.withClazz(parameterizedType
-                          .withType(WEB_MVC_CONFIGURER_TYPE)
-                          .withClazz(TypeTree.build(WEB_MVC_CONFIGURER).withType(WEB_MVC_CONFIGURER_TYPE))
+                                .withType(WEB_MVC_CONFIGURER_TYPE)
+                                .withClazz(TypeTree.build(WEB_MVC_CONFIGURER).withType(WEB_MVC_CONFIGURER_TYPE))
                         );
                     }
                     maybeRemoveImport(WEB_MVC_CONFIGURER_ADAPTER);
@@ -105,14 +105,14 @@ public class MigrateWebMvcConfigurerAdapter extends Recipe {
                     if (md.getReturnTypeExpression() instanceof J.Identifier) {
                         J.Identifier identifier = (J.Identifier) md.getReturnTypeExpression();
                         md = md.withReturnTypeExpression(identifier
-                          .withType(WEB_MVC_CONFIGURER_TYPE)
-                          .withSimpleName(((JavaType.ShallowClass) WEB_MVC_CONFIGURER_TYPE).getClassName())
+                                .withType(WEB_MVC_CONFIGURER_TYPE)
+                                .withSimpleName(((JavaType.ShallowClass) WEB_MVC_CONFIGURER_TYPE).getClassName())
                         );
                     } else if (md.getReturnTypeExpression() instanceof J.ParameterizedType) {
                         J.ParameterizedType parameterizedType = (J.ParameterizedType) md.getReturnTypeExpression();
                         md = md.withReturnTypeExpression(parameterizedType
-                          .withType(WEB_MVC_CONFIGURER_TYPE)
-                          .withClazz(TypeTree.build(WEB_MVC_CONFIGURER).withType(WEB_MVC_CONFIGURER_TYPE))
+                                .withType(WEB_MVC_CONFIGURER_TYPE)
+                                .withClazz(TypeTree.build(WEB_MVC_CONFIGURER).withType(WEB_MVC_CONFIGURER_TYPE))
                         );
                     }
 

--- a/src/main/java/org/openrewrite/java/spring/framework/MigrateWebMvcConfigurerAdapter.java
+++ b/src/main/java/org/openrewrite/java/spring/framework/MigrateWebMvcConfigurerAdapter.java
@@ -86,12 +86,6 @@ public class MigrateWebMvcConfigurerAdapter extends Recipe {
                                 .withType(WEB_MVC_CONFIGURER_TYPE)
                                 .withSimpleName(((JavaType.ShallowClass) WEB_MVC_CONFIGURER_TYPE).getClassName())
                         );
-                    } else if (newClass.getClazz() instanceof J.ParameterizedType) {
-                        J.ParameterizedType parameterizedType = (J.ParameterizedType) newClass.getClazz();
-                        newClass = newClass.withClazz(parameterizedType
-                                .withType(WEB_MVC_CONFIGURER_TYPE)
-                                .withClazz(TypeTree.build(WEB_MVC_CONFIGURER).withType(WEB_MVC_CONFIGURER_TYPE))
-                        );
                     }
                     maybeRemoveImport(WEB_MVC_CONFIGURER_ADAPTER);
                     maybeAddImport(WEB_MVC_CONFIGURER);
@@ -107,12 +101,6 @@ public class MigrateWebMvcConfigurerAdapter extends Recipe {
                         md = md.withReturnTypeExpression(identifier
                                 .withType(WEB_MVC_CONFIGURER_TYPE)
                                 .withSimpleName(((JavaType.ShallowClass) WEB_MVC_CONFIGURER_TYPE).getClassName())
-                        );
-                    } else if (md.getReturnTypeExpression() instanceof J.ParameterizedType) {
-                        J.ParameterizedType parameterizedType = (J.ParameterizedType) md.getReturnTypeExpression();
-                        md = md.withReturnTypeExpression(parameterizedType
-                                .withType(WEB_MVC_CONFIGURER_TYPE)
-                                .withClazz(TypeTree.build(WEB_MVC_CONFIGURER).withType(WEB_MVC_CONFIGURER_TYPE))
                         );
                     }
 

--- a/src/testWithSpringBoot_2_1/java/org/openrewrite/java/spring/framework/MigrateWebMvcConfigurerAdapterTest.java
+++ b/src/testWithSpringBoot_2_1/java/org/openrewrite/java/spring/framework/MigrateWebMvcConfigurerAdapterTest.java
@@ -29,7 +29,12 @@ class MigrateWebMvcConfigurerAdapterTest implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
         spec.parser(JavaParser.fromJavaVersion()
-            .classpathFromResources(new InMemoryExecutionContext(), "spring-webmvc-5.*", "spring-core-5.*", "spring-web-5.*"))
+            .classpathFromResources(new InMemoryExecutionContext(),
+              "spring-webmvc-5.*",
+              "spring-core-5.*",
+              "spring-web-5.*",
+              "spring-context-5.*"
+            ))
           .recipe(new MigrateWebMvcConfigurerAdapter());
     }
 
@@ -41,9 +46,9 @@ class MigrateWebMvcConfigurerAdapterTest implements RewriteTest {
           java(
                 """
             package a.b.c;
-            
+
             import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter;
-            
+
             public class CustomMvcConfigurer extends WebMvcConfigurerAdapter {
                 private final String someArg;
                 public CustomMvcConfigurer(String someArg) {
@@ -53,9 +58,9 @@ class MigrateWebMvcConfigurerAdapterTest implements RewriteTest {
             }
             """, """
             package a.b.c;
-            
+
             import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
-            
+
             public class CustomMvcConfigurer implements WebMvcConfigurer {
                 private final String someArg;
                 public CustomMvcConfigurer(String someArg) {
@@ -63,6 +68,41 @@ class MigrateWebMvcConfigurerAdapterTest implements RewriteTest {
                 }
             }
             """)
+        );
+    }
+
+    @Test
+    void transformBean() {
+        // language=java
+        rewriteRun(
+          java(
+            """
+              import org.springframework.context.annotation.Bean;
+              import org.springframework.context.annotation.Configuration;
+              import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter;
+
+              @Configuration
+              public class WebConfig {
+                  @Bean
+                  public WebMvcConfigurerAdapter forwardToIndex() {
+                      return new WebMvcConfigurerAdapter() {
+                      };
+                  }
+              }
+              """, """
+              import org.springframework.context.annotation.Bean;
+              import org.springframework.context.annotation.Configuration;
+              import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+              @Configuration
+              public class WebConfig {
+                  @Bean
+                  public WebMvcConfigurer forwardToIndex() {
+                      return new WebMvcConfigurer() {
+                      };
+                  }
+              }
+              """)
         );
     }
 }

--- a/src/testWithSpringBoot_2_1/java/org/openrewrite/java/spring/framework/MigrateWebMvcConfigurerAdapterTest.java
+++ b/src/testWithSpringBoot_2_1/java/org/openrewrite/java/spring/framework/MigrateWebMvcConfigurerAdapterTest.java
@@ -28,13 +28,8 @@ class MigrateWebMvcConfigurerAdapterTest implements RewriteTest {
 
     @Override
     public void defaults(RecipeSpec spec) {
-        spec.parser(JavaParser.fromJavaVersion()
-            .classpathFromResources(new InMemoryExecutionContext(),
-              "spring-webmvc-5.*",
-              "spring-core-5.*",
-              "spring-web-5.*",
-              "spring-context-5.*"
-            ))
+        spec.parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(),
+            "spring-webmvc-5", "spring-core-5", "spring-web-5"))
           .recipe(new MigrateWebMvcConfigurerAdapter());
     }
 
@@ -44,30 +39,26 @@ class MigrateWebMvcConfigurerAdapterTest implements RewriteTest {
         rewriteRun(
           //language=java
           java(
-                """
-            package a.b.c;
+            """
+              import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter;
 
-            import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter;
+              public class CustomMvcConfigurer extends WebMvcConfigurerAdapter {
+                  private final String someArg;
+                  public CustomMvcConfigurer(String someArg) {
+                      super();
+                      this.someArg = someArg;
+                  }
+              }
+              """, """
+              import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
-            public class CustomMvcConfigurer extends WebMvcConfigurerAdapter {
-                private final String someArg;
-                public CustomMvcConfigurer(String someArg) {
-                    super();
-                    this.someArg = someArg;
-                }
-            }
-            """, """
-            package a.b.c;
-
-            import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
-
-            public class CustomMvcConfigurer implements WebMvcConfigurer {
-                private final String someArg;
-                public CustomMvcConfigurer(String someArg) {
-                    this.someArg = someArg;
-                }
-            }
-            """)
+              public class CustomMvcConfigurer implements WebMvcConfigurer {
+                  private final String someArg;
+                  public CustomMvcConfigurer(String someArg) {
+                      this.someArg = someArg;
+                  }
+              }
+              """)
         );
     }
 
@@ -77,32 +68,26 @@ class MigrateWebMvcConfigurerAdapterTest implements RewriteTest {
         rewriteRun(
           java(
             """
-              import org.springframework.context.annotation.Bean;
-              import org.springframework.context.annotation.Configuration;
               import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter;
 
-              @Configuration
-              public class WebConfig {
-                  @Bean
-                  public WebMvcConfigurerAdapter forwardToIndex() {
+              class WebConfig {
+                  WebMvcConfigurerAdapter forwardToIndex() {
                       return new WebMvcConfigurerAdapter() {
                       };
                   }
               }
-              """, """
-              import org.springframework.context.annotation.Bean;
-              import org.springframework.context.annotation.Configuration;
+              """,
+            """
               import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
-              @Configuration
-              public class WebConfig {
-                  @Bean
-                  public WebMvcConfigurer forwardToIndex() {
+              class WebConfig {
+                  WebMvcConfigurer forwardToIndex() {
                       return new WebMvcConfigurer() {
                       };
                   }
               }
-              """)
+              """
+          )
         );
     }
 }


### PR DESCRIPTION
## What's changed?
The origin recipe only handle classes that extend WebMvcConfigurer. In some cases, people return `new WebMvcConfigurer()` directly as a bean.

### Checklist
- [✅] I've added unit tests to cover both positive and negative cases
- [✅] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [✅] I've used the IntelliJ IDEA auto-formatter on affected files