### PR TITLE
Add support for HttpStatus in SimplifyWebTestClientCalls

### DIFF
--- a/src/main/java/org/openrewrite/java/spring/http/SimplifyWebTestClientCalls.java
+++ b/src/main/java/org/openrewrite/java/spring/http/SimplifyWebTestClientCalls.java
@@ -154,9 +154,7 @@ public class SimplifyWebTestClientCalls extends Recipe {
                         .withArguments(emptyList())
                         .withMethodType(type)
                         .withName(methodInvocation.getName().withType(type));
-
             }
         });
     }
 }
-

--- a/src/test/java/org/openrewrite/java/spring/http/SimplifyWebTestClientCallsTest.java
+++ b/src/test/java/org/openrewrite/java/spring/http/SimplifyWebTestClientCallsTest.java
@@ -35,9 +35,9 @@ class SimplifyWebTestClientCallsTest implements RewriteTest {
         spec
           .recipe(new SimplifyWebTestClientCalls())
           .parser(JavaParser.fromJavaVersion()
-                            .classpathFromResources(new InMemoryExecutionContext(), "spring-web-6", "spring-test-6"))
+            .classpathFromResources(new InMemoryExecutionContext(), "spring-web-6", "spring-test-6"))
           .parser(KotlinParser.builder()
-                              .classpathFromResources(new InMemoryExecutionContext(), "spring-web-6", "spring-test-6"));
+            .classpathFromResources(new InMemoryExecutionContext(), "spring-web-6", "spring-test-6"));
     }
 
     @DocumentExample

--- a/src/test/java/org/openrewrite/java/spring/http/SimplifyWebTestClientCallsTest.java
+++ b/src/test/java/org/openrewrite/java/spring/http/SimplifyWebTestClientCallsTest.java
@@ -15,7 +15,6 @@
  */
 package org.openrewrite.java.spring.http;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
@@ -36,9 +35,9 @@ class SimplifyWebTestClientCallsTest implements RewriteTest {
         spec
           .recipe(new SimplifyWebTestClientCalls())
           .parser(JavaParser.fromJavaVersion()
-            .classpathFromResources(new InMemoryExecutionContext(), "spring-web-6", "spring-test-6"))
+                            .classpathFromResources(new InMemoryExecutionContext(), "spring-web-6", "spring-test-6"))
           .parser(KotlinParser.builder()
-            .classpathFromResources(new InMemoryExecutionContext(), "spring-web-6", "spring-test-6"));
+                              .classpathFromResources(new InMemoryExecutionContext(), "spring-web-6", "spring-test-6"));
     }
 
     @DocumentExample
@@ -165,14 +164,14 @@ class SimplifyWebTestClientCallsTest implements RewriteTest {
     }
 
     @Test
-    @Disabled("Yet to be implemented")
-    void usesIsOkForHttpStatus200() {
+    void usesIsOkForHttpStatusValueOf200() {
         rewriteRun(
           //language=java
           java(
             """
               import org.springframework.test.web.reactive.server.WebTestClient;
               import org.springframework.http.HttpStatus;
+
               class Test {
                   private final WebTestClient webClient = WebTestClient.bindToServer().build();
                   void someMethod() {
@@ -187,6 +186,7 @@ class SimplifyWebTestClientCallsTest implements RewriteTest {
               """,
             """
               import org.springframework.test.web.reactive.server.WebTestClient;
+
               class Test {
                   private final WebTestClient webClient = WebTestClient.bindToServer().build();
                   void someMethod() {
@@ -199,6 +199,101 @@ class SimplifyWebTestClientCallsTest implements RewriteTest {
                   }
               }
               """
+          )
+        );
+    }
+
+    @Test
+    void usesIsOkForHttpStatusValueCodeOf200() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import org.springframework.test.web.reactive.server.WebTestClient;
+              import org.springframework.http.HttpStatusCode;
+
+              class Test {
+                  private final WebTestClient webClient = WebTestClient.bindToServer().build();
+                  void someMethod() {
+                      webClient
+                          .post()
+                          .uri("/some/value")
+                          .exchange()
+                          .expectStatus()
+                          .isEqualTo(HttpStatusCode.valueOf(200));
+                  }
+              }
+              """,
+            """
+              import org.springframework.test.web.reactive.server.WebTestClient;
+
+              class Test {
+                  private final WebTestClient webClient = WebTestClient.bindToServer().build();
+                  void someMethod() {
+                      webClient
+                          .post()
+                          .uri("/some/value")
+                          .exchange()
+                          .expectStatus()
+                          .isOk();
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+      "OK,isOk()",
+      "CREATED,isCreated()",
+      "ACCEPTED,isAccepted()",
+      "NO_CONTENT,isNoContent()",
+      "FOUND,isFound()",
+      "SEE_OTHER,isSeeOther()",
+      "NOT_MODIFIED,isNotModified()",
+      "TEMPORARY_REDIRECT,isTemporaryRedirect()",
+      "PERMANENT_REDIRECT,isPermanentRedirect()",
+      "BAD_REQUEST,isBadRequest()",
+      "UNAUTHORIZED,isUnauthorized()",
+      "FORBIDDEN,isForbidden()",
+      "NOT_FOUND,isNotFound()"
+    })
+    void usesIsOkForHttpStatusValue(String httpStatus, String method) {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import org.springframework.test.web.reactive.server.WebTestClient;
+              import org.springframework.http.HttpStatus;
+
+              class Test {
+                  private final WebTestClient webClient = WebTestClient.bindToServer().build();
+                  void someMethod() {
+                      webClient
+                          .post()
+                          .uri("/some/value")
+                          .exchange()
+                          .expectStatus()
+                          .isEqualTo(HttpStatus.%s);
+                  }
+              }
+              """.formatted(httpStatus),
+            """
+              import org.springframework.test.web.reactive.server.WebTestClient;
+
+              class Test {
+                  private final WebTestClient webClient = WebTestClient.bindToServer().build();
+                  void someMethod() {
+                      webClient
+                          .post()
+                          .uri("/some/value")
+                          .exchange()
+                          .expectStatus()
+                          .%s;
+                  }
+              }
+              """.formatted(method)
           )
         );
     }


### PR DESCRIPTION
`SimplifyWebTestClientCalls` supports only int parameters for `isEqualTo` method.

## What's changed?
This PR adds support for:
- `isEqualTo(HttpStatus.valueOf(200))`
- `isEqualTo(HttpStatusCode.valueOf(200))`
- `isEqualTo(HttpStatus.OK)`

## What's your motivation?
Fix disabled test in `SimplifyWebTestClientCallsTest` and to be feature complete on this recipe.

## Anything in particular you'd like reviewers to focus on?
Probably implementation can be improved but I am not yet familiar with OpenRewrite patterns.

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
none

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
