### PR TITLE
Add logic to quote yaml scalar value

### DIFF
--- a/src/test/java/org/openrewrite/java/spring/ChangeSpringPropertyValueTest.java
+++ b/src/test/java/org/openrewrite/java/spring/ChangeSpringPropertyValueTest.java
@@ -56,4 +56,27 @@ class ChangeSpringPropertyValueTest implements RewriteTest {
           yaml("server.port: 53", "server.port: 8053")
         );
     }
+
+    @Test
+    void yamlValueQuoted() {
+        rewriteRun(
+          spec -> spec.recipe(new ChangeSpringPropertyValue("management.endpoints.web.exposure.include", "*", null, null,  null)),
+          properties("management.endpoints.web.exposure.include=info,health", "management.endpoints.web.exposure.include=*"),
+          yaml(
+            """
+              management:
+                endpoints:
+                  web:
+                    exposure:
+                      include: info,health
+            """,
+            """
+              management:
+                endpoints:
+                  web:
+                    exposure:
+                      include: "*"
+            """)
+        );
+    }
 }


### PR DESCRIPTION
## What's changed?
Ran into an edge case when attempting to change the value of `management.endpoints.web.exposure.include` to `*` and the current implementation does not quote the value when properties are expressed as YAML. Simply added logic that is similar to the logic used in AddSpringProperty to quote the scalar value.
 
