### PR TITLE
Remove BeanMethodsNotPublic from SpringBoot2BestPractices (again)

### DIFF
--- a/src/main/resources/META-INF/rewrite/best-practices.yml
+++ b/src/main/resources/META-INF/rewrite/best-practices.yml
@@ -15,6 +15,23 @@
 #
 ---
 type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.spring.boot2.SpringBoot2BestPractices
+displayName: Spring Boot 2.x best practices
+description: Applies best practices to Spring Boot 2 applications.
+tags:
+  - spring
+  - boot
+recipeList:
+  # Note that we do not upgrade to Spring Boot 2.x here, as the 2.0 recipe includes SpringBoot2BestPractices itself
+  - org.openrewrite.java.spring.NoRequestMappingAnnotation
+  - org.openrewrite.java.spring.ImplicitWebAnnotationNames
+  - org.openrewrite.java.spring.boot2.UnnecessarySpringExtension
+  - org.openrewrite.java.spring.NoAutowiredOnConstructor
+  - org.openrewrite.java.spring.boot2.RestTemplateBuilderRequestFactory
+  - org.openrewrite.java.spring.boot2.ReplaceDeprecatedEnvironmentTestUtils
+
+---
+type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.spring.boot3.SpringBoot3BestPractices
 displayName: Spring Boot 3.x best practices
 description: Applies best practices to Spring Boot 3 applications.
@@ -22,10 +39,12 @@ tags:
   - spring
   - boot
 recipeList:
+  # These steps go above & beyond what's needed for a pure upgrade, and are not be included with 3.x upgrades themselves
   - org.openrewrite.java.spring.boot2.SpringBoot2BestPractices
   - org.openrewrite.java.migrate.UpgradeToJava21 # Allows for virtual threads
   - org.openrewrite.java.spring.boot3.UpgradeSpringBoot_3_3
   - org.openrewrite.java.spring.boot3.EnableVirtualThreads
+  - org.openrewrite.java.spring.framework.BeanMethodsNotPublic # Intentionally not in 2.x
   # Replace literals with constants and simplify MediaType parse calls
   - org.openrewrite.java.spring.http.ReplaceStringLiteralsWithHttpHeadersConstants
   - org.openrewrite.java.spring.http.ReplaceStringLiteralsWithMediaTypeConstants

--- a/src/main/resources/META-INF/rewrite/spring-boot-20.yml
+++ b/src/main/resources/META-INF/rewrite/spring-boot-20.yml
@@ -168,18 +168,3 @@ recipeList:
       artifactId: validation-api
       version: 2.x
       onlyIfUsing: org.hibernate.validator.constraints.*
----
-type: specs.openrewrite.org/v1beta/recipe
-name: org.openrewrite.java.spring.boot2.SpringBoot2BestPractices
-displayName: Spring Boot 2.x best practices
-description: Applies best practices to Spring Boot 2 applications.
-tags:
-  - spring
-  - boot
-recipeList:
-  - org.openrewrite.java.spring.NoRequestMappingAnnotation
-  - org.openrewrite.java.spring.ImplicitWebAnnotationNames
-  - org.openrewrite.java.spring.boot2.UnnecessarySpringExtension
-  - org.openrewrite.java.spring.NoAutowiredOnConstructor
-  - org.openrewrite.java.spring.boot2.RestTemplateBuilderRequestFactory
-  - org.openrewrite.java.spring.boot2.ReplaceDeprecatedEnvironmentTestUtils

--- a/src/main/resources/META-INF/rewrite/spring-boot-20.yml
+++ b/src/main/resources/META-INF/rewrite/spring-boot-20.yml
@@ -183,4 +183,3 @@ recipeList:
   - org.openrewrite.java.spring.NoAutowiredOnConstructor
   - org.openrewrite.java.spring.boot2.RestTemplateBuilderRequestFactory
   - org.openrewrite.java.spring.boot2.ReplaceDeprecatedEnvironmentTestUtils
-  - org.openrewrite.java.spring.framework.BeanMethodsNotPublic


### PR DESCRIPTION
- See #304 for exactly the same conversation :)

That said, getting philosophical:
I think we typically have a design pattern where "upgrades" and "best practices" are kept separate, and "best practices" allows for more opinionated/noisy changes. That's what the JUnit 5 recipes look like, iirc.

This file violates that pattern by having the 2.0 upgrade recipe include the best practices recipe. Buuuut, it's been that way for over a year, and the other included recipes aren't nearly as disruptive as this one.

I could imagine a spectrum with one extreme having only the most-strictly necessary changes, and the other end having the most noisy and least-popularly-agreed-upon changes, and we slice that spectrum into sections like:
- 1: "upgrades"
- 2: "best practices"
- 3: "standalone recipes"
- 4: "not even recipes"

And in that model, maybe the other recipes in `SpringBoot2BestPractices` happen to fall closer to section 1, and `BeanMethodsNotPublic` is in section 3, and the composite recipe happens to be named for section 2 and then is included in the section 1 `UpgradeSpringBoot_2_0` recipe. So it's easy for someone to think "this is a section 2 recipe, lemme add it to that bucket" and then it sneaks into section 1 and that feels bad. But it's all fuzzy.