### PR TITLE
Remove unneeded annotation when migrating from Swagger to SpringDoc

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -154,6 +154,7 @@ dependencies {
 
     testRuntimeOnly("ch.qos.logback:logback-classic:1.+")
     testRuntimeOnly(gradleApi())
+    testRuntimeOnly("io.springfox:springfox-bean-validators:3.+")
 
     testImplementation("org.openrewrite:rewrite-test")
     testImplementation("org.openrewrite.gradle.tooling:model:$rewriteVersion")

--- a/src/main/java/org/openrewrite/java/spring/doc/RemoveBeanValidatorPluginsConfiguration.java
+++ b/src/main/java/org/openrewrite/java/spring/doc/RemoveBeanValidatorPluginsConfiguration.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.spring.doc;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Preconditions;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.internal.ListUtils;
+import org.openrewrite.java.AnnotationMatcher;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.RemoveAnnotationVisitor;
+import org.openrewrite.java.TypeMatcher;
+import org.openrewrite.java.search.UsesType;
+import org.openrewrite.java.tree.Expression;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaType;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class RemoveBeanValidatorPluginsConfiguration extends Recipe {
+
+    private static final String ANNOTATION_IMPORT = "org.springframework.context.annotation.Import";
+    private static final AnnotationMatcher IMPORT_MATCHER = new AnnotationMatcher("@" + ANNOTATION_IMPORT);
+    private static final String BEAN_VALIDATOR_PLUGINS_CONFIGURATION = "springfox.bean.validators.configuration.BeanValidatorPluginsConfiguration";
+    private static final TypeMatcher BEAN_VALIDATOR_TYPEMATCHER = new TypeMatcher("springfox.bean.validators.configuration.BeanValidatorPluginsConfiguration");
+
+    @Override
+    public String getDisplayName() {
+        return "Removes @Import(BeanValidatorPluginsConfiguration.class)";
+    }
+
+    @Override
+    public String getDescription() {
+        return "As Springdoc OpenAPI supports Bean Validation out of the box, the BeanValidatorPluginsConfiguration is no longer supported nor needed. " +
+                "Thus remove @Import(BeanValidatorPluginsConfiguration.class).";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return Preconditions.check(Preconditions.or(
+                new UsesType<>(ANNOTATION_IMPORT, false),
+                new UsesType<>(BEAN_VALIDATOR_PLUGINS_CONFIGURATION, false)
+                ), new JavaIsoVisitor<ExecutionContext>() {
+            @Override
+            public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration classDecl, ExecutionContext ctx) {
+                J.ClassDeclaration c = super.visitClassDeclaration(classDecl, ctx);
+
+                maybeRemoveImport(BEAN_VALIDATOR_PLUGINS_CONFIGURATION);
+
+                AtomicBoolean changed = new AtomicBoolean(false);
+                List<J.Annotation> leadingAnnotations = new ArrayList<>();
+                for (J.Annotation a : c.getLeadingAnnotations()) {
+                    if (a.getArguments() != null && IMPORT_MATCHER.matches(a)) {
+                        if (a.getArguments().size() == 1 && isBeanValidator(a.getArguments().get(0))) {
+                            return (J.ClassDeclaration) new RemoveAnnotationVisitor(IMPORT_MATCHER).visitNonNull(c, ctx, getCursor().getParentOrThrow());
+                        }
+                        List<Expression> argsWithoutBeanValidator = ListUtils.map(a.getArguments(), e -> {
+                            if (e instanceof J.NewArray && ((J.NewArray) e).getInitializer() != null) {
+                                List<Expression> initializer = ((J.NewArray) e).getInitializer();
+                                for (Expression ex : initializer) {
+                                    if (isBeanValidator(ex)) {
+                                        changed.set(true);
+                                        return ((J.NewArray) e).withInitializer(ListUtils.filter(initializer, it -> it != ex));
+                                    }
+                                }
+                            }
+                            return e;
+                        });
+                        leadingAnnotations.add(a.withArguments(argsWithoutBeanValidator));
+                    } else {
+                        leadingAnnotations.add(a);
+                    }
+                }
+
+                return changed.get() ? c.withLeadingAnnotations(leadingAnnotations) : c;
+            }
+
+            private boolean isBeanValidator(Expression e) {
+                if (e instanceof J.NewArray && ((J.NewArray) e).getInitializer() != null && ((J.NewArray) e).getInitializer().size() == 1) {
+                     e = ((J.NewArray) e).getInitializer().get(0);
+                }
+                return e.getType() instanceof JavaType.Parameterized && BEAN_VALIDATOR_TYPEMATCHER.matches(((JavaType.Parameterized) e.getType()).getTypeParameters().get(0));
+            }
+        });
+    }
+}

--- a/src/main/resources/META-INF/rewrite/springdoc.yml
+++ b/src/main/resources/META-INF/rewrite/springdoc.yml
@@ -40,6 +40,7 @@ tags:
   - openapi
 recipeList:
   - org.openrewrite.openapi.swagger.SwaggerToOpenAPI
+  - org.openrewrite.java.spring.doc.RemoveBeanValidatorPluginsConfiguration
   - org.openrewrite.java.spring.DeleteSpringProperty:
       propertyKey: swagger.title
   - org.openrewrite.java.spring.DeleteSpringProperty:
@@ -49,6 +50,8 @@ recipeList:
   - org.openrewrite.java.dependencies.RemoveDependency:
       groupId: io.swagger.core.v3
       artifactId: swagger-annotations
+  - org.openrewrite.java.RemoveAnnotation:
+      annotationPattern: '@springfox.documentation.swagger2.annotations.EnableSwagger2'
 
 ---
 type: specs.openrewrite.org/v1beta/recipe

--- a/src/test/java/org/openrewrite/java/spring/doc/RemoveBeanValidatorPluginsConfigurationTest.java
+++ b/src/test/java/org/openrewrite/java/spring/doc/RemoveBeanValidatorPluginsConfigurationTest.java
@@ -1,0 +1,103 @@
+package org.openrewrite.java.spring.doc;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+class RemoveBeanValidatorPluginsConfigurationTest implements RewriteTest {
+
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(new RemoveBeanValidatorPluginsConfiguration())
+          .parser(JavaParser.fromJavaVersion()
+            .classpath("spring-context", "springfox-bean-validators"));
+    }
+
+    @DocumentExample
+    @Test
+    void removeImportWithBeanValidatorPluginsConfiguration() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import org.springframework.context.annotation.Configuration;
+              import org.springframework.context.annotation.Import;
+              import springfox.bean.validators.configuration.BeanValidatorPluginsConfiguration;
+
+              @Configuration
+              @Import(BeanValidatorPluginsConfiguration.class)
+              class ApplicationConfiguration {}
+              """,
+            """
+              import org.springframework.context.annotation.Configuration;
+              import org.springframework.context.annotation.Import;
+
+              @Configuration
+              class ApplicationConfiguration {}
+              """
+          )
+        );
+    }
+
+    @Test
+    void removeImportWithBeanValidatorPluginsConfigurationWhenSingleArray() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import org.springframework.context.annotation.Configuration;
+              import org.springframework.context.annotation.Import;
+              import springfox.bean.validators.configuration.BeanValidatorPluginsConfiguration;
+
+              @Configuration
+              @Import({BeanValidatorPluginsConfiguration.class})
+              class ApplicationConfiguration {}
+              """,
+            """
+              import org.springframework.context.annotation.Configuration;
+              import org.springframework.context.annotation.Import;
+
+              @Configuration
+              class ApplicationConfiguration {}
+              """
+          )
+        );
+    }
+
+    @Test
+    void removeBeanValidatorPluginsConfigurationWhenMultipleArray() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              class Some {}
+              class SomeOther {}
+              """
+          ),
+          java(
+            """
+              import org.springframework.context.annotation.Configuration;
+              import org.springframework.context.annotation.Import;
+              import springfox.bean.validators.configuration.BeanValidatorPluginsConfiguration;
+
+              @Configuration
+              @Import({Some.class, BeanValidatorPluginsConfiguration.class, SomeOther.class})
+              class ApplicationConfiguration {}
+              """,
+            """
+              import org.springframework.context.annotation.Configuration;
+              import org.springframework.context.annotation.Import;
+
+              @Configuration
+              @Import({Some.class, SomeOther.class})
+              class ApplicationConfiguration {}
+              """
+          )
+        );
+    }
+}

--- a/src/test/java/org/openrewrite/java/spring/doc/RemoveBeanValidatorPluginsConfigurationTest.java
+++ b/src/test/java/org/openrewrite/java/spring/doc/RemoveBeanValidatorPluginsConfigurationTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openrewrite.java.spring.doc;
 
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
## What's changed?
Remove `@EnableSwagger2` and `@Import(BeanValidatorPluginsConfiguration.class)` when migration from Swagger to SpringDoc

## What's your motivation?
Recipe was missing from the more general migration recipe.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
