### PR TITLE
MigrateHandlerInterceptor recipe migrates too much

### DIFF
--- a/src/main/java/org/openrewrite/java/spring/boot2/MigrateDatabaseCredentials.java
+++ b/src/main/java/org/openrewrite/java/spring/boot2/MigrateDatabaseCredentials.java
@@ -83,7 +83,7 @@ public class MigrateDatabaseCredentials extends Recipe {
                 public Yaml visitDocuments(Yaml.Documents documents, ExecutionContext ctx) {
                     if (FindProperty.find(documents, "spring." + tool + ".username", true).isEmpty() &&
                             FindProperty.find(documents, "spring." + tool + ".password", true).isEmpty()) {
-                        doAfterVisit(new FindProperty("spring." + tool + ".url", true).getVisitor());
+                        doAfterVisit(new FindProperty("spring." + tool + ".url", true, null).getVisitor());
                     }
                     return documents;
                 }

--- a/src/main/java/org/openrewrite/java/spring/framework/MigrateHandlerInterceptor.java
+++ b/src/main/java/org/openrewrite/java/spring/framework/MigrateHandlerInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 the original author or authors.
+ * Copyright 2021 the original author or authors.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/openrewrite/java/spring/framework/MigrateHandlerInterceptor.java
+++ b/src/main/java/org/openrewrite/java/spring/framework/MigrateHandlerInterceptor.java
@@ -31,8 +31,8 @@ import static java.util.Objects.requireNonNull;
 
 public class MigrateHandlerInterceptor extends Recipe {
 
-    public static final String HANDLER_INTERCEPTOR_ADAPTER = "org.springframework.web.servlet.handler.HandlerInterceptorAdapter";
-    public static final String HANDLER_INTERCEPTOR = "org.springframework.web.servlet.HandlerInterceptor";
+    private static final String HANDLER_INTERCEPTOR_ADAPTER = "org.springframework.web.servlet.handler.HandlerInterceptorAdapter";
+    private static final String HANDLER_INTERCEPTOR = "org.springframework.web.servlet.HandlerInterceptor";
 
     @Override
     public String getDisplayName() {

--- a/src/main/java/org/openrewrite/java/spring/framework/MigrateHandlerInterceptor.java
+++ b/src/main/java/org/openrewrite/java/spring/framework/MigrateHandlerInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 the original author or authors.
+ * Copyright 2024 the original author or authors.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -72,9 +72,9 @@ public class MigrateHandlerInterceptor extends Recipe {
             public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
                 J.MethodInvocation mi = super.visitMethodInvocation(method, ctx);
                 if (mi.getMethodType() != null &&
-                        TypeUtils.isOfClassType(mi.getMethodType().getDeclaringType(), HANDLER_INTERCEPTOR) &&
-                        mi.getSelect() instanceof J.Identifier &&
-                        "super".equals(((J.Identifier) mi.getSelect()).getSimpleName())
+                    TypeUtils.isOfClassType(mi.getMethodType().getDeclaringType(), HANDLER_INTERCEPTOR) &&
+                    mi.getSelect() instanceof J.Identifier &&
+                    "super".equals(((J.Identifier) mi.getSelect()).getSimpleName())
                 ) {
                     return mi.withSelect(TypeTree.build("HandlerInterceptor.super")
                             .withType(JavaType.buildType(HANDLER_INTERCEPTOR)));

--- a/src/main/java/org/openrewrite/java/spring/framework/MigrateHandlerInterceptor.java
+++ b/src/main/java/org/openrewrite/java/spring/framework/MigrateHandlerInterceptor.java
@@ -19,10 +19,12 @@ import org.openrewrite.ExecutionContext;
 import org.openrewrite.Preconditions;
 import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
-import org.openrewrite.internal.ListUtils;
 import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.search.UsesType;
-import org.openrewrite.java.tree.*;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaType;
+import org.openrewrite.java.tree.TypeTree;
+import org.openrewrite.java.tree.TypeUtils;
 
 import static java.util.Collections.singletonList;
 import static java.util.Objects.requireNonNull;
@@ -54,16 +56,9 @@ public class MigrateHandlerInterceptor extends Recipe {
 
                 maybeAddImport(HANDLER_INTERCEPTOR);
                 maybeRemoveImport(HANDLER_INTERCEPTOR_ADAPTER);
-
-                cd = cd.withExtends(null);
-                cd = cd.withImplements(singletonList(TypeTree.build("HandlerInterceptor")
-                        .withType(JavaType.buildType(HANDLER_INTERCEPTOR)))
-                );
-
-                // temporary
-                cd = cd.getPadding().withImplements(JContainer.withElements(requireNonNull(cd.getPadding().getImplements()),
-                        ListUtils.mapFirst(cd.getPadding().getImplements().getElements(),
-                                anImplements -> anImplements.withPrefix(Space.format(" ")))));
+                cd = cd.withExtends(null)
+                        .withImplements(singletonList(TypeTree.build("HandlerInterceptor")
+                                .withType(JavaType.buildType(HANDLER_INTERCEPTOR))));
 
                 return autoFormat(cd, requireNonNull(cd.getImplements()).get(0), ctx, getCursor().getParentOrThrow());
             }
@@ -74,11 +69,9 @@ public class MigrateHandlerInterceptor extends Recipe {
                 if (mi.getMethodType() != null &&
                     TypeUtils.isOfClassType(mi.getMethodType().getDeclaringType(), HANDLER_INTERCEPTOR) &&
                     mi.getSelect() instanceof J.Identifier &&
-                    "super".equals(((J.Identifier) mi.getSelect()).getSimpleName())
-                ) {
+                    "super".equals(((J.Identifier) mi.getSelect()).getSimpleName())) {
                     return mi.withSelect(TypeTree.build("HandlerInterceptor.super")
                             .withType(JavaType.buildType(HANDLER_INTERCEPTOR)));
-
                 }
                 return mi;
             }

--- a/src/testWithSpringBoot_2_4/java/org/openrewrite/java/spring/MigrateHandlerInterceptorTest.java
+++ b/src/testWithSpringBoot_2_4/java/org/openrewrite/java/spring/MigrateHandlerInterceptorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 the original author or authors.
+ * Copyright 2021 the original author or authors.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/testWithSpringBoot_2_4/java/org/openrewrite/java/spring/MigrateHandlerInterceptorTest.java
+++ b/src/testWithSpringBoot_2_4/java/org/openrewrite/java/spring/MigrateHandlerInterceptorTest.java
@@ -135,7 +135,7 @@ class MigrateHandlerInterceptorTest implements RewriteTest {
               }
               """
           ),
-          // And do not change any other super call when HandlerInterceptorAdapter is imported
+          // And do not change any other super call when HandlerInterceptorAdapter is used
           java(
             """
               import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
@@ -143,6 +143,7 @@ class MigrateHandlerInterceptorTest implements RewriteTest {
               class B extends A {
                   @Override
                   public String test() {
+                      new HandlerInterceptorAdapter() {};
                       return super.test();
                   }
               }

--- a/src/testWithSpringBoot_2_4/java/org/openrewrite/java/spring/MigrateHandlerInterceptorTest.java
+++ b/src/testWithSpringBoot_2_4/java/org/openrewrite/java/spring/MigrateHandlerInterceptorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 the original author or authors.
+ * Copyright 2024 the original author or authors.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -89,7 +89,8 @@ class MigrateHandlerInterceptorTest implements RewriteTest {
                   public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
                       return super.preHandle(request, response, handler);
                   }
-              }""",
+              }
+              """,
             """
               import javax.servlet.http.*;
 

--- a/src/testWithSpringBoot_2_4/java/org/openrewrite/java/spring/MigrateHandlerInterceptorTest.java
+++ b/src/testWithSpringBoot_2_4/java/org/openrewrite/java/spring/MigrateHandlerInterceptorTest.java
@@ -112,4 +112,35 @@ class MigrateHandlerInterceptorTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void unusedImportOfHandlerInterceptorAdapterAndHasASuperCallShouldDoNothing() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
+
+              class MyInterceptorLike extends MySuperInterceptor {
+                  @Override
+                  public boolean test() {
+                      return super.test();
+                  }
+                  @Override
+                  public boolean test2() {
+                      return super.test();
+                  }
+              }
+
+              class MySuperInterceptor {
+                  public boolean test() {
+                      return true;
+                  }
+                  public boolean test2() {
+                      return true;
+                  }
+              }"""
+          )
+        );
+    }
 }

--- a/src/testWithSpringBoot_2_4/java/org/openrewrite/java/spring/MigrateHandlerInterceptorTest.java
+++ b/src/testWithSpringBoot_2_4/java/org/openrewrite/java/spring/MigrateHandlerInterceptorTest.java
@@ -44,11 +44,22 @@ class MigrateHandlerInterceptorTest implements RewriteTest {
               import javax.servlet.http.*;
 
               import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
+              import org.springframework.web.servlet.ModelAndView;
 
               class MyInterceptor extends HandlerInterceptorAdapter {
                   @Override
                   public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
                       return super.preHandle(request, response, handler);
+                  }
+
+                  @Override
+                  public void postHandle(HttpServletRequest request, HttpServletResponse response, Object handler, ModelAndView modelAndView) throws Exception {
+                      super.postHandle(request, response, handler, modelAndView);
+                  }
+
+                  @Override
+                  public void afterCompletion(HttpServletRequest request, HttpServletResponse response, Object handler, Exception ex) throws Exception {
+                      super.afterCompletion(request, response, handler, ex);
                   }
               }
               """,
@@ -56,11 +67,20 @@ class MigrateHandlerInterceptorTest implements RewriteTest {
               import javax.servlet.http.*;
 
               import org.springframework.web.servlet.HandlerInterceptor;
+              import org.springframework.web.servlet.ModelAndView;
 
               class MyInterceptor implements HandlerInterceptor {
                   @Override
                   public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
-                      return HandlerInterceptor.super.preHandle(request, response, handler);
+                      return true;
+                  }
+
+                  @Override
+                  public void postHandle(HttpServletRequest request, HttpServletResponse response, Object handler, ModelAndView modelAndView) throws Exception {
+                  }
+
+                  @Override
+                  public void afterCompletion(HttpServletRequest request, HttpServletResponse response, Object handler, Exception ex) throws Exception {
                   }
               }
               """
@@ -95,7 +115,7 @@ class MigrateHandlerInterceptorTest implements RewriteTest {
               class MySuperInterceptor implements HandlerInterceptor {
                   @Override
                   public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
-                      return HandlerInterceptor.super.preHandle(request, response, handler);
+                      return true;
                   }
               }
               """
@@ -111,6 +131,25 @@ class MigrateHandlerInterceptorTest implements RewriteTest {
                   @Override
                   public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
                       return super.preHandle(request, response, handler);
+                  }
+              }
+              """
+          ),
+          // And do not change any other super call when HandlerInterceptorAdapter is imported
+          java(
+            """
+              import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
+
+              class B extends A {
+                  @Override
+                  public String test() {
+                      return super.test();
+                  }
+              }
+
+              class A {
+                  public String test() {
+                      return "test";
                   }
               }
               """

--- a/src/testWithSpringBoot_2_4/java/org/openrewrite/java/spring/MigrateHandlerInterceptorTest.java
+++ b/src/testWithSpringBoot_2_4/java/org/openrewrite/java/spring/MigrateHandlerInterceptorTest.java
@@ -41,9 +41,9 @@ class MigrateHandlerInterceptorTest implements RewriteTest {
           java(
             """
               import javax.servlet.http.*;
-              
+
               import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
-              
+
               class MyInterceptor extends HandlerInterceptorAdapter {
                   @Override
                   public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
@@ -53,10 +53,56 @@ class MigrateHandlerInterceptorTest implements RewriteTest {
               """,
             """
               import javax.servlet.http.*;
-              
+
               import org.springframework.web.servlet.HandlerInterceptor;
-              
+
               class MyInterceptor implements HandlerInterceptor {
+                  @Override
+                  public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
+                      return HandlerInterceptor.super.preHandle(request, response, handler);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void doesNotReplaceInterceptorsExtendingOwnInterceptors() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import javax.servlet.http.*;
+
+              import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
+
+              class MyInterceptor extends MySuperInterceptor {
+                  @Override
+                  public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
+                      return super.preHandle(request, response, handler);
+                  }
+              }
+
+              class MySuperInterceptor extends HandlerInterceptorAdapter {
+                  @Override
+                  public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
+                      return super.preHandle(request, response, handler);
+                  }
+              }""",
+            """
+              import javax.servlet.http.*;
+
+              import org.springframework.web.servlet.HandlerInterceptor;
+
+              class MyInterceptor extends MySuperInterceptor {
+                  @Override
+                  public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
+                      return super.preHandle(request, response, handler);
+                  }
+              }
+
+              class MySuperInterceptor implements HandlerInterceptor {
                   @Override
                   public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
                       return HandlerInterceptor.super.preHandle(request, response, handler);


### PR DESCRIPTION
## What's changed?
Improve/Bugfix the `MigrateHandlerInterceptor`recipe to only migrate classes that directly extends the HandlerInterceptorAdapter.

## What's your motivation?
Migration is targeted broadly, so it can migrate `super` calls when it is not intended to. This can lead to bugs, see 
- fixes https://github.com/openrewrite/rewrite-spring/issues/620

for example.

## Any additional context
The migration does now convert `super.preHandle(..)` to `HandlerInterceptor.super.preHandle(..)`. According to mr [unconditional](https://stackoverflow.com/users/4571544/unconditional), you should migrate to `return true`. See [this](https://stackoverflow.com/questions/72152105/migrate-handlerinterceptor-to-spring-boot-2-6) SO post for more information.

_Also [this](https://sbrta.medium.com/spring-boot-2-to-3-a-migration-journey-92d5fb3a5b5b#7a20) blog seems to suggest that this is the right move (as in, when you move from SB 2 to 3, you likely have a `return true` kind of implementation)._

There are two other methods avaliable in the HandlerInterceptorAdapter/HandlerInterceptor classes: `postHandle` and `afterCompletion`. Both of them have empty default implementation, So maybe the recipe should be doing something else:

- **preHandle**: `super.preHandle(..)` -> `return true`
- **postHandle**: `super.postHandle(..)` -> `<remove super call>`
 - **afterCompletion**: `super.afterCompletion(..)` ->  `<remove super call>`

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
