### PR TITLE
Replace micrometer-spring-legacy with spring-boot-starter-actuator

### DIFF
--- a/src/main/resources/META-INF/rewrite/spring-boot-20.yml
+++ b/src/main/resources/META-INF/rewrite/spring-boot-20.yml
@@ -70,6 +70,7 @@ recipeList:
   - org.openrewrite.java.spring.boot2.MigrateErrorControllerPackageName
   - org.openrewrite.java.spring.boot2.MigrateHibernateConstraintsToJavax
   - org.openrewrite.java.spring.boot2.MigrateLocalServerPortAnnotation
+  - org.openrewrite.java.spring.boot2.MaybeAddSpringBootStarterActuator
   # Update properties
   - org.openrewrite.java.spring.boot2.SpringBootProperties_2_0
   - org.openrewrite.java.spring.ChangeSpringPropertyValue:
@@ -168,3 +169,20 @@ recipeList:
       artifactId: validation-api
       version: 2.x
       onlyIfUsing: org.hibernate.validator.constraints.*
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.spring.boot2.MaybeAddSpringBootStarterActuator
+displayName: Replace `micrometer-spring-legacy` with `spring-boot-starter-actuator`
+description: Replace deprecated `micrometer-spring-legacy` with `spring-boot-starter-actuator`
+preconditions:
+  - org.openrewrite.java.dependencies.DependencyInsight:
+      groupIdPattern: io.micrometer
+      artifactIdPattern: micrometer-spring-legacy
+recipeList:
+  - org.openrewrite.java.dependencies.RemoveDependency:
+      groupId: io.micrometer
+      artifactId: micrometer-spring-legacy
+  - org.openrewrite.java.dependencies.AddDependency:
+      groupId: org.springframework.boot
+      artifactId: spring-boot-starter-actuator
+      version: 2.0.x


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
Replace deprecated `micrometer-spring-legacy` with `spring-boot-starter-actuator` when upgrading to Spring Boot 2.

## What's your motivation?
- Fixes #673

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->
It's a simple addition of just a yaml definition, but should there be tests?

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
