### PR TITLE
Add recipe for Spring Boot 3.4 migration

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 group = "org.openrewrite.recipe"
 description = "Eliminate legacy Spring patterns and migrate between major Spring Boot versions. Automatically."
 
-val springBootVersions: List<String> = listOf("1_5", "2_1", "2_2", "2_3", "2_4", "2_5", "2_6", "2_7", "3_0", "3_2", "3_3")
+val springBootVersions: List<String> = listOf("1_5", "2_1", "2_2", "2_3", "2_4", "2_5", "2_6", "2_7", "3_0", "3_2", "3_3", "3_4")
 val springSecurityVersions: List<String> = listOf("5_7", "5_8", "6_2")
 
 val sourceSetNames: Map<String, List<String>> = mapOf(

--- a/src/main/resources/META-INF/rewrite/spring-boot-3-best-practices.yml
+++ b/src/main/resources/META-INF/rewrite/spring-boot-3-best-practices.yml
@@ -1,0 +1,32 @@
+#
+# Copyright 2024 the original author or authors.
+# <p>
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# <p>
+# https://www.apache.org/licenses/LICENSE-2.0
+# <p>
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.spring.boot3.SpringBoot3BestPractices
+displayName: Spring Boot 3.x best practices
+description: Applies best practices to Spring Boot 3 applications.
+tags:
+  - spring
+  - boot
+recipeList:
+  - org.openrewrite.java.spring.boot2.SpringBoot2BestPractices
+  - org.openrewrite.java.migrate.UpgradeToJava21 # Allows for virtual threads
+  - org.openrewrite.java.spring.boot3.UpgradeSpringBoot_3_4
+  # Replace literals with constants and simplify MediaType parse calls
+  - org.openrewrite.java.spring.http.ReplaceStringLiteralsWithHttpHeadersConstants
+  - org.openrewrite.java.spring.http.ReplaceStringLiteralsWithMediaTypeConstants
+  - org.openrewrite.java.spring.http.SimplifyMediaTypeParseCalls
+  - org.openrewrite.java.spring.http.SimplifyWebTestClientCalls

--- a/src/main/resources/META-INF/rewrite/spring-boot-34.yml
+++ b/src/main/resources/META-INF/rewrite/spring-boot-34.yml
@@ -15,49 +15,36 @@
 #
 ---
 type: specs.openrewrite.org/v1beta/recipe
-name: org.openrewrite.java.spring.boot3.UpgradeSpringBoot_3_3
-displayName: Migrate to Spring Boot 3.3
+name: org.openrewrite.java.spring.boot3.UpgradeSpringBoot_3_4
+displayName: Migrate to Spring Boot 3.4
 description: >-
-  Migrate applications to the latest Spring Boot 3.3 release. This recipe will modify an
+  Migrate applications to the latest Spring Boot 3.4 release. This recipe will modify an
   application's build files, make changes to deprecated/preferred APIs, and migrate configuration settings that have
   changes between versions. This recipe will also chain additional framework migrations (Spring Framework, Spring Data,
-  etc) that are required as part of the migration to Spring Boot 3.2.
+  etc) that are required as part of the migration to Spring Boot 3.3.
 tags:
   - spring
   - boot
 recipeList:
-  - org.openrewrite.java.spring.boot3.UpgradeSpringBoot_3_2
-  - org.openrewrite.java.spring.boot3.SpringBootProperties_3_3
+  - org.openrewrite.java.spring.boot3.UpgradeSpringBoot_3_3
+  - org.openrewrite.java.spring.boot3.SpringBootProperties_3_4
   - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
       groupId: org.springframework.boot
       artifactId: "*"
-      newVersion: 3.3.x
+      newVersion: 3.4.x
       overrideManagedVersion: false
   - org.openrewrite.maven.UpgradePluginVersion:
       groupId: org.springframework.boot
       artifactId: spring-boot-maven-plugin
-      newVersion: 3.3.x
-  - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
-      groupId: org.springframework
-      artifactId: "*"
-      newVersion: 6.1.x
+      newVersion: 3.4.x
+#  - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
+#      groupId: org.springframework
+#      artifactId: "*"
+#      newVersion: 6.2.x    <- Does not exist yet, but probably required?
   - org.openrewrite.maven.UpgradeParentVersion:
       groupId: org.springframework.boot
       artifactId: spring-boot-starter-parent
-      newVersion: 3.3.x
+      newVersion: 3.4.x
   - org.openrewrite.gradle.plugins.UpgradePluginVersion:
       pluginIdPattern: org.springframework.boot
-      newVersion: 3.3.x
-  - org.openrewrite.micrometer.UpgradeMicrometer_1_13
-  - org.openrewrite.gradle.plugins.UpgradePluginVersion:
-      pluginIdPattern: org.graalvm.buildtools.native
-      newVersion: 0.10.x
-  - org.openrewrite.java.dependencies.ChangeDependency:
-      oldGroupId: com.datastax.oss
-      newGroupId: org.apache.cassandra
-      oldArtifactId: "*"
-  - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
-      groupId: org.springdoc
-      artifactId: "*"
-      newVersion: 2.6.x
-  - org.openrewrite.hibernate.MigrateToHibernate65
+      newVersion: 3.4.x

--- a/src/main/resources/META-INF/rewrite/spring-boot-34.yml
+++ b/src/main/resources/META-INF/rewrite/spring-boot-34.yml
@@ -21,7 +21,7 @@ description: >-
   Migrate applications to the latest Spring Boot 3.4 release. This recipe will modify an
   application's build files, make changes to deprecated/preferred APIs, and migrate configuration settings that have
   changes between versions. This recipe will also chain additional framework migrations (Spring Framework, Spring Data,
-  etc) that are required as part of the migration to Spring Boot 3.3.
+  etc) that are required as part of the migration to Spring Boot 3.4.
 tags:
   - spring
   - boot

--- a/src/main/resources/META-INF/rewrite/spring-boot-34.yml
+++ b/src/main/resources/META-INF/rewrite/spring-boot-34.yml
@@ -37,10 +37,6 @@ recipeList:
       groupId: org.springframework.boot
       artifactId: spring-boot-maven-plugin
       newVersion: 3.4.x
-#  - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
-#      groupId: org.springframework
-#      artifactId: "*"
-#      newVersion: 6.2.x    <- Does not exist yet, but probably required?
   - org.openrewrite.maven.UpgradeParentVersion:
       groupId: org.springframework.boot
       artifactId: spring-boot-starter-parent

--- a/src/testWithSpringBoot_3_4/java/org/openrewrite/java/spring/boot3/SpringBootVersionUpgradeTest.java
+++ b/src/testWithSpringBoot_3_4/java/org/openrewrite/java/spring/boot3/SpringBootVersionUpgradeTest.java
@@ -21,8 +21,6 @@ import org.openrewrite.config.Environment;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
-import java.util.regex.Pattern;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.openrewrite.java.Assertions.mavenProject;
 import static org.openrewrite.maven.Assertions.pomXml;

--- a/src/testWithSpringBoot_3_4/java/org/openrewrite/java/spring/boot3/SpringBootVersionUpgradeTest.java
+++ b/src/testWithSpringBoot_3_4/java/org/openrewrite/java/spring/boot3/SpringBootVersionUpgradeTest.java
@@ -60,7 +60,7 @@ class SpringBootVersionUpgradeTest implements RewriteTest {
                 </project>
                 """,
               spec -> spec.after(actual -> {
-                  assertThat(actual).containsPattern("<version>3.3.\\d+</version>");
+                  assertThat(actual).containsPattern("<version>3.[34].\\d+</version>");
                   return actual;
               })
             )

--- a/src/testWithSpringBoot_3_4/java/org/openrewrite/java/spring/boot3/SpringBootVersionUpgradeTest.java
+++ b/src/testWithSpringBoot_3_4/java/org/openrewrite/java/spring/boot3/SpringBootVersionUpgradeTest.java
@@ -21,11 +21,13 @@ import org.openrewrite.config.Environment;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
+import java.util.regex.Pattern;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.openrewrite.java.Assertions.mavenProject;
 import static org.openrewrite.maven.Assertions.pomXml;
 
-class SpringCloudVersionUpgradeTest implements RewriteTest {
+class SpringBootVersionUpgradeTest implements RewriteTest {
 
     @Override
     public void defaults(RecipeSpec spec) {
@@ -40,7 +42,7 @@ class SpringCloudVersionUpgradeTest implements RewriteTest {
 
     @Test
     @DocumentExample
-    void upgradeSpringCloudVersion() {
+    void upgradeVersion() {
         rewriteRun(
           mavenProject("project",
             //language=xml
@@ -58,27 +60,10 @@ class SpringCloudVersionUpgradeTest implements RewriteTest {
                         <version>2.2.2.RELEASE</version>
                         <relativePath/>
                     </parent>
-                    <properties>
-                        <java.version>11</java.version>
-                        <spring-cloud.version>Hoxton.SR9</spring-cloud.version>
-                        <mockito.version>2.18.3</mockito.version>
-                    </properties>
-                    <dependencyManagement>
-                        <dependencies>
-                            <dependency>
-                                <groupId>org.springframework.cloud</groupId>
-                                <artifactId>spring-cloud-dependencies</artifactId>
-                                <version>${spring-cloud.version}</version>
-                                <type>pom</type>
-                                <scope>import</scope>
-                            </dependency>
-                        </dependencies>
-                    </dependencyManagement>
                 </project>
                 """,
               spec -> spec.after(actual -> {
-                  assertThat(actual).containsPattern("<version>3.4.\\d+</version>");
-                  assertThat(actual).containsPattern("<spring-cloud.version>2023.0.\\d+</spring-cloud.version>");
+                  assertThat(actual).containsPattern("<version>3.3.\\d+</version>");
                   return actual;
               })
             )

--- a/src/testWithSpringBoot_3_4/java/org/openrewrite/java/spring/boot3/SpringBootVersionUpgradeTest.java
+++ b/src/testWithSpringBoot_3_4/java/org/openrewrite/java/spring/boot3/SpringBootVersionUpgradeTest.java
@@ -30,7 +30,6 @@ class SpringBootVersionUpgradeTest implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
         spec
-          .expectedCyclesThatMakeChanges(2)
           .recipe(Environment.builder()
             .scanRuntimeClasspath("org.openrewrite.java.spring")
             .build()

--- a/src/testWithSpringBoot_3_4/java/org/openrewrite/java/spring/boot3/testWithSpringBoot_3_4/java/org/openrewrite/java/spring/boot3/SpringCloudVersionUpgradeTest.java
+++ b/src/testWithSpringBoot_3_4/java/org/openrewrite/java/spring/boot3/testWithSpringBoot_3_4/java/org/openrewrite/java/spring/boot3/SpringCloudVersionUpgradeTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.spring.boot3;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.config.Environment;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.openrewrite.java.Assertions.mavenProject;
+import static org.openrewrite.maven.Assertions.pomXml;
+
+class SpringCloudVersionUpgradeTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec
+          .expectedCyclesThatMakeChanges(2)
+          .recipe(Environment.builder()
+            .scanRuntimeClasspath("org.openrewrite.java.spring")
+            .build()
+            .activateRecipes("org.openrewrite.java.spring.boot3.UpgradeSpringBoot_3_4")
+          );
+    }
+
+    @Test
+    @DocumentExample
+    void upgradeSpringCloudVersion() {
+        rewriteRun(
+          mavenProject("project",
+            //language=xml
+            pomXml(
+              """
+                <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>com.example</groupId>
+                    <artifactId>fooservice</artifactId>
+                    <version>1.0-SNAPSHOT</version>
+                    <parent>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-parent</artifactId>
+                        <version>2.2.2.RELEASE</version>
+                        <relativePath/>
+                    </parent>
+                    <properties>
+                        <java.version>11</java.version>
+                        <spring-cloud.version>Hoxton.SR9</spring-cloud.version>
+                        <mockito.version>2.18.3</mockito.version>
+                    </properties>
+                    <dependencyManagement>
+                        <dependencies>
+                            <dependency>
+                                <groupId>org.springframework.cloud</groupId>
+                                <artifactId>spring-cloud-dependencies</artifactId>
+                                <version>${spring-cloud.version}</version>
+                                <type>pom</type>
+                                <scope>import</scope>
+                            </dependency>
+                        </dependencies>
+                    </dependencyManagement>
+                </project>
+                """,
+              spec -> spec.after(actual -> {
+                  assertThat(actual).containsPattern("<version>3.4.\\d+</version>");
+                  assertThat(actual).containsPattern("<spring-cloud.version>2023.0.\\d+</spring-cloud.version>");
+                  return actual;
+              })
+            )
+          )
+        );
+    }
+}


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->

Two changes
- Add a recipe for updating to Spring Boot 3.4.
- The Spring Boot 3 best practices recipe has been extracted from the Spring Boot 3.3 update recipe. 

## What's your motivation?

## Anything in particular you'd like reviewers to focus on?
- We don't have a recipe for Spring 6.2 yet, which I think should be part of the update.
- I have made the 3.4 upgrade part of the `org.openrewrite.java.spring.boot3.SpringBoot3BestPractices` recipe, as was the case with the 3.3 upgrade. However, since the recipe is now extracted/standalone do we still want this to be the case? 

## Anyone you would like to review specifically?
@Laurens-W @timtebeek 

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
