### PR TITLE
Move spring-data-mongodb to `compileOnly` dependency

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -152,7 +152,7 @@ dependencies {
         exclude("com.google.auto.service", "auto-service-annotations")
     }
     implementation("org.mongodb:mongo-java-driver:3.12.+")
-    implementation("org.springframework.data:spring-data-mongodb:2.2.+"){
+    compileOnly("org.springframework.data:spring-data-mongodb:2.2.+"){
         because("We only require the classes (for refaster style recipes), not the dependencies")
         exclude(group = "org.springframework")
     }


### PR DESCRIPTION
## What's your motivation?
Up to now we had had a runtime spring-data-mongodb dependency, as seen in:
https://repo1.maven.org/maven2/org/openrewrite/recipe/rewrite-spring/5.22.0/rewrite-spring-5.22.0.pom
```
<dependency>
  <groupId>org.springframework.data</groupId>
  <artifactId>spring-data-mongodb</artifactId>
  <version>2.2.12.RELEASE</version>
  <scope>runtime</scope>
  <exclusions>
    <exclusion>
      <groupId>org.springframework</groupId>
      <artifactId>*</artifactId>
    </exclusion>
  </exclusions>
</dependency>
```

But we've seen this fail when organizations block access to vulnerable dependencies, as I had a case today where the excluded `spring-core:5.2.12.RELEASE` lead to a 404 and failure to install the rewrite-spring recipe jar, via this chain of downloads
https://repo1.maven.org/maven2/org/springframework/data/spring-data-mongodb/2.2.12.RELEASE/spring-data-mongodb-2.2.12.RELEASE.pom
https://repo1.maven.org/maven2/org/springframework/data/spring-data-mongodb-parent/2.2.12.RELEASE/spring-data-mongodb-parent-2.2.12.RELEASE.pom
https://repo1.maven.org/maven2/org/springframework/data/build/spring-data-parent/2.2.12.RELEASE/spring-data-parent-2.2.12.RELEASE.pom

With the change we drop that runtime classpath dependency, but possible break the recipe.

## Anything in particular you'd like reviewers to focus on?
The generated recipe still uses `JavaParser.runtimeClasspath()`; I'm wondering if this change will break that, and/or whether we should switch to using `classpathFromResources` there, and possibly then drop the Refaster recipe
```
final JavaTemplate before = JavaTemplate
        .builder("new org.springframework.data.mongodb.core.SimpleMongoDbFactory(new com.mongodb.MongoClientURI(#{uri:any(java.lang.String)}))")
        .javaParser(JavaParser.fromJavaVersion().classpath(JavaParser.runtimeClasspath()))
        .build();
final JavaTemplate after = JavaTemplate
        .builder("new org.springframework.data.mongodb.core.SimpleMongoClientDbFactory(#{uri:any(java.lang.String)})")
        .javaParser(JavaParser.fromJavaVersion().classpath(JavaParser.runtimeClasspath()))
        .build();
```

## Anyone you would like to review specifically?
@knutwannheden 

## Have you considered any alternatives or workarounds?
- We could ensure that excluded dependencies are not downloaded, if we don't already do so in openrewrite/rewrite.
- We could add a visitor that uses LST types and a regular MethodMatcher, as opposed to a JavaTemplate.Matcher.