### PR TITLE
Added a precondition to MigrateWebMvcTagsToObservationConvention

### DIFF
--- a/src/main/java/org/openrewrite/java/spring/boot3/MigrateWebMvcTagsToObservationConvention.java
+++ b/src/main/java/org/openrewrite/java/spring/boot3/MigrateWebMvcTagsToObservationConvention.java
@@ -24,6 +24,7 @@ import org.openrewrite.java.JavaParser;
 import org.openrewrite.java.JavaTemplate;
 import org.openrewrite.java.JavaVisitor;
 import org.openrewrite.java.MethodMatcher;
+import org.openrewrite.java.search.DeclaresMethod;
 import org.openrewrite.java.search.FindImplementations;
 import org.openrewrite.java.tree.*;
 
@@ -44,6 +45,7 @@ public class MigrateWebMvcTagsToObservationConvention extends Recipe {
     private static final String WEBMVCTAGS_FQ = "org.springframework.boot.actuate.metrics.web.servlet.WebMvcTags";
     private static final String WEBMVCTAGSPROVIDER_FQ = "org.springframework.boot.actuate.metrics.web.servlet.WebMvcTagsProvider";
     private static final MethodMatcher GET_TAGS = new MethodMatcher("* getTags(jakarta.servlet.http.HttpServletRequest, jakarta.servlet.http.HttpServletResponse, java.lang.Object, java.lang.Throwable)");
+    private static final MethodMatcher GET_LONG_REQUEST_TAGS = new MethodMatcher("* getLongRequestTags(jakarta.servlet.http.HttpServletRequest, java.lang.Object)");
     private static final MethodMatcher GET_HIGH_CARD_KEY_VALUES = new MethodMatcher("* getHighCardinalityKeyValues(org.springframework.http.server.observation.ServerRequestObservationContext)");
     private static final MethodMatcher TAG_OF = new MethodMatcher("io.micrometer.core.instrument.Tag of(java.lang.String, java.lang.String)");
     private static final MethodMatcher TAGS_AND_STRING_STRING = new MethodMatcher("io.micrometer.core.instrument.Tags and(java.lang.String, java.lang.String)");
@@ -68,229 +70,234 @@ public class MigrateWebMvcTagsToObservationConvention extends Recipe {
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
-        return Preconditions.check(new FindImplementations(WEBMVCTAGSPROVIDER_FQ), new JavaVisitor<ExecutionContext>() {
-            @Override
-            public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration classDecl, ExecutionContext ctx) {
-                J.MethodDeclaration getTagsMethod = null;
-                List<Statement> getTagsBodyStatements = new ArrayList<>();
-                for (Statement stmt : classDecl.getBody().getStatements()) {
-                    if (stmt instanceof J.MethodDeclaration) {
-                        J.MethodDeclaration md = (J.MethodDeclaration) stmt;
-                        if (GET_TAGS.matches(md, classDecl)) {
-                            getTagsMethod = md;
-                            if (getTagsMethod.getBody() != null) {
-                                getTagsBodyStatements.addAll(getTagsMethod.getBody().getStatements().subList(0, getTagsMethod.getBody().getStatements().size() - 1));
-                                Statement ret = getTagsMethod.getBody().getStatements().get(getTagsMethod.getBody().getStatements().size() - 1);
-                                if (ret instanceof J.Return && ((J.Return) ret).getExpression() instanceof J.MethodInvocation) {
-                                    if (TAGS_OF_ANY.matches(((J.Return) ret).getExpression())) {
-                                        getTagsBodyStatements.add((Statement) ((J.Return) ret).getExpression());
+        return Preconditions.check(
+                Preconditions.and(
+                        new FindImplementations(WEBMVCTAGSPROVIDER_FQ).getVisitor(),
+                        Preconditions.not(new DeclaresMethod<>(GET_LONG_REQUEST_TAGS)
+                        )),
+                new JavaVisitor<ExecutionContext>() {
+                    @Override
+                    public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration classDecl, ExecutionContext ctx) {
+                        J.MethodDeclaration getTagsMethod = null;
+                        List<Statement> getTagsBodyStatements = new ArrayList<>();
+                        for (Statement stmt : classDecl.getBody().getStatements()) {
+                            if (stmt instanceof J.MethodDeclaration) {
+                                J.MethodDeclaration md = (J.MethodDeclaration) stmt;
+                                if (GET_TAGS.matches(md, classDecl)) {
+                                    getTagsMethod = md;
+                                    if (getTagsMethod.getBody() != null) {
+                                        getTagsBodyStatements.addAll(getTagsMethod.getBody().getStatements().subList(0, getTagsMethod.getBody().getStatements().size() - 1));
+                                        Statement ret = getTagsMethod.getBody().getStatements().get(getTagsMethod.getBody().getStatements().size() - 1);
+                                        if (ret instanceof J.Return && ((J.Return) ret).getExpression() instanceof J.MethodInvocation) {
+                                            if (TAGS_OF_ANY.matches(((J.Return) ret).getExpression())) {
+                                                getTagsBodyStatements.add((Statement) ((J.Return) ret).getExpression());
+                                            }
+                                        }
+                                        break;
                                     }
+
                                 }
-                                break;
                             }
-
                         }
-                    }
-                }
 
-                String tmpl = "class " + classDecl.getSimpleName() + " extends DefaultServerRequestObservationConvention {\n" +
-                              "    @Override\n" +
-                              "    public KeyValues getHighCardinalityKeyValues(ServerRequestObservationContext context) {\n" +
-                              "        KeyValues values = super.getHighCardinalityKeyValues(context);\n" +
-                              "        return values;" +
-                              "    }\n" +
-                              "}";
-                J.ClassDeclaration newClassDeclaration = JavaTemplate.builder(tmpl)
-                        .contextSensitive()
-                        .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "micrometer-commons-1.11.+", "spring-web-6.+", "jakarta.servlet-api"))
-                        .imports(DEFAULTSERVERREQUESTOBSERVATIONCONVENTION_FQ, KEYVALUES_FQ, HTTPSERVLETREQUEST_FQ, HTTPSERVLETRESPONSE_FQ, SERVERREQUESTOBSERVATIONCONVENTION_FQ)
-                        .build()
-                        .apply(getCursor(), classDecl.getCoordinates().replace());
-
-                J.ClassDeclaration finalNewClassDeclaration = newClassDeclaration;
-                final J.MethodDeclaration finalGetTagsMethod = getTagsMethod;
-                newClassDeclaration = newClassDeclaration
-                        .withId(classDecl.getId())
-                        .withLeadingAnnotations(classDecl.getLeadingAnnotations())
-                        .withModifiers(classDecl.getModifiers())
-                        .withPrefix(classDecl.getPrefix())
-                        .withBody(newClassDeclaration.getBody().withStatements(ListUtils.map(classDecl.getBody().getStatements(), stmt -> {
-                            if (stmt.equals(finalGetTagsMethod)) {
-                                J.MethodDeclaration md = (J.MethodDeclaration) finalNewClassDeclaration.getBody().getStatements().get(0);
-                                md = md.withPrefix(stmt.getPrefix());
-                                //noinspection DataFlowIssue
-                                return md.withBody(md.getBody().withStatements(ListUtils.insertAll(md.getBody().getStatements(), md.getBody().getStatements().size() - 1, getTagsBodyStatements)));
-                            }
-                            return stmt;
-                        })));
-                maybeAddImport(DEFAULTSERVERREQUESTOBSERVATIONCONVENTION_FQ);
-                maybeAddImport(KEYVALUE_FQ);
-                maybeAddImport(KEYVALUES_FQ);
-                maybeAddImport(SERVERREQUESTOBSERVATIONCONVENTION_FQ);
-                maybeRemoveImport(HTTPSERVLETREQUEST_FQ);
-                maybeRemoveImport(HTTPSERVLETRESPONSE_FQ);
-                maybeRemoveImport(TAG_FQ);
-                maybeRemoveImport(TAGS_FQ);
-                maybeRemoveImport(WEBMVCTAGS_FQ);
-                maybeRemoveImport(WEBMVCTAGSPROVIDER_FQ);
-                updateCursor(newClassDeclaration);
-                return (J.ClassDeclaration) super.visitClassDeclaration(newClassDeclaration, ctx);
-            }
-
-            @Override
-            public J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration method, ExecutionContext ctx) {
-                J.MethodDeclaration m = (J.MethodDeclaration) super.visitMethodDeclaration(method, ctx);
-                J.ClassDeclaration cd = getCursor().firstEnclosing(J.ClassDeclaration.class);
-                if (cd != null && GET_HIGH_CARD_KEY_VALUES.matches(m, cd)) {
-                    J.VariableDeclarations methodParam = (J.VariableDeclarations) m.getParameters().get(0);
-                    J.Identifier methodParamIdentifier = methodParam.getVariables().get(0).getName();
-                    Boolean addHttpServletResponse = getCursor().pollMessage("addHttpServletResponse");
-                    Boolean addHttpServletRequest = getCursor().pollMessage("addHttpServletRequest");
-                    if (Boolean.TRUE.equals(addHttpServletResponse) && m.getBody() != null) {
-                        m = JavaTemplate.builder("HttpServletResponse response = #{any()}.getResponse();")
-                                .imports(HTTPSERVLETRESPONSE_FQ)
-                                .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "jakarta.servlet-api", "spring-web-6.+", "micrometer-observation-1.11.+"))
+                        String tmpl = "class " + classDecl.getSimpleName() + " extends DefaultServerRequestObservationConvention {\n" +
+                                "    @Override\n" +
+                                "    public KeyValues getHighCardinalityKeyValues(ServerRequestObservationContext context) {\n" +
+                                "        KeyValues values = super.getHighCardinalityKeyValues(context);\n" +
+                                "        return values;" +
+                                "    }\n" +
+                                "}";
+                        J.ClassDeclaration newClassDeclaration = JavaTemplate.builder(tmpl)
+                                .contextSensitive()
+                                .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "micrometer-commons-1.11.+", "spring-web-6.+", "jakarta.servlet-api"))
+                                .imports(DEFAULTSERVERREQUESTOBSERVATIONCONVENTION_FQ, KEYVALUES_FQ, HTTPSERVLETREQUEST_FQ, HTTPSERVLETRESPONSE_FQ, SERVERREQUESTOBSERVATIONCONVENTION_FQ)
                                 .build()
-                                .apply(updateCursor(m), m.getBody().getCoordinates().firstStatement(), methodParamIdentifier);
-                    }
-                    if (Boolean.TRUE.equals(addHttpServletRequest) && m.getBody() != null) {
-                        m = JavaTemplate.builder("HttpServletRequest request = #{any()}.getCarrier();")
-                                .imports(HTTPSERVLETREQUEST_FQ)
-                                .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "jakarta.servlet-api", "spring-web-6.+", "micrometer-observation-1.11.+"))
-                                .build()
-                                .apply(updateCursor(m), m.getBody().getCoordinates().firstStatement(), methodParamIdentifier);
-                    }
-                }
-                return m;
-            }
+                                .apply(getCursor(), classDecl.getCoordinates().replace());
 
-            @Override
-            public Statement visitStatement(Statement statement, ExecutionContext ctx) {
-                Statement s = (Statement) super.visitStatement(statement, ctx);
-                if (s instanceof J.VariableDeclarations) {
-                    J.VariableDeclarations vd = (J.VariableDeclarations) s;
-                    if (TypeUtils.isOfType(vd.getType(), JavaType.buildType(TAGS_FQ))) {
-                        if (vd.getVariables().get(0).getInitializer() != null) {
-                            //noinspection DataFlowIssue
-                            return refactorTagsUsage(ctx, vd.getCoordinates(), (J.MethodInvocation) vd.getVariables().get(0).getInitializer(), vd);
-                        }
+                        J.ClassDeclaration finalNewClassDeclaration = newClassDeclaration;
+                        final J.MethodDeclaration finalGetTagsMethod = getTagsMethod;
+                        newClassDeclaration = newClassDeclaration
+                                .withId(classDecl.getId())
+                                .withLeadingAnnotations(classDecl.getLeadingAnnotations())
+                                .withModifiers(classDecl.getModifiers())
+                                .withPrefix(classDecl.getPrefix())
+                                .withBody(newClassDeclaration.getBody().withStatements(ListUtils.map(classDecl.getBody().getStatements(), stmt -> {
+                                    if (stmt.equals(finalGetTagsMethod)) {
+                                        J.MethodDeclaration md = (J.MethodDeclaration) finalNewClassDeclaration.getBody().getStatements().get(0);
+                                        md = md.withPrefix(stmt.getPrefix());
+                                        //noinspection DataFlowIssue
+                                        return md.withBody(md.getBody().withStatements(ListUtils.insertAll(md.getBody().getStatements(), md.getBody().getStatements().size() - 1, getTagsBodyStatements)));
+                                    }
+                                    return stmt;
+                                })));
+                        maybeAddImport(DEFAULTSERVERREQUESTOBSERVATIONCONVENTION_FQ);
+                        maybeAddImport(KEYVALUE_FQ);
+                        maybeAddImport(KEYVALUES_FQ);
+                        maybeAddImport(SERVERREQUESTOBSERVATIONCONVENTION_FQ);
+                        maybeRemoveImport(HTTPSERVLETREQUEST_FQ);
+                        maybeRemoveImport(HTTPSERVLETRESPONSE_FQ);
+                        maybeRemoveImport(TAG_FQ);
+                        maybeRemoveImport(TAGS_FQ);
+                        maybeRemoveImport(WEBMVCTAGS_FQ);
+                        maybeRemoveImport(WEBMVCTAGSPROVIDER_FQ);
+                        updateCursor(newClassDeclaration);
+                        return (J.ClassDeclaration) super.visitClassDeclaration(newClassDeclaration, ctx);
                     }
-                    return vd;
-                }
-                if (s instanceof J.Assignment) {
-                    J.Assignment a = (J.Assignment) s;
-                    if (TypeUtils.isOfType(a.getType(), JavaType.buildType(TAGS_FQ))) {
-                        return refactorTagsUsage(ctx, a.getCoordinates(), (J.MethodInvocation) a.getAssignment(), a);
-                    }
-                    return a;
-                }
-                if (s instanceof J.MethodInvocation) {
-                    J.MethodInvocation mi = (J.MethodInvocation) s;
-                    if (TAGS_OF_ANY.matches(mi)) {
-                        return refactorTagsUsage(ctx, mi.getCoordinates(), mi, mi);
-                    }
-                }
-                return s;
-            }
 
-            private Statement refactorTagsUsage(ExecutionContext ctx, org.openrewrite.java.tree.CoordinateBuilder.Statement coords, J.MethodInvocation init, Statement original) {
-                J.MethodDeclaration insideMethod = getCursor().firstEnclosing(J.MethodDeclaration.class);
-                if (insideMethod != null && insideMethod.getBody() != null) {
-                    J.Identifier returnIdentifier = (J.Identifier) ((J.Return) insideMethod.getBody().getStatements().get(insideMethod.getBody().getStatements().size() - 1)).getExpression();
-
-                    if (returnIdentifier != null) {
-                        if (TAGS_AND_STRING_STRING.matches(init) || TAGS_OF_STRING_STRING.matches(init)) {
-                            J.MethodInvocation createKeyValue = JavaTemplate.builder("KeyValue.of(#{any(java.lang.String)}, #{any(java.lang.String)})")
-                                    .imports(KEYVALUE_FQ)
-                                    .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "micrometer-commons-1.11.+"))
-                                    .build()
-                                    .apply(getCursor(), coords.replace(), init.getArguments().get(0), init.getArguments().get(1));
-                            return JavaTemplate.builder("#{any()}.and(#{any(io.micrometer.common.KeyValue)})")
-                                    .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "micrometer-commons-1.11.+"))
-                                    .build()
-                                    .apply(getCursor(), coords.replace(), returnIdentifier, createKeyValue);
-                        } else if (TAGS_AND_STRING_ARRAY.matches(init) || TAGS_OF_STRING_ARRAY.matches(init)) {
-                            List<J> args = new ArrayList<>();
-                            for (int i = 0; i < init.getArguments().size(); i += 2) {
-                                args.add(JavaTemplate.builder("KeyValue.of(#{any(java.lang.String)}, #{any(java.lang.String)})")
-                                        .imports(KEYVALUE_FQ)
-                                        .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "micrometer-commons-1.11.+"))
+                    @Override
+                    public J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration method, ExecutionContext ctx) {
+                        J.MethodDeclaration m = (J.MethodDeclaration) super.visitMethodDeclaration(method, ctx);
+                        J.ClassDeclaration cd = getCursor().firstEnclosing(J.ClassDeclaration.class);
+                        if (cd != null && GET_HIGH_CARD_KEY_VALUES.matches(m, cd)) {
+                            J.VariableDeclarations methodParam = (J.VariableDeclarations) m.getParameters().get(0);
+                            J.Identifier methodParamIdentifier = methodParam.getVariables().get(0).getName();
+                            Boolean addHttpServletResponse = getCursor().pollMessage("addHttpServletResponse");
+                            Boolean addHttpServletRequest = getCursor().pollMessage("addHttpServletRequest");
+                            if (Boolean.TRUE.equals(addHttpServletResponse) && m.getBody() != null) {
+                                m = JavaTemplate.builder("HttpServletResponse response = #{any()}.getResponse();")
+                                        .imports(HTTPSERVLETRESPONSE_FQ)
+                                        .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "jakarta.servlet-api", "spring-web-6.+", "micrometer-observation-1.11.+"))
                                         .build()
-                                        .apply(getCursor(), coords.replace(), init.getArguments().get(i), init.getArguments().get(i + 1)));
+                                        .apply(updateCursor(m), m.getBody().getCoordinates().firstStatement(), methodParamIdentifier);
                             }
-                            return getMultiKeyValueStatement(ctx, coords, args, returnIdentifier);
-                        } else if (TAGS_AND_TAG_ARRAY.matches(init) || TAGS_OF_TAG_ARRAY.matches(init)) {
-                            List<Expression> validArgs = ListUtils.map(init.getArguments(), expression -> {
-                                if (expression instanceof J.MethodInvocation && ((J.MethodInvocation) expression).getMethodType() != null && TypeUtils.isOfType(((J.MethodInvocation) expression).getMethodType().getDeclaringType(), JavaType.buildType(WEBMVCTAGS_FQ))) {
+                            if (Boolean.TRUE.equals(addHttpServletRequest) && m.getBody() != null) {
+                                m = JavaTemplate.builder("HttpServletRequest request = #{any()}.getCarrier();")
+                                        .imports(HTTPSERVLETREQUEST_FQ)
+                                        .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "jakarta.servlet-api", "spring-web-6.+", "micrometer-observation-1.11.+"))
+                                        .build()
+                                        .apply(updateCursor(m), m.getBody().getCoordinates().firstStatement(), methodParamIdentifier);
+                            }
+                        }
+                        return m;
+                    }
+
+                    @Override
+                    public Statement visitStatement(Statement statement, ExecutionContext ctx) {
+                        Statement s = (Statement) super.visitStatement(statement, ctx);
+                        if (s instanceof J.VariableDeclarations) {
+                            J.VariableDeclarations vd = (J.VariableDeclarations) s;
+                            if (TypeUtils.isOfType(vd.getType(), JavaType.buildType(TAGS_FQ))) {
+                                if (vd.getVariables().get(0).getInitializer() != null) {
                                     //noinspection DataFlowIssue
-                                    return null;
+                                    return refactorTagsUsage(ctx, vd.getCoordinates(), (J.MethodInvocation) vd.getVariables().get(0).getInitializer(), vd);
                                 }
-                                return expression;
-                            });
-                            if (validArgs.isEmpty()) {
-                                //noinspection DataFlowIssue
-                                return null;
                             }
-                            List<J> args = new ArrayList<>();
-                            for (Expression arg : validArgs) {
-                                if (arg instanceof J.MethodInvocation && TAG_OF.matches(arg)) {
-                                    args.add(JavaTemplate.builder("KeyValue.of(#{any(java.lang.String)}, #{any(java.lang.String)})")
+                            return vd;
+                        }
+                        if (s instanceof J.Assignment) {
+                            J.Assignment a = (J.Assignment) s;
+                            if (TypeUtils.isOfType(a.getType(), JavaType.buildType(TAGS_FQ))) {
+                                return refactorTagsUsage(ctx, a.getCoordinates(), (J.MethodInvocation) a.getAssignment(), a);
+                            }
+                            return a;
+                        }
+                        if (s instanceof J.MethodInvocation) {
+                            J.MethodInvocation mi = (J.MethodInvocation) s;
+                            if (TAGS_OF_ANY.matches(mi)) {
+                                return refactorTagsUsage(ctx, mi.getCoordinates(), mi, mi);
+                            }
+                        }
+                        return s;
+                    }
+
+                    private Statement refactorTagsUsage(ExecutionContext ctx, org.openrewrite.java.tree.CoordinateBuilder.Statement coords, J.MethodInvocation init, Statement original) {
+                        J.MethodDeclaration insideMethod = getCursor().firstEnclosing(J.MethodDeclaration.class);
+                        if (insideMethod != null && insideMethod.getBody() != null) {
+                            J.Identifier returnIdentifier = (J.Identifier) ((J.Return) insideMethod.getBody().getStatements().get(insideMethod.getBody().getStatements().size() - 1)).getExpression();
+
+                            if (returnIdentifier != null) {
+                                if (TAGS_AND_STRING_STRING.matches(init) || TAGS_OF_STRING_STRING.matches(init)) {
+                                    J.MethodInvocation createKeyValue = JavaTemplate.builder("KeyValue.of(#{any(java.lang.String)}, #{any(java.lang.String)})")
                                             .imports(KEYVALUE_FQ)
                                             .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "micrometer-commons-1.11.+"))
                                             .build()
-                                            .apply(getCursor(), coords.replace(), ((J.MethodInvocation) arg).getArguments().get(0), ((J.MethodInvocation) arg).getArguments().get(1)));
-                                } else {
-                                    args.add(JavaTemplate.builder("KeyValue.of(#{any()}.getKey(), #{any()}.getValue())")
-                                            .imports(KEYVALUE_FQ)
-                                            .contextSensitive()
-                                            .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "micrometer-core-1.11.+", "micrometer-commons-1.11.+"))
+                                            .apply(getCursor(), coords.replace(), init.getArguments().get(0), init.getArguments().get(1));
+                                    return JavaTemplate.builder("#{any()}.and(#{any(io.micrometer.common.KeyValue)})")
+                                            .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "micrometer-commons-1.11.+"))
                                             .build()
-                                            .apply(getCursor(), coords.replace(), arg, arg));
+                                            .apply(getCursor(), coords.replace(), returnIdentifier, createKeyValue);
+                                } else if (TAGS_AND_STRING_ARRAY.matches(init) || TAGS_OF_STRING_ARRAY.matches(init)) {
+                                    List<J> args = new ArrayList<>();
+                                    for (int i = 0; i < init.getArguments().size(); i += 2) {
+                                        args.add(JavaTemplate.builder("KeyValue.of(#{any(java.lang.String)}, #{any(java.lang.String)})")
+                                                .imports(KEYVALUE_FQ)
+                                                .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "micrometer-commons-1.11.+"))
+                                                .build()
+                                                .apply(getCursor(), coords.replace(), init.getArguments().get(i), init.getArguments().get(i + 1)));
+                                    }
+                                    return getMultiKeyValueStatement(ctx, coords, args, returnIdentifier);
+                                } else if (TAGS_AND_TAG_ARRAY.matches(init) || TAGS_OF_TAG_ARRAY.matches(init)) {
+                                    List<Expression> validArgs = ListUtils.map(init.getArguments(), expression -> {
+                                        if (expression instanceof J.MethodInvocation && ((J.MethodInvocation) expression).getMethodType() != null && TypeUtils.isOfType(((J.MethodInvocation) expression).getMethodType().getDeclaringType(), JavaType.buildType(WEBMVCTAGS_FQ))) {
+                                            //noinspection DataFlowIssue
+                                            return null;
+                                        }
+                                        return expression;
+                                    });
+                                    if (validArgs.isEmpty()) {
+                                        //noinspection DataFlowIssue
+                                        return null;
+                                    }
+                                    List<J> args = new ArrayList<>();
+                                    for (Expression arg : validArgs) {
+                                        if (arg instanceof J.MethodInvocation && TAG_OF.matches(arg)) {
+                                            args.add(JavaTemplate.builder("KeyValue.of(#{any(java.lang.String)}, #{any(java.lang.String)})")
+                                                    .imports(KEYVALUE_FQ)
+                                                    .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "micrometer-commons-1.11.+"))
+                                                    .build()
+                                                    .apply(getCursor(), coords.replace(), ((J.MethodInvocation) arg).getArguments().get(0), ((J.MethodInvocation) arg).getArguments().get(1)));
+                                        } else {
+                                            args.add(JavaTemplate.builder("KeyValue.of(#{any()}.getKey(), #{any()}.getValue())")
+                                                    .imports(KEYVALUE_FQ)
+                                                    .contextSensitive()
+                                                    .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "micrometer-core-1.11.+", "micrometer-commons-1.11.+"))
+                                                    .build()
+                                                    .apply(getCursor(), coords.replace(), arg, arg));
+                                        }
+
+                                    }
+                                    return getMultiKeyValueStatement(ctx, coords, args, returnIdentifier);
+                                } else if (TAGS_AND_TAG_ITERABLE.matches(init) || TAGS_OF_TAG_ITERABLE.matches(init)) {
+                                    Expression iterable = init.getArguments().get(0);
+                                    String template = "for (Tag tag : #{any()}) {\n" +
+                                            "    #{any()}.and(KeyValue.of(tag.getKey(), tag.getValue()));\n" +
+                                            "}\n";
+                                    J.ForEachLoop foreach = JavaTemplate.builder(template)
+                                            .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "micrometer-core-1.11.+", "micrometer-commons-1.11.+"))
+                                            .imports(TAG_FQ, KEYVALUE_FQ)
+                                            .build()
+                                            .apply(getCursor(), coords.replace(), iterable, returnIdentifier);
+                                    return foreach.withControl(foreach.getControl().withIterable(foreach.getControl().getIterable().withPrefix(Space.SINGLE_SPACE)));
                                 }
-
                             }
-                            return getMultiKeyValueStatement(ctx, coords, args, returnIdentifier);
-                        } else if (TAGS_AND_TAG_ITERABLE.matches(init) || TAGS_OF_TAG_ITERABLE.matches(init)) {
-                            Expression iterable = init.getArguments().get(0);
-                            String template = "for (Tag tag : #{any()}) {\n" +
-                                              "    #{any()}.and(KeyValue.of(tag.getKey(), tag.getValue()));\n" +
-                                              "}\n";
-                            J.ForEachLoop foreach = JavaTemplate.builder(template)
-                                    .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "micrometer-core-1.11.+", "micrometer-commons-1.11.+"))
-                                    .imports(TAG_FQ, KEYVALUE_FQ)
-                                    .build()
-                                    .apply(getCursor(), coords.replace(), iterable, returnIdentifier);
-                            return foreach.withControl(foreach.getControl().withIterable(foreach.getControl().getIterable().withPrefix(Space.SINGLE_SPACE)));
                         }
+                        return original;
                     }
-                }
-                return original;
-            }
 
-            private Statement getMultiKeyValueStatement(ExecutionContext ctx, CoordinateBuilder.Statement coords, List<J> args, J.Identifier returnIdentifier) {
-                String keyValueVarArg = "#{any(io.micrometer.common.KeyValue)}";
-                String keyValueVarArgsCombined = String.join(", ", Collections.nCopies(args.size(), keyValueVarArg));
-                return JavaTemplate.builder("#{any()}.and(" + keyValueVarArgsCombined + ")")
-                        .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "micrometer-commons-1.11.+"))
-                        .build()
-                        .apply(getCursor(), coords.replace(), ListUtils.insert(args, returnIdentifier, 0).toArray());
-            }
-
-            @Override
-            public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
-                J.MethodInvocation m = (J.MethodInvocation) super.visitMethodInvocation(method, ctx);
-                J.MethodDeclaration enclosingMethod = getCursor().firstEnclosing(J.MethodDeclaration.class);
-                if (enclosingMethod != null && enclosingMethod.getSimpleName().equals("getHighCardinalityKeyValues")) {
-                    if (m.getMethodType() != null && TypeUtils.isOfType(m.getMethodType().getDeclaringType(), JavaType.buildType(HTTPSERVLETREQUEST_FQ))) {
-                        getCursor().putMessageOnFirstEnclosing(J.MethodDeclaration.class, "addHttpServletRequest", true);
+                    private Statement getMultiKeyValueStatement(ExecutionContext ctx, CoordinateBuilder.Statement coords, List<J> args, J.Identifier returnIdentifier) {
+                        String keyValueVarArg = "#{any(io.micrometer.common.KeyValue)}";
+                        String keyValueVarArgsCombined = String.join(", ", Collections.nCopies(args.size(), keyValueVarArg));
+                        return JavaTemplate.builder("#{any()}.and(" + keyValueVarArgsCombined + ")")
+                                .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "micrometer-commons-1.11.+"))
+                                .build()
+                                .apply(getCursor(), coords.replace(), ListUtils.insert(args, returnIdentifier, 0).toArray());
                     }
-                    if (m.getMethodType() != null && TypeUtils.isOfType(m.getMethodType().getDeclaringType(), JavaType.buildType(HTTPSERVLETRESPONSE_FQ))) {
-                        getCursor().putMessageOnFirstEnclosing(J.MethodDeclaration.class, "addHttpServletResponse", true);
-                    }
-                }
 
-                return m;
-            }
-        });
+                    @Override
+                    public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
+                        J.MethodInvocation m = (J.MethodInvocation) super.visitMethodInvocation(method, ctx);
+                        J.MethodDeclaration enclosingMethod = getCursor().firstEnclosing(J.MethodDeclaration.class);
+                        if (enclosingMethod != null && enclosingMethod.getSimpleName().equals("getHighCardinalityKeyValues")) {
+                            if (m.getMethodType() != null && TypeUtils.isOfType(m.getMethodType().getDeclaringType(), JavaType.buildType(HTTPSERVLETREQUEST_FQ))) {
+                                getCursor().putMessageOnFirstEnclosing(J.MethodDeclaration.class, "addHttpServletRequest", true);
+                            }
+                            if (m.getMethodType() != null && TypeUtils.isOfType(m.getMethodType().getDeclaringType(), JavaType.buildType(HTTPSERVLETRESPONSE_FQ))) {
+                                getCursor().putMessageOnFirstEnclosing(J.MethodDeclaration.class, "addHttpServletResponse", true);
+                            }
+                        }
+
+                        return m;
+                    }
+                });
     }
 }

--- a/src/testWithSpringBoot_3_0/java/org/openrewrite/java/spring/boot3/MigrateWebMvcTagsToObservationConventionTest.java
+++ b/src/testWithSpringBoot_3_0/java/org/openrewrite/java/spring/boot3/MigrateWebMvcTagsToObservationConventionTest.java
@@ -50,13 +50,13 @@ class MigrateWebMvcTagsToObservationConventionTest implements RewriteTest {
               import jakarta.servlet.http.HttpServletResponse;
               import org.springframework.boot.actuate.metrics.web.servlet.WebMvcTags;
               import org.springframework.boot.actuate.metrics.web.servlet.WebMvcTagsProvider;
-              
+
               class CustomWebMvcTagsProvider implements WebMvcTagsProvider {
-              
+
                   @Override
                   public Iterable<Tag> getTags(HttpServletRequest request, HttpServletResponse response, Object handler, Throwable exception) {
                       Tags tags = Tags.of(WebMvcTags.method(request), WebMvcTags.uri(request, response), WebMvcTags.status(response), WebMvcTags.outcome(response));
-              
+
                       String customHeader = request.getHeader("X-Custom-Header");
                       if (customHeader != null) {
                           tags = tags.and("custom.header", customHeader);
@@ -71,14 +71,14 @@ class MigrateWebMvcTagsToObservationConventionTest implements RewriteTest {
               import jakarta.servlet.http.HttpServletRequest;
               import org.springframework.http.server.observation.DefaultServerRequestObservationConvention;
               import org.springframework.http.server.observation.ServerRequestObservationContext;
-              
+
               class CustomWebMvcTagsProvider extends DefaultServerRequestObservationConvention {
-              
+
                   @Override
                   public KeyValues getHighCardinalityKeyValues(ServerRequestObservationContext context) {
                       HttpServletRequest request = context.getCarrier();
                       KeyValues values = super.getHighCardinalityKeyValues(context);
-              
+
                       String customHeader = request.getHeader("X-Custom-Header");
                       if (customHeader != null) {
                           values.and(KeyValue.of("custom.header", customHeader));
@@ -103,12 +103,12 @@ class MigrateWebMvcTagsToObservationConventionTest implements RewriteTest {
               import jakarta.servlet.http.HttpServletResponse;
               import org.springframework.boot.actuate.metrics.web.servlet.WebMvcTags;
               import org.springframework.boot.actuate.metrics.web.servlet.WebMvcTagsProvider;
-              
+
               class CustomWebMvcTagsProvider implements WebMvcTagsProvider {
-              
+
                   Tags staticTags = Tags.of("a", "b", "c", "d");
                   Tag staticTag = Tag.of("a", "b");
-              
+
                   @Override
                   public Iterable<Tag> getTags(HttpServletRequest request, HttpServletResponse response, Object handler, Throwable exception) {
                       Tags tags = Tags.of(WebMvcTags.method(request), WebMvcTags.uri(request, response), WebMvcTags.status(response), WebMvcTags.outcome(response));
@@ -127,12 +127,12 @@ class MigrateWebMvcTagsToObservationConventionTest implements RewriteTest {
               import io.micrometer.core.instrument.Tags;
               import org.springframework.http.server.observation.DefaultServerRequestObservationConvention;
               import org.springframework.http.server.observation.ServerRequestObservationContext;
-              
+
               class CustomWebMvcTagsProvider extends DefaultServerRequestObservationConvention {
-              
+
                   Tags staticTags = Tags.of("a", "b", "c", "d");
                   Tag staticTag = Tag.of("a", "b");
-              
+
                   @Override
                   public KeyValues getHighCardinalityKeyValues(ServerRequestObservationContext context) {
                       KeyValues values = super.getHighCardinalityKeyValues(context);
@@ -162,16 +162,16 @@ class MigrateWebMvcTagsToObservationConventionTest implements RewriteTest {
               import jakarta.servlet.http.HttpServletResponse;
               import org.springframework.boot.actuate.metrics.web.servlet.WebMvcTags;
               import org.springframework.boot.actuate.metrics.web.servlet.WebMvcTagsProvider;
-              
+
               class CustomWebMvcTagsProvider implements WebMvcTagsProvider {
-              
+
                   Tags staticTags = Tags.of("a", "b", "c", "d");
                   Tag staticTag = Tag.of("a", "b");
-              
+
                   @Override
                   public Iterable<Tag> getTags(HttpServletRequest request, HttpServletResponse response, Object handler, Throwable exception) {
                       Tags tags = Tags.of(WebMvcTags.method(request), WebMvcTags.uri(request, response), WebMvcTags.status(response), WebMvcTags.outcome(response));
-              
+
                       String customHeader = request.getHeader("X-Custom-Header");
                       if (customHeader != null) {
                           tags = tags.and("custom.header", customHeader);
@@ -185,7 +185,7 @@ class MigrateWebMvcTagsToObservationConventionTest implements RewriteTest {
                       tags = tags.and(methodTags());
                       return tags;
                   }
-              
+
                   private Tags methodTags() {
                       return staticTags;
                   }
@@ -200,18 +200,18 @@ class MigrateWebMvcTagsToObservationConventionTest implements RewriteTest {
               import jakarta.servlet.http.HttpServletResponse;
               import org.springframework.http.server.observation.DefaultServerRequestObservationConvention;
               import org.springframework.http.server.observation.ServerRequestObservationContext;
-              
+
               class CustomWebMvcTagsProvider extends DefaultServerRequestObservationConvention {
-              
+
                   Tags staticTags = Tags.of("a", "b", "c", "d");
                   Tag staticTag = Tag.of("a", "b");
-              
+
                   @Override
                   public KeyValues getHighCardinalityKeyValues(ServerRequestObservationContext context) {
                       HttpServletRequest request = context.getCarrier();
                       HttpServletResponse response = context.getResponse();
                       KeyValues values = super.getHighCardinalityKeyValues(context);
-              
+
                       String customHeader = request.getHeader("X-Custom-Header");
                       if (customHeader != null) {
                           values.and(KeyValue.of("custom.header", customHeader));
@@ -229,7 +229,7 @@ class MigrateWebMvcTagsToObservationConventionTest implements RewriteTest {
                       }
                       return values;
                   }
-              
+
                   private Tags methodTags() {
                       return staticTags;
                   }
@@ -250,9 +250,9 @@ class MigrateWebMvcTagsToObservationConventionTest implements RewriteTest {
               import jakarta.servlet.http.HttpServletRequest;
               import jakarta.servlet.http.HttpServletResponse;
               import org.springframework.boot.actuate.metrics.web.servlet.WebMvcTagsProvider;
-              
+
               class CustomWebMvcTagsProvider implements WebMvcTagsProvider {
-              
+
                   @Override
                   public Iterable<Tag> getTags(HttpServletRequest request, HttpServletResponse response, Object handler, Throwable exception) {
                       return Tags.of(Tag.of("a", "b"));
@@ -264,9 +264,9 @@ class MigrateWebMvcTagsToObservationConventionTest implements RewriteTest {
               import io.micrometer.common.KeyValues;
               import org.springframework.http.server.observation.DefaultServerRequestObservationConvention;
               import org.springframework.http.server.observation.ServerRequestObservationContext;
-              
+
               class CustomWebMvcTagsProvider extends DefaultServerRequestObservationConvention {
-              
+
                   @Override
                   public KeyValues getHighCardinalityKeyValues(ServerRequestObservationContext context) {
                       KeyValues values = super.getHighCardinalityKeyValues(context);
@@ -289,16 +289,16 @@ class MigrateWebMvcTagsToObservationConventionTest implements RewriteTest {
               import jakarta.servlet.http.HttpServletRequest;
               import jakarta.servlet.http.HttpServletResponse;
               import org.springframework.boot.actuate.metrics.web.servlet.WebMvcTagsProvider;
-              
+
               import java.util.Collections;
-              
+
               class CustomWebMvcTagsProvider implements WebMvcTagsProvider {
-              
+
                   @Override
                   public Iterable<Tag> getTags(HttpServletRequest request, HttpServletResponse response, Object handler, Throwable exception) {
                       return Collections.emptyList();
                   }
-              
+
                   void shouldNotFailOnEmptyMethod() {}
               }
               """,
@@ -306,18 +306,57 @@ class MigrateWebMvcTagsToObservationConventionTest implements RewriteTest {
               import io.micrometer.common.KeyValues;
               import org.springframework.http.server.observation.DefaultServerRequestObservationConvention;
               import org.springframework.http.server.observation.ServerRequestObservationContext;
-              
+
               import java.util.Collections;
-              
+
               class CustomWebMvcTagsProvider extends DefaultServerRequestObservationConvention {
-              
+
                   @Override
                   public KeyValues getHighCardinalityKeyValues(ServerRequestObservationContext context) {
                       KeyValues values = super.getHighCardinalityKeyValues(context);
                       return values;
                   }
-              
+
                   void shouldNotFailOnEmptyMethod() {}
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void shouldNotCrashWhengetLongRequestTagsExists() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import io.micrometer.core.instrument.Tag;
+              import io.micrometer.core.instrument.Tags;
+              import org.springframework.boot.actuate.metrics.web.servlet.WebMvcTagsProvider;
+
+              import jakarta.servlet.http.HttpServletRequest;
+              import jakarta.servlet.http.HttpServletResponse;
+
+              public class WebMvcExample implements WebMvcTagsProvider {
+
+                  /**
+                   * Instance of {@link WebMvcTagsProvider}.
+                   */
+                  private final WebMvcTagsProvider webMvcTagsProvider;
+
+                  public WebMvcExample(WebMvcTagsProvider webMvcTagsProvider) {
+                      this.webMvcTagsProvider = webMvcTagsProvider;
+                  }
+
+                  @Override
+                  public Iterable<Tag> getTags(final HttpServletRequest request, final HttpServletResponse response, final Object handler, final Throwable exception) {
+                      return Tags.of(webMvcTagsProvider.getTags(request, response, handler, exception)).and("ABC", "ABC");
+                  }
+
+                  @Override
+                  public Iterable<Tag> getLongRequestTags(final HttpServletRequest request, final Object handler) {
+                      return Tags.of(webMvcTagsProvider.getLongRequestTags(request, handler)).and("ABC", "ABC");
+                  }
               }
               """
           )


### PR DESCRIPTION
## What's changed?
Currently the recipe only supports classes that don't declare the getLongRequestTags method.
The recipe will now safely back off instead of crashing if that method exists.

## What's your motivation?
For now, prevent the recipe from crashing if it can't handle the existing code.
Partly adresses https://github.com/openrewrite/rewrite-spring/issues/718

## Have you considered any alternatives or workarounds?
I considered changeing the recipe to also handle `getLongRequestTags` and handle `.and(..)` in the fluent api.  
However I'm still pretty new at writing java recipes and it would probably take me quite a while.  
So for now I've taken the simplest route to at least avoid crashing the process if the recipe can't handle the existing code.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
