### PR TITLE
Spring Boot 3, Jakarta EE 9 regression

### DIFF
--- a/src/main/resources/META-INF/rewrite/spring-boot-30.yml
+++ b/src/main/resources/META-INF/rewrite/spring-boot-30.yml
@@ -60,7 +60,7 @@ recipeList:
   - org.openrewrite.gradle.UpdateGradleWrapper:
       version: ^7.4
       addIfMissing: false
-  - org.openrewrite.java.migrate.jakarta.JavaxMigrationToJakarta
+  - org.openrewrite.java.migrate.jakarta.JakartaEE10
   - org.openrewrite.java.spring.boot3.RemoveConstructorBindingAnnotation
   - org.openrewrite.java.spring.boot2.MoveAutoConfigurationToImportsFile
   - org.openrewrite.java.spring.boot3.ActuatorEndpointSanitization


### PR DESCRIPTION
## What's changed?

Since PR https://github.com/openrewrite/rewrite-migrate-java/pull/674, the recipe JavaxMigrationToJakarta update to Jakarta 9 and not 10

## What's your motivation?

Spring Boot 3 is Jakarta 10

## Anything in particular you'd like reviewers to focus on?

None

## Anyone you would like to review specifically?

None

## Have you considered any alternatives or workarounds?

No, it's the best option 😄 

## Any additional context

No

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
