### PR TITLE
Support `@Value` and `@ConditionalOnProperty` in `ChangeSpringPropertyKey`

### DIFF
--- a/src/main/java/org/openrewrite/java/spring/ChangeSpringPropertyKey.java
+++ b/src/main/java/org/openrewrite/java/spring/ChangeSpringPropertyKey.java
@@ -109,7 +109,7 @@ public class ChangeSpringPropertyKey extends Recipe {
     private String exceptRegex() {
         return except == null || except.isEmpty() ?
                 "" :
-                "(?!\\.(?:" + String.join("|", except) + "))";
+                "(?!\\.(?:" + String.join("|", except) + ")\\b)";
     }
 
     private class JavaPropertyKeyVisitor extends JavaIsoVisitor<ExecutionContext> {

--- a/src/test/java/org/openrewrite/java/spring/ChangeSpringPropertyKeyTest.java
+++ b/src/test/java/org/openrewrite/java/spring/ChangeSpringPropertyKeyTest.java
@@ -30,7 +30,6 @@ import static org.openrewrite.java.Assertions.*;
 import static org.openrewrite.properties.Assertions.properties;
 import static org.openrewrite.yaml.Assertions.yaml;
 
-
 class ChangeSpringPropertyKeyTest implements RewriteTest {
 
     @Override

--- a/src/test/java/org/openrewrite/java/spring/ChangeSpringPropertyKeyTest.java
+++ b/src/test/java/org/openrewrite/java/spring/ChangeSpringPropertyKeyTest.java
@@ -325,4 +325,65 @@ class ChangeSpringPropertyKeyTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    @Issue("https://github.com/openrewrite/rewrite-spring/issues/231")
+    void changeConditionalOnPropertyAnnotation() {
+        rewriteRun(
+          spec -> spec.recipe(new ChangeSpringPropertyKey("foo", "bar", List.of("baz")))
+            .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(), "spring-boot-autoconfigure")),
+          java(
+            """
+              import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+
+              class MyConfiguration {
+                  @ConditionalOnProperty(name = "foo", havingValue = "true")
+                  public String foo() {
+                      return "foo";
+                  }
+
+                  @ConditionalOnProperty(name = "foo.foo", havingValue = "true")
+                  public String fooFoo() {
+                      return "foo.foo";
+                  }
+
+                  @ConditionalOnProperty(name = "foo.bar", havingValue = "true")
+                  public String fooBar() {
+                      return "foo.bar";
+                  }
+
+                  @ConditionalOnProperty(name = "foo.baz", havingValue = "true")
+                  public String fooBaz() {
+                      return "foo.baz";
+                  }
+              }
+              """,
+            """
+              import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+
+              class MyConfiguration {
+                  @ConditionalOnProperty(name = "bar", havingValue = "true")
+                  public String foo() {
+                      return "foo";
+                  }
+
+                  @ConditionalOnProperty(name = "bar.foo", havingValue = "true")
+                  public String fooFoo() {
+                      return "foo.foo";
+                  }
+
+                  @ConditionalOnProperty(name = "bar.bar", havingValue = "true")
+                  public String fooBar() {
+                      return "foo.bar";
+                  }
+
+                  @ConditionalOnProperty(name = "foo.baz", havingValue = "true")
+                  public String fooBaz() {
+                      return "foo.baz";
+                  }
+              }
+              """
+          )
+        );
+    }
 }

--- a/src/test/java/org/openrewrite/java/spring/ChangeSpringPropertyKeyTest.java
+++ b/src/test/java/org/openrewrite/java/spring/ChangeSpringPropertyKeyTest.java
@@ -356,6 +356,11 @@ class ChangeSpringPropertyKeyTest implements RewriteTest {
                   public String fooBaz() {
                       return "foo.baz";
                   }
+
+                  @ConditionalOnProperty(name = "foo.bazes", havingValue = "true")
+                  public String fooBazes() {
+                      return "foo.bazes";
+                  }
               }
               """,
             """
@@ -380,6 +385,11 @@ class ChangeSpringPropertyKeyTest implements RewriteTest {
                   @ConditionalOnProperty(name = "foo.baz", havingValue = "true")
                   public String fooBaz() {
                       return "foo.baz";
+                  }
+
+                  @ConditionalOnProperty(name = "bar.bazes", havingValue = "true")
+                  public String fooBazes() {
+                      return "foo.bazes";
                   }
               }
               """


### PR DESCRIPTION
Also support `except` option and default values (as in `${foo:bar}`), including escaping (e.g. `${foo:\{bar\}}`).

Issues:
 - #231
