### PR TITLE
Adjust expectation as seen in CI

### DIFF
--- a/src/testWithSpringBoot_2_7/java/org/openrewrite/java/spring/security5/AuthorizeHttpRequestsTest.java
+++ b/src/testWithSpringBoot_2_7/java/org/openrewrite/java/spring/security5/AuthorizeHttpRequestsTest.java
@@ -121,7 +121,7 @@ class AuthorizeHttpRequestsTest implements RewriteTest {
               public class JdbcSecurityConfiguration {
                   @Bean
                   SecurityFilterChain web(HttpSecurity http) throws Exception {
-                      AuthorizationManagerRequestMatcherRegistry reqs = http.authorizeHttpRequests();
+                      AuthorizeHttpRequestsConfigurer.AuthorizationManagerRequestMatcherRegistry reqs = http.authorizeHttpRequests();
                       reqs.antMatchers("/ll").authenticated();
                       return http.build();
                   }


### PR DESCRIPTION
This seems wrong; we're not seeing a matching import, as that import is qualified; Either the import should change too, or this PR should not be necessary. Any insights as to recent related changes @knutwannheden ? I think I saw something come by.