### PR TITLE
Add `unlessUsing` to `RemoveDependency` to not break compilation

### DIFF
--- a/src/main/resources/META-INF/rewrite/spring-framework-53.yml
+++ b/src/main/resources/META-INF/rewrite/spring-framework-53.yml
@@ -48,6 +48,7 @@ recipeList:
   - org.openrewrite.java.dependencies.RemoveDependency:
       groupId: aopalliance
       artifactId: aopalliance
+      unlessUsing: org.aopalliance.aop.*
   - org.openrewrite.java.dependencies.RemoveDependency:
       groupId: cglib
       artifactId: cglib

--- a/src/main/resources/META-INF/rewrite/spring-framework-53.yml
+++ b/src/main/resources/META-INF/rewrite/spring-framework-53.yml
@@ -44,12 +44,14 @@ recipeList:
   - org.openrewrite.java.dependencies.RemoveDependency:
       groupId: org.aspectj
       artifactId: aspectjrt
+      unlessUsing: org.aspectj.lang.annotation.*
   - org.openrewrite.java.dependencies.RemoveDependency:
       groupId: aopalliance
       artifactId: aopalliance
   - org.openrewrite.java.dependencies.RemoveDependency:
       groupId: cglib
       artifactId: cglib
+      unlessUsing: net.sf.cglib.core.*
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.spring.framework.UseObjectUtilsIsEmpty


### PR DESCRIPTION
## What's your motivation?
Fixes a reported issue about dependencies removed despite being used.

## Anything in particular you'd like reviewers to focus on?
Didn't immediately spot any other RemoveDependency where we would want to add this conditional, as the others are part of a larger migration with code changes.