### PR TITLE
Fix MergeYaml, J.Identifier, JavaType.Method constructor calls

### DIFF
--- a/src/main/java/org/openrewrite/java/spring/AddSpringProperty.java
+++ b/src/main/java/org/openrewrite/java/spring/AddSpringProperty.java
@@ -140,7 +140,7 @@ public class AddSpringProperty extends Recipe {
         } else {
             yaml.append(" ").append(value);
         }
-        return new MergeYaml("$", yaml.toString(), true, null, null, null, null);
+        return new MergeYaml("$", yaml.toString(), true, null, null, null, null, null);
     }
 
     private static final Pattern scalarNeedsAQuote = Pattern.compile("[^a-zA-Z\\d\\s]*");

--- a/src/main/java/org/openrewrite/java/spring/boot2/ConvertToSecurityDslVisitor.java
+++ b/src/main/java/org/openrewrite/java/spring/boot2/ConvertToSecurityDslVisitor.java
@@ -295,7 +295,7 @@ public class ConvertToSecurityDslVisitor<P> extends JavaIsoVisitor<P> {
     private J.MethodInvocation createDefaultsCall() {
         JavaType.Method methodType = new JavaType.Method(null, 9, CUSTOMIZER_SHALLOW_TYPE, "withDefaults",
                 new JavaType.GenericTypeVariable(null, "T", JavaType.GenericTypeVariable.Variance.INVARIANT, null),
-                null, null, null, null);
+                null, null, null, null, Collections.emptyList(), Collections.emptyList());
         maybeAddImport(methodType.getDeclaringType().getFullyQualifiedName(), methodType.getName());
         return new J.MethodInvocation(Tree.randomId(), Space.EMPTY, Markers.EMPTY, null, null,
                 new J.Identifier(Tree.randomId(), Space.EMPTY, Markers.EMPTY, emptyList(), "withDefaults", null, null),

--- a/src/main/java/org/openrewrite/java/spring/boot2/MigrateDatabaseCredentials.java
+++ b/src/main/java/org/openrewrite/java/spring/boot2/MigrateDatabaseCredentials.java
@@ -90,8 +90,8 @@ public class MigrateDatabaseCredentials extends Recipe {
             }, new YamlVisitor<ExecutionContext>() {
                 @Override
                 public Yaml visitDocuments(Yaml.Documents documents, ExecutionContext ctx) {
-                    doAfterVisit(new MergeYaml("$.spring." + tool, "username: ${spring.datasource.username}", true, null, null, null, null).getVisitor());
-                    doAfterVisit(new MergeYaml("$.spring." + tool, "password: ${spring.datasource.password}", true, null, null, null, null).getVisitor());
+                    doAfterVisit(new MergeYaml("$.spring." + tool, "username: ${spring.datasource.username}", true, null, null, null, null, null).getVisitor());
+                    doAfterVisit(new MergeYaml("$.spring." + tool, "password: ${spring.datasource.password}", true, null, null, null, null, null).getVisitor());
                     doAfterVisit(new CoalesceProperties().getVisitor());
                     return documents;
                 }

--- a/src/main/java/org/openrewrite/java/spring/data/JdbcTemplateQueryForLongMigration.java
+++ b/src/main/java/org/openrewrite/java/spring/data/JdbcTemplateQueryForLongMigration.java
@@ -23,6 +23,7 @@ import org.openrewrite.java.tree.*;
 import org.openrewrite.marker.Markers;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 public class JdbcTemplateQueryForLongMigration extends Recipe {
@@ -72,6 +73,7 @@ public class JdbcTemplateQueryForLongMigration extends Recipe {
                                 Tree.randomId(),
                                 Space.EMPTY,
                                 Markers.EMPTY,
+                                Collections.emptyList(),
                                 "Long",
                                 JavaType.ShallowClass.build("java.lang.Long"),
                                 null
@@ -82,6 +84,7 @@ public class JdbcTemplateQueryForLongMigration extends Recipe {
                                         Tree.randomId(),
                                         Space.EMPTY,
                                         Markers.EMPTY,
+                                        Collections.emptyList(),
                                         "class",
                                         JavaType.ShallowClass.build("java.lang.Class"),
                                         null),

--- a/src/main/java/org/openrewrite/java/spring/table/ApiCalls.java
+++ b/src/main/java/org/openrewrite/java/spring/table/ApiCalls.java
@@ -25,8 +25,7 @@ import org.openrewrite.Recipe;
 public class ApiCalls extends DataTable<ApiCalls.Row> {
 
     public ApiCalls(Recipe recipe) {
-        super(recipe, Row.class, ApiCalls.class.getName(),
-                "API endpoints", "The API endpoints that applications expose.");
+        super(recipe, "API endpoints", "The API endpoints that applications expose.");
     }
 
     @Value

--- a/src/main/java/org/openrewrite/java/spring/table/ApiEndpoints.java
+++ b/src/main/java/org/openrewrite/java/spring/table/ApiEndpoints.java
@@ -25,8 +25,7 @@ import org.openrewrite.Recipe;
 public class ApiEndpoints extends DataTable<ApiEndpoints.Row> {
 
     public ApiEndpoints(Recipe recipe) {
-        super(recipe, Row.class, ApiEndpoints.class.getName(),
-                "API endpoints", "The API endpoints that applications expose.");
+        super(recipe, "API endpoints", "The API endpoints that applications expose.");
     }
 
     @Value

--- a/src/main/java/org/openrewrite/java/spring/table/SpringComponentRelationships.java
+++ b/src/main/java/org/openrewrite/java/spring/table/SpringComponentRelationships.java
@@ -25,7 +25,7 @@ import org.openrewrite.Recipe;
 public class SpringComponentRelationships extends DataTable<SpringComponentRelationships.Row> {
 
     public SpringComponentRelationships(Recipe recipe) {
-        super(recipe, Row.class, SpringComponentRelationships.class.getName(),
+        super(recipe,
                 "Relationships between Spring components",
                 "A table of relationships between Spring components.");
     }

--- a/src/main/java/org/openrewrite/java/spring/table/SpringComponents.java
+++ b/src/main/java/org/openrewrite/java/spring/table/SpringComponents.java
@@ -25,8 +25,7 @@ import org.openrewrite.Recipe;
 public class SpringComponents extends DataTable<SpringComponents.Row> {
 
     public SpringComponents(Recipe recipe) {
-        super(recipe, Row.class, SpringComponents.class.getName(),
-                "Spring component definitions",
+        super(recipe, "Spring component definitions",
                 "Classes defined with a form of a Spring `@Component` stereotype and types returned from `@Bean` annotated methods.");
     }
 


### PR DESCRIPTION
## What's changed?

Adapting code to changes in upstream constructors done in https://github.com/openrewrite/rewrite/pull/5324

## What's your motivation?

Fix broken CI.
