### PR TITLE
Add KafkaFailureCallback handler

### DIFF
--- a/src/main/java/org/openrewrite/java/spring/util/concurrent/SuccessFailureCallbackToBiConsumerVisitor.java
+++ b/src/main/java/org/openrewrite/java/spring/util/concurrent/SuccessFailureCallbackToBiConsumerVisitor.java
@@ -15,13 +15,18 @@
  */
 package org.openrewrite.java.spring.util.concurrent;
 
+import lombok.AllArgsConstructor;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.JavaTemplate;
 import org.openrewrite.java.MethodMatcher;
 import org.openrewrite.java.spring.util.MemberReferenceToMethodInvocation;
+import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.staticanalysis.RemoveUnneededBlock;
+
+import java.util.Objects;
+import java.util.regex.Pattern;
 
 class SuccessFailureCallbackToBiConsumerVisitor extends JavaIsoVisitor<ExecutionContext> {
 
@@ -29,6 +34,9 @@ class SuccessFailureCallbackToBiConsumerVisitor extends JavaIsoVisitor<Execution
             "org.springframework.util.concurrent.ListenableFuture addCallback(" +
             "org.springframework.util.concurrent.SuccessCallback, " +
             "org.springframework.util.concurrent.FailureCallback)");
+    private static final String FQN_KAFKA_FAILURE_CALLBACK = "org.springframework.kafka.core.KafkaFailureCallback";
+    private static final MethodMatcher GET_FAILED_PRODUCER_RECORD = new MethodMatcher("org.springframework.kafka.core.KafkaProducerException getFailedProducerRecord()");
+    private static final String FQN_KAFKA_PRODUCER_EXCEPTION = "org.springframework.kafka.core.KafkaProducerException";
 
     @Override
     public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
@@ -37,7 +45,16 @@ class SuccessFailureCallbackToBiConsumerVisitor extends JavaIsoVisitor<Execution
             mi = (J.MethodInvocation) new MemberReferenceToMethodInvocation().visitNonNull(mi, ctx, getCursor().getParent());
 
             J.Lambda successCallback = (J.Lambda) mi.getArguments().get(0);
-            J.Lambda failureCallback = (J.Lambda) mi.getArguments().get(1);
+
+            boolean isKafkaFailureCallback = false;
+            J.Lambda failureCallback;
+            if (mi.getArguments().get(1) instanceof J.TypeCast) {
+                // In this case, assume it's casted to `org.springframework.kafka.core.KafkaFailureCallback` only
+                failureCallback = (J.Lambda) ((J.TypeCast) mi.getArguments().get(1)).getExpression();
+                isKafkaFailureCallback = true;
+            } else {
+                failureCallback = (J.Lambda) mi.getArguments().get(1);
+            }
 
             J.Identifier successParam = ((J.VariableDeclarations) successCallback.getParameters().getParameters().get(0)).getVariables().get(0).getName();
             J.Identifier failureParam = ((J.VariableDeclarations) failureCallback.getParameters().getParameters().get(0)).getVariables().get(0).getName();
@@ -56,8 +73,34 @@ class SuccessFailureCallbackToBiConsumerVisitor extends JavaIsoVisitor<Execution
                             successCallback.getBody(),
                             failureCallback.getBody());
 
-            return (J.MethodInvocation) new RemoveUnneededBlock().getVisitor().visitNonNull(whenComplete, ctx, getCursor().getParent());
+            whenComplete = (J.MethodInvocation) new RemoveUnneededBlock().getVisitor().visitNonNull(whenComplete, ctx, getCursor().getParent());
+            if (isKafkaFailureCallback) {
+                J.Lambda biConsumer = (J.Lambda) whenComplete.getArguments().get(0);
+                doAfterVisit(new MigrateKafkaProducerExceptionVisitor(((J.VariableDeclarations) biConsumer.getParameters().getParameters().get(1)).getVariables().get(0).getName()));
+                maybeRemoveImport(FQN_KAFKA_FAILURE_CALLBACK);
+            }
+            return whenComplete;
         }
         return mi;
+    }
+
+    @AllArgsConstructor
+    public static class MigrateKafkaProducerExceptionVisitor extends JavaIsoVisitor<ExecutionContext> {
+        private Expression name;
+
+        @Override
+        public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext executionContext) {
+            method = super.visitMethodInvocation(method, executionContext);
+            if (GET_FAILED_PRODUCER_RECORD.matches(method) && Objects.equals(method.getSelect().printTrimmed(), name.printTrimmed())) {
+                maybeAddImport(FQN_KAFKA_PRODUCER_EXCEPTION, null,false);
+
+                return JavaTemplate.builder("((KafkaProducerException)#{any(org.springframework.kafka.core.KafkaProducerException)}).getFailedProducerRecord()")
+                    .imports(FQN_KAFKA_PRODUCER_EXCEPTION)
+                    .build()
+                    .apply(getCursor(), method.getCoordinates().replace(), name);
+            } else {
+                return method;
+            }
+        }
     }
 }

--- a/src/test/java/org/openrewrite/java/spring/util/concurrent/ListenableToCompletableFutureTest.java
+++ b/src/test/java/org/openrewrite/java/spring/util/concurrent/ListenableToCompletableFutureTest.java
@@ -50,7 +50,7 @@ class ListenableToCompletableFutureTest implements RewriteTest {
                           public void onSuccess(String result) {
                               System.out.println(result);
                           }
-              
+
                           @Override
                           public void onFailure(Throwable ex) {
                               System.err.println(ex.getMessage());
@@ -61,7 +61,7 @@ class ListenableToCompletableFutureTest implements RewriteTest {
               """,
             """
               import java.util.concurrent.CompletableFuture;
-              
+
               class A {
                   void test(CompletableFuture<String> future) {
                       future.whenComplete((String result, Throwable ex) -> {
@@ -89,14 +89,14 @@ class ListenableToCompletableFutureTest implements RewriteTest {
               class A {
                   void test(ListenableFuture<String> future) {
                       future.addCallback(new ListenableFutureCallback<String>() {
-              
+
                           private final String field = "value";
-              
+
                           @Override
                           public void onSuccess(String result) {
                               System.out.println(result);
                           }
-              
+
                           @Override
                           public void onFailure(Throwable ex) {
                               System.err.println(ex.getMessage());
@@ -108,13 +108,13 @@ class ListenableToCompletableFutureTest implements RewriteTest {
             """
               import java.util.concurrent.CompletableFuture;
               import java.util.function.BiConsumer;
-              
+
               class A {
                   void test(CompletableFuture<String> future) {
                       future.whenComplete(new BiConsumer<String, Throwable>() {
-              
+
                           private final String field = "value";
-              
+
                           @Override
                           public void accept(String result, Throwable ex) {
                               if (ex == null) {
@@ -138,13 +138,13 @@ class ListenableToCompletableFutureTest implements RewriteTest {
           java(
             """
               import org.springframework.util.concurrent.ListenableFutureCallback;
-              
+
               class MyCallback implements ListenableFutureCallback<String> {
                   @Override
                   public void onSuccess(String result) {
                       System.out.println(result);
                   }
-              
+
                   @Override
                   public void onFailure(Throwable ex) {
                       System.err.println(ex.getMessage());
@@ -178,9 +178,9 @@ class ListenableToCompletableFutureTest implements RewriteTest {
               """,
             """
               import org.springframework.util.concurrent.ListenableFutureCallback;
-              
+
               import java.util.concurrent.CompletableFuture;
-              
+
               class A {
                   void test(CompletableFuture<String> future) {
                       future.whenComplete(new MyCallback());
@@ -208,7 +208,7 @@ class ListenableToCompletableFutureTest implements RewriteTest {
               """,
             """
               import java.util.concurrent.CompletableFuture;
-              
+
               class A {
                   void test(CompletableFuture<String> future) {
                       future.whenComplete((string, ex) -> {
@@ -245,7 +245,7 @@ class ListenableToCompletableFutureTest implements RewriteTest {
               """,
             """
               import java.util.concurrent.CompletableFuture;
-              
+
               class A {
                   void test(CompletableFuture<String> future) {
                       future.whenComplete((string, ex) -> {
@@ -267,7 +267,9 @@ class ListenableToCompletableFutureTest implements RewriteTest {
     void addSuccessFailureCallbackWithTypeCast() {
         //language=java
         rewriteRun(
-            spec -> spec.typeValidationOptions(TypeValidation.builder().methodInvocations(false).build()).afterTypeValidationOptions(TypeValidation.none()),
+            spec -> spec
+              .typeValidationOptions(TypeValidation.all().methodInvocations(false))
+              .afterTypeValidationOptions(TypeValidation.all().identifiers(false)),
             java(
                 """
                   import org.springframework.util.concurrent.ListenableFuture;
@@ -290,7 +292,7 @@ class ListenableToCompletableFutureTest implements RewriteTest {
                   import org.springframework.kafka.core.KafkaProducerException;
 
                   import java.util.concurrent.CompletableFuture;
-                  
+
                   class Example {
                       void test(CompletableFuture<String> future) {
                           future.whenComplete((string, ex) -> {


### PR DESCRIPTION
## What's changed?
Handle a corner case of using `KafkaFailureCallback` in `ListenableFuture`

### Checklist
- [X] I've added unit tests to cover both positive and negative cases
- [X] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [X] I've used the IntelliJ IDEA auto-formatter on affected files
