### PR TITLE
Fix incorrect path computation for Spring API endpoints

### DIFF
--- a/src/main/java/org/openrewrite/java/spring/search/FindApiEndpoints.java
+++ b/src/main/java/org/openrewrite/java/spring/search/FindApiEndpoints.java
@@ -20,25 +20,17 @@ import lombok.Value;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
-import org.openrewrite.java.AnnotationMatcher;
 import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.service.AnnotationService;
 import org.openrewrite.java.spring.table.ApiEndpoints;
 import org.openrewrite.java.spring.trait.SpringRequestMapping;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaSourceFile;
 import org.openrewrite.marker.SearchResult;
 
-import java.util.List;
-import java.util.stream.Stream;
-
-import static java.util.stream.Collectors.toList;
-
 @Value
 @EqualsAndHashCode(callSuper = false)
 public class FindApiEndpoints extends Recipe {
-    private static final List<AnnotationMatcher> REST_ENDPOINTS = Stream.of("Request", "Get", "Post", "Put", "Delete", "Patch")
-            .map(method -> new AnnotationMatcher("@org.springframework.web.bind.annotation." + method + "Mapping"))
-            .collect(toList());
 
     transient ApiEndpoints apis = new ApiEndpoints(this);
 
@@ -63,7 +55,7 @@ public class FindApiEndpoints extends Recipe {
                 J.MethodDeclaration m = super.visitMethodDeclaration(method, ctx);
 
                 SpringRequestMapping.Matcher matcher = new SpringRequestMapping.Matcher();
-                for (J.Annotation annotation : m.getAllAnnotations()) {
+                for (J.Annotation annotation : service(AnnotationService.class).getAllAnnotations(getCursor())) {
                     m = matcher.get(annotation, getCursor()).map(requestMapping -> {
                         String path = requestMapping.getPath();
                         String httpMethod = requestMapping.getHttpMethod();

--- a/src/main/java/org/openrewrite/java/spring/trait/SpringRequestMapping.java
+++ b/src/main/java/org/openrewrite/java/spring/trait/SpringRequestMapping.java
@@ -65,7 +65,7 @@ public class SpringRequestMapping implements Trait<J.Annotation> {
         List<String> pathEndings = new Annotated(cursor)
                 .getDefaultAttribute(null)
                 .map(Literal::getStrings)
-                .orElse(Collections.emptyList());
+                .orElse(Collections.singletonList(""));
 
         StringBuilder result = new StringBuilder();
         for (int j = 0; j < pathPrefixes.size(); j++) {

--- a/src/main/java/org/openrewrite/java/spring/trait/SpringRequestMapping.java
+++ b/src/main/java/org/openrewrite/java/spring/trait/SpringRequestMapping.java
@@ -35,9 +35,8 @@ import static java.util.stream.Collectors.toList;
 
 @Value
 public class SpringRequestMapping implements Trait<J.Annotation> {
-    private static final List<AnnotationMatcher> REST_ENDPOINTS = Stream.of("Request", "Get", "Post", "Put", "Delete", "Patch")
-            .map(method -> new AnnotationMatcher("@org.springframework.web.bind.annotation." + method + "Mapping"))
-            .collect(toList());
+
+    private static final AnnotationMatcher MAPPING_MATCHER = new AnnotationMatcher("@org.springframework.web.bind.annotation.*Mapping");
 
     Cursor cursor;
 
@@ -55,7 +54,7 @@ public class SpringRequestMapping implements Trait<J.Annotation> {
                 .filter(J.ClassDeclaration.class::isInstance)
                 .map(J.ClassDeclaration.class::cast)
                 .flatMap(classDecl -> classDecl.getLeadingAnnotations().stream()
-                        .filter(SpringRequestMapping::hasRequestMapping)
+                        .filter(MAPPING_MATCHER::matches)
                         .findAny()
                         .flatMap(classMapping -> new Annotated(new Cursor(null, classMapping))
                                 .getDefaultAttribute(null)
@@ -85,18 +84,10 @@ public class SpringRequestMapping implements Trait<J.Annotation> {
         @Override
         protected @Nullable SpringRequestMapping test(Cursor cursor) {
             Object value = cursor.getValue();
-            return value instanceof J.Annotation && hasRequestMapping((J.Annotation) value) ?
+            return value instanceof J.Annotation && MAPPING_MATCHER.matches((J.Annotation) value) ?
                     new SpringRequestMapping(cursor) :
                     null;
         }
     }
 
-    private static boolean hasRequestMapping(J.Annotation ann) {
-        for (AnnotationMatcher restEndpoint : REST_ENDPOINTS) {
-            if (restEndpoint.matches(ann)) {
-                return true;
-            }
-        }
-        return false;
-    }
 }

--- a/src/testWithSpringBoot_3_0/java/org/openrewrite/java/spring/search/FindApiEndpointsTest.java
+++ b/src/testWithSpringBoot_3_0/java/org/openrewrite/java/spring/search/FindApiEndpointsTest.java
@@ -15,7 +15,6 @@
  */
 package org.openrewrite.java.spring.search;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.java.JavaParser;
@@ -24,7 +23,6 @@ import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.java.Assertions.java;
 
-@Disabled
 class FindApiEndpointsTest implements RewriteTest {
 
     @Override
@@ -42,7 +40,7 @@ class FindApiEndpointsTest implements RewriteTest {
             """
               import org.springframework.stereotype.Controller;
               import org.springframework.web.bind.annotation.*;
-              
+
               @Controller
               class PersonController {
                   @GetMapping("/count")
@@ -54,7 +52,7 @@ class FindApiEndpointsTest implements RewriteTest {
             """
               import org.springframework.stereotype.Controller;
               import org.springframework.web.bind.annotation.*;
-              
+
               @Controller
               class PersonController {
                   /*~~(GET /count)~~>*/@GetMapping("/count")
@@ -75,7 +73,7 @@ class FindApiEndpointsTest implements RewriteTest {
           java(
             """
               import org.springframework.web.bind.annotation.*;
-              
+
               @RequestMapping("/person")
               class PersonController {
                   @GetMapping("/count")
@@ -86,7 +84,7 @@ class FindApiEndpointsTest implements RewriteTest {
               """,
             """
               import org.springframework.web.bind.annotation.*;
-              
+
               @RequestMapping("/person")
               class PersonController {
                   /*~~(GET /person/count)~~>*/@GetMapping("/count")
@@ -106,7 +104,7 @@ class FindApiEndpointsTest implements RewriteTest {
           java(
             """
               import org.springframework.web.bind.annotation.*;
-              
+
               @RequestMapping({"/person", "/people"})
               class PersonController {
                   @GetMapping({"/count", "/length"})
@@ -117,7 +115,7 @@ class FindApiEndpointsTest implements RewriteTest {
               """,
             """
               import org.springframework.web.bind.annotation.*;
-              
+
               @RequestMapping({"/person", "/people"})
               class PersonController {
                   /*~~(GET /person/count, /person/length, /people/count, /people/length)~~>*/@GetMapping({"/count", "/length"})
@@ -130,7 +128,6 @@ class FindApiEndpointsTest implements RewriteTest {
         );
     }
 
-
     @Test
     void pathDefinedOnlyOnController() {
         rewriteRun(
@@ -139,7 +136,7 @@ class FindApiEndpointsTest implements RewriteTest {
             """
               import org.springframework.stereotype.Controller;
               import org.springframework.web.bind.annotation.*;
-              
+
               @Controller
               @RequestMapping("/count")
               class PersonController {
@@ -152,7 +149,7 @@ class FindApiEndpointsTest implements RewriteTest {
             """
               import org.springframework.stereotype.Controller;
               import org.springframework.web.bind.annotation.*;
-              
+
               @Controller
               @RequestMapping("/count")
               class PersonController {

--- a/src/testWithSpringBoot_3_0/java/org/openrewrite/java/spring/search/FindApiEndpointsTest.java
+++ b/src/testWithSpringBoot_3_0/java/org/openrewrite/java/spring/search/FindApiEndpointsTest.java
@@ -129,4 +129,40 @@ class FindApiEndpointsTest implements RewriteTest {
           )
         );
     }
+
+
+    @Test
+    void pathDefinedOnlyOnController() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import org.springframework.stereotype.Controller;
+              import org.springframework.web.bind.annotation.*;
+              
+              @Controller
+              @RequestMapping("/count")
+              class PersonController {
+                  @GetMapping
+                  int count() {
+                    return 42;
+                  }
+              }
+              """,
+            """
+              import org.springframework.stereotype.Controller;
+              import org.springframework.web.bind.annotation.*;
+              
+              @Controller
+              @RequestMapping("/count")
+              class PersonController {
+                  /*~~(GET /count)~~>*/@GetMapping
+                  int count() {
+                    return 42;
+                  }
+              }
+              """
+          )
+        );
+    }
 }

--- a/src/testWithSpringBoot_3_0/java/org/openrewrite/java/spring/search/FindApiEndpointsTest.java
+++ b/src/testWithSpringBoot_3_0/java/org/openrewrite/java/spring/search/FindApiEndpointsTest.java
@@ -66,6 +66,47 @@ class FindApiEndpointsTest implements RewriteTest {
     }
 
     @Test
+    void withResponseBody() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import org.springframework.stereotype.Controller;
+              import org.springframework.web.bind.annotation.*;
+
+              @Controller
+              class PersonController {
+                  @GetMapping("/person")
+                  @ResponseBody Person person() {
+                      return new Person();
+                  }
+              }
+
+              class Person {
+                  int age = 42;
+              }
+              """,
+            """
+              import org.springframework.stereotype.Controller;
+              import org.springframework.web.bind.annotation.*;
+
+              @Controller
+              class PersonController {
+                  /*~~(GET /person)~~>*/@GetMapping("/person")
+                  @ResponseBody Person person() {
+                      return new Person();
+                  }
+              }
+
+              class Person {
+                  int age = 42;
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     @DocumentExample
     void webClient() {
         rewriteRun(


### PR DESCRIPTION
## What's changed?
The current logic did not cover the case where a `RequestMapping` with a path was defined on the Controller class, and no paths were defined in the `*Mapping` at the method level.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
