### PR TITLE
Add Recipe to migrate `org.springframework.web.reactive.HandlerResult.hasExceptionHandler` to `getExceptionHandler()` method

### DIFF
--- a/src/main/java/org/openrewrite/java/spring/framework/MigrateHandlerResultHasExceptionHandlerMethod.java
+++ b/src/main/java/org/openrewrite/java/spring/framework/MigrateHandlerResultHasExceptionHandlerMethod.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.spring.framework;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Preconditions;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.JavaTemplate;
+import org.openrewrite.java.JavaVisitor;
+import org.openrewrite.java.MethodMatcher;
+import org.openrewrite.java.search.UsesType;
+import org.openrewrite.java.tree.J;
+
+public class MigrateHandlerResultHasExceptionHandlerMethod extends Recipe {
+
+    private static final String HandlerResult = "org.springframework.web.reactive.HandlerResult";
+
+    private static final MethodMatcher METHOD_MATCHER = new MethodMatcher(HandlerResult + " hasExceptionHandler()");
+
+    private static final JavaTemplate replacementTemplate = JavaTemplate
+        .builder("#{any(org.springframework.web.reactive.HandlerResult)}.getExceptionHandler() != null")
+        .build();
+
+    @Override
+    public String getDisplayName() {
+        return "Migrate `org.springframework.web.reactive.HandlerResult.hasExceptionHandler` method";
+    }
+
+    @Override
+    public String getDescription() {
+        return "`org.springframework.web.reactive.HandlerResult.hasExceptionHandler()` was deprecated, in favor of `getExceptionHandler()`.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return Preconditions.check(new UsesType<>(HandlerResult, false), new JavaVisitor<ExecutionContext>() {
+
+            @Override
+            public J visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
+                J.MethodInvocation mi = (J.MethodInvocation) super.visitMethodInvocation(method, ctx);
+                if (METHOD_MATCHER.matches(mi)) {
+                    return replacementTemplate.apply(getCursor(), mi.getCoordinates().replace(), mi.getSelect());
+                }
+                return mi;
+            }
+        });
+    }
+}

--- a/src/test/java/org/openrewrite/java/spring/framework/MigrateHandlerResultHasExceptionHandlerMethodTest.java
+++ b/src/test/java/org/openrewrite/java/spring/framework/MigrateHandlerResultHasExceptionHandlerMethodTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.spring.framework;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.InMemoryExecutionContext;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+import org.openrewrite.test.TypeValidation;
+
+import static org.openrewrite.java.Assertions.java;
+
+class MigrateHandlerResultHasExceptionHandlerMethodTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec
+            .typeValidationOptions(TypeValidation.none())
+            .recipe(new MigrateHandlerResultHasExceptionHandlerMethod())
+            .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(),
+                "reactor-core-3.6.+", "spring-webflux-6.1.+"));
+    }
+
+    @DocumentExample
+    @Test
+    void migrateHandlerResultHasExceptionHandlerMethodWithinIfStatement() {
+        rewriteRun(
+            // language=java
+            java(
+                """
+                    import org.springframework.web.reactive.HandlerResult;
+                    class MyHandler {
+                        void configureHandler(HandlerResult result) {
+                            if (result.hasExceptionHandler()) {
+                                // do something
+                            }
+                        }
+                    }
+                    """,
+                """
+                    import org.springframework.web.reactive.HandlerResult;
+                    class MyHandler {
+                        void configureHandler(HandlerResult result) {
+                            if (result.getExceptionHandler() != null) {
+                                // do something
+                            }
+                        }
+                    }
+                    """
+            )
+        );
+    }
+
+    @Test
+    void migrateHandlerResultHasExceptionHandlerMethodWithinWithinVariableDeclaration() {
+        rewriteRun(
+          // language=java
+          java(
+            """
+                import org.springframework.web.reactive.HandlerResult;
+                class MyHandler {
+                    void configureHandler(HandlerResult result) {
+                        boolean b = result.hasExceptionHandler();
+                    }
+                }
+                """,
+            """
+                import org.springframework.web.reactive.HandlerResult;
+                class MyHandler {
+                    void configureHandler(HandlerResult result) {
+                        boolean b = result.getExceptionHandler() != null;
+                    }
+                }
+                """
+          )
+        );
+    }
+
+    @Test
+    void migrateHandlerResultHasExceptionHandlerMethodWithinMethod() {
+        rewriteRun(
+          // language=java
+          java(
+            """
+              import org.springframework.web.reactive.HandlerResult;
+              class MyHandler {
+                  void configureHandler(HandlerResult result) {
+                      set(result.hasExceptionHandler(), "foo");
+                  }
+
+                  void set(boolean b, String s) {
+                      // do something
+                  }
+              }
+              """,
+            """
+                import org.springframework.web.reactive.HandlerResult;
+                class MyHandler {
+                    void configureHandler(HandlerResult result) {
+                        set(result.getExceptionHandler() != null, "foo");
+                    }
+
+                    void set(boolean b, String s) {
+                        // do something
+                    }
+                }
+                """
+          )
+        );
+    }
+}


### PR DESCRIPTION
…andler` method to `getExceptionHandler()`

<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->
Addresses part of https://github.com/openrewrite/rewrite-spring/issues/627

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
