### PR TITLE
Replace Assert.notEmpty(Collection<?> collection) with Assert.notEmpty(Collection<?> collection, String)

### DIFF
--- a/src/main/resources/META-INF/rewrite/spring-framework-60.yml
+++ b/src/main/resources/META-INF/rewrite/spring-framework-60.yml
@@ -90,3 +90,7 @@ recipeList:
       methodPattern: org.springframework.util.Assert notEmpty(java.util.Map)
       argumentIndex: 1
       literal: must not be empty
+  - org.openrewrite.java.AddLiteralMethodArgument:
+      methodPattern: org.springframework.util.Assert notEmpty(java.util.Collection)
+      argumentIndex: 1
+      literal: must not be empty


### PR DESCRIPTION
## What's changed?
The Assert.notEmpty(Collection<?> collection) was deprecated of 4.3.7, and removed in 6.1 in favor of Assert.notEmpty(Collection, String).

## What's your motivation?
To prevent potential compilation errors during the upgrade to Spring Boot 3.3.X.

## Anything in particular you'd like reviewers to focus on?
No.

## Anyone you would like to review specifically?
No.

## Have you considered any alternatives or workarounds?
I don't think there is other workaround because this method will be removed in 6.1.

## Any additional context
No.

### Checklist
No.