### PR TITLE
Fix transitivity handling for `commons-codec:commons-codec` in Spring Boot Update 3.2

### DIFF
--- a/src/main/resources/META-INF/rewrite/spring-boot-32.yml
+++ b/src/main/resources/META-INF/rewrite/spring-boot-32.yml
@@ -53,6 +53,7 @@ recipeList:
       artifactId: commons-codec
       version: 1.7.x
       onlyIfUsing: org.apache.commons.codec..*
+      acceptTransitive: true
   - org.openrewrite.java.spring.security6.UpgradeSpringSecurity_6_2
   - org.openrewrite.java.spring.boot3.SpringBootProperties_3_2
   - org.openrewrite.java.spring.framework.UpgradeSpringFramework_6_1


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->
In the Spring Boot 3.2 Upgrade Recipe the dependency `commons-codec:commons-code:1.7.x` was added even if transitively available.

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->
Not overwrite other configuration from Dependency management.

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
