### PR TITLE
Fixed the ClassCastException in MergeBootstrapYamlWithApplicationYaml recipe

### DIFF
--- a/src/main/java/org/openrewrite/java/spring/boot2/MergeBootstrapYamlWithApplicationYaml.java
+++ b/src/main/java/org/openrewrite/java/spring/boot2/MergeBootstrapYamlWithApplicationYaml.java
@@ -59,9 +59,9 @@ public class MergeBootstrapYamlWithApplicationYaml extends ScanningRecipe<MergeB
                 }
                 SourceFile source = (SourceFile) tree;
                 Path sourcePath = source.getSourcePath();
-                if (acc.getBootstrapYaml() == null && PathUtils.matchesGlob(sourcePath, "**/main/resources/bootstrap.y?ml")) {
+                if (acc.getBootstrapYaml() == null && PathUtils.matchesGlob(sourcePath, "**/main/resources/bootstrap.y*ml")) {
                     acc.setBootstrapYaml(source);
-                } else if (acc.getApplicationYaml() == null && PathUtils.matchesGlob(sourcePath, "**/main/resources/application.y?ml")) {
+                } else if (acc.getApplicationYaml() == null && PathUtils.matchesGlob(sourcePath, "**/main/resources/application.y*ml")) {
                     acc.setApplicationYaml(source);
                 }
                 return source;

--- a/src/testWithSpringBoot_2_4/java/org/openrewrite/java/spring/boot2/MergeBootstrapYamlWithApplicationYamlTest.java
+++ b/src/testWithSpringBoot_2_4/java/org/openrewrite/java/spring/boot2/MergeBootstrapYamlWithApplicationYamlTest.java
@@ -31,7 +31,7 @@ class MergeBootstrapYamlWithApplicationYamlTest implements RewriteTest {
     }
 
     @Test
-    void mergeBootstrap() {
+    void mergeBootstrapYAML() {
         rewriteRun(
           srcMainResources(
             //language=yaml
@@ -52,6 +52,33 @@ class MergeBootstrapYamlWithApplicationYamlTest implements RewriteTest {
                 """,
               null,
               spec -> spec.path("bootstrap.yaml")
+            )
+          )
+        );
+    }
+
+    @Test
+    void mergeBootstrapYML() {
+        rewriteRun(
+          srcMainResources(
+            //language=yaml
+            yaml(
+              """
+                spring.application.name: main
+                """,
+              """
+                spring.application.name: main
+                name: test
+                """,
+              spec -> spec.path("application.yml")
+            ),
+            //language=yaml
+            yaml(
+              """
+                name: test
+                """,
+              null,
+              spec -> spec.path("bootstrap.yml")
             )
           )
         );


### PR DESCRIPTION
## What's changed?
There was a ClassCastException in this recipe when running on platform against some spring projects. 

## What's your motivation?
The existing test was failing when I undo the disabling. Fixed the test, added some more tests + adapted the behaviour to correspond with the tests. 

### Checklist
- [X] I've added unit tests to cover both positive and negative cases
- [X] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [X] I've used the IntelliJ IDEA auto-formatter on affected files
