### PR TITLE
Use springdoc compatibility matrix

### DIFF
--- a/src/main/resources/META-INF/rewrite/spring-boot-30.yml
+++ b/src/main/resources/META-INF/rewrite/spring-boot-30.yml
@@ -78,7 +78,7 @@ recipeList:
   - org.openrewrite.java.spring.kafka.UpgradeSpringKafka_3_0
   - org.openrewrite.java.spring.security6.UpgradeSpringSecurity_6_0
   - org.openrewrite.java.spring.cloud2022.UpgradeSpringCloud_2022
-  - org.openrewrite.java.springdoc.UpgradeSpringDoc_2
+  - org.openrewrite.java.springdoc.UpgradeSpringDoc_2_1
   - org.openrewrite.hibernate.MigrateToHibernate61
   - org.openrewrite.java.spring.boot3.UpgradeMyBatisToSpringBoot_3_0
 

--- a/src/main/resources/META-INF/rewrite/spring-boot-30.yml
+++ b/src/main/resources/META-INF/rewrite/spring-boot-30.yml
@@ -78,7 +78,7 @@ recipeList:
   - org.openrewrite.java.spring.kafka.UpgradeSpringKafka_3_0
   - org.openrewrite.java.spring.security6.UpgradeSpringSecurity_6_0
   - org.openrewrite.java.spring.cloud2022.UpgradeSpringCloud_2022
-  - org.openrewrite.java.springdoc.UpgradeSpringDoc_2_1
+  - org.openrewrite.java.springdoc.UpgradeSpringDoc_2
   - org.openrewrite.hibernate.MigrateToHibernate61
   - org.openrewrite.java.spring.boot3.UpgradeMyBatisToSpringBoot_3_0
 

--- a/src/main/resources/META-INF/rewrite/spring-boot-31.yml
+++ b/src/main/resources/META-INF/rewrite/spring-boot-31.yml
@@ -52,3 +52,4 @@ recipeList:
       newVersion: 2.2.x
   - org.openrewrite.hibernate.MigrateToHibernate62
   - org.openrewrite.java.testing.mockito.Mockito4to5Only
+  - org.openrewrite.java.springdoc.UpgradeSpringDoc_2_2

--- a/src/main/resources/META-INF/rewrite/spring-boot-32.yml
+++ b/src/main/resources/META-INF/rewrite/spring-boot-32.yml
@@ -80,6 +80,7 @@ recipeList:
   - org.openrewrite.hibernate.MigrateToHibernate64
   - org.openrewrite.java.spring.boot3.RelocateLauncherClasses
   - org.openrewrite.java.spring.boot3.UpgradeMyBatisToSpringBoot_3_2
+  - org.openrewrite.java.springdoc.UpgradeSpringDoc_2_5
 
 ---
 type: specs.openrewrite.org/v1beta/recipe

--- a/src/main/resources/META-INF/rewrite/spring-boot-33.yml
+++ b/src/main/resources/META-INF/rewrite/spring-boot-33.yml
@@ -60,6 +60,7 @@ recipeList:
       newVersion: 2.6.x
   - org.openrewrite.hibernate.MigrateToHibernate65
   - org.openrewrite.java.flyway.MigrateToFlyway10
+  - org.openrewrite.java.springdoc.UpgradeSpringDoc_2_6
 
 ---
 type: specs.openrewrite.org/v1beta/recipe

--- a/src/main/resources/META-INF/rewrite/spring-boot-34.yml
+++ b/src/main/resources/META-INF/rewrite/spring-boot-34.yml
@@ -60,3 +60,4 @@ recipeList:
       newVersion: 1.0.x
   - org.openrewrite.java.spring.boot3.ReplaceRestTemplateBuilderMethods
   - org.openrewrite.java.spring.boot3.AddValidToNestedConfigProperties
+  - org.openrewrite.java.springdoc.UpgradeSpringDoc_2_8

--- a/src/main/resources/META-INF/rewrite/springdoc.yml
+++ b/src/main/resources/META-INF/rewrite/springdoc.yml
@@ -92,8 +92,8 @@ recipeList:
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.springdoc.UpgradeSpringDoc_2_6
-displayName: Upgrade to SpringDoc 2.1
-description: Upgrade to SpringDoc v2.1.
+displayName: Upgrade to SpringDoc 2.6
+description: Upgrade to SpringDoc v2.6.
 tags:
   - springdoc
 recipeList:
@@ -105,8 +105,8 @@ recipeList:
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.springdoc.UpgradeSpringDoc_2_5
-displayName: Upgrade to SpringDoc 2.1
-description: Upgrade to SpringDoc v2.1.
+displayName: Upgrade to SpringDoc 2.5
+description: Upgrade to SpringDoc v2.5.
 tags:
   - springdoc
 recipeList:
@@ -118,8 +118,8 @@ recipeList:
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.springdoc.UpgradeSpringDoc_2_2
-displayName: Upgrade to SpringDoc 2.1
-description: Upgrade to SpringDoc v2.1.
+displayName: Upgrade to SpringDoc 2.2
+description: Upgrade to SpringDoc v2.2.
 tags:
   - springdoc
 recipeList:

--- a/src/main/resources/META-INF/rewrite/springdoc.yml
+++ b/src/main/resources/META-INF/rewrite/springdoc.yml
@@ -123,14 +123,14 @@ description: Upgrade to SpringDoc v2.1.
 tags:
   - springdoc
 recipeList:
-  - org.openrewrite.java.springdoc.UpgradeSpringDoc_2_1
+  - org.openrewrite.java.springdoc.UpgradeSpringDoc_2
   - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
       groupId: org.springdoc
       artifactId: "*"
       newVersion: 2.2.x
 ---
 type: specs.openrewrite.org/v1beta/recipe
-name: org.openrewrite.java.springdoc.UpgradeSpringDoc_2_1
+name: org.openrewrite.java.springdoc.UpgradeSpringDoc_2
 displayName: Upgrade to SpringDoc 2.1
 description: Upgrade to SpringDoc v2.1, as described in the [upgrade guide](https://springdoc.org/#migrating-from-springdoc-v1).
 tags:

--- a/src/main/resources/META-INF/rewrite/springdoc.yml
+++ b/src/main/resources/META-INF/rewrite/springdoc.yml
@@ -75,11 +75,64 @@ recipeList:
       artifactId: springdoc-openapi-ui
       version: 1.5.x # aligns with spring boot 2.6
 
+# Compatibility matrix: https://springdoc.org/#what-is-the-compatibility-matrix-of-springdoc-openapi-with-spring-boot
 ---
 type: specs.openrewrite.org/v1beta/recipe
-name: org.openrewrite.java.springdoc.UpgradeSpringDoc_2
-displayName: Upgrade SpringDoc
-description: Upgrade to SpringDoc v2, as described in the [upgrade guide](https://springdoc.org/#migrating-from-springdoc-v1).
+name: org.openrewrite.java.springdoc.UpgradeSpringDoc_2_8
+displayName: Upgrade to SpringDoc 2.8
+description: Upgrade to SpringDoc v2.8.
+tags:
+  - springdoc
+recipeList:
+  - org.openrewrite.java.springdoc.UpgradeSpringDoc_2_6
+  - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
+      groupId: org.springdoc
+      artifactId: "*"
+      newVersion: 2.8.x
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.springdoc.UpgradeSpringDoc_2_6
+displayName: Upgrade to SpringDoc 2.1
+description: Upgrade to SpringDoc v2.1.
+tags:
+  - springdoc
+recipeList:
+  - org.openrewrite.java.springdoc.UpgradeSpringDoc_2_5
+  - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
+      groupId: org.springdoc
+      artifactId: "*"
+      newVersion: 2.6.x
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.springdoc.UpgradeSpringDoc_2_5
+displayName: Upgrade to SpringDoc 2.1
+description: Upgrade to SpringDoc v2.1.
+tags:
+  - springdoc
+recipeList:
+  - org.openrewrite.java.springdoc.UpgradeSpringDoc_2_2
+  - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
+      groupId: org.springdoc
+      artifactId: "*"
+      newVersion: 2.5.x
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.springdoc.UpgradeSpringDoc_2_2
+displayName: Upgrade to SpringDoc 2.1
+description: Upgrade to SpringDoc v2.1.
+tags:
+  - springdoc
+recipeList:
+  - org.openrewrite.java.springdoc.UpgradeSpringDoc_2_1
+  - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
+      groupId: org.springdoc
+      artifactId: "*"
+      newVersion: 2.2.x
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.springdoc.UpgradeSpringDoc_2_1
+displayName: Upgrade to SpringDoc 2.1
+description: Upgrade to SpringDoc v2.1, as described in the [upgrade guide](https://springdoc.org/#migrating-from-springdoc-v1).
 tags:
   - springdoc
 recipeList:
@@ -130,32 +183,32 @@ recipeList:
       oldGroupId: org.springdoc
       oldArtifactId: springdoc-openapi-common
       newArtifactId: springdoc-openapi-starter-common
-      newVersion: 2.x
+      newVersion: 2.1.x
   - org.openrewrite.java.dependencies.ChangeDependency:
       oldGroupId: org.springdoc
       oldArtifactId: springdoc-openapi-webmvc-core
       newArtifactId: springdoc-openapi-starter-webmvc-api
-      newVersion: 2.x
+      newVersion: 2.1.x
   - org.openrewrite.java.dependencies.ChangeDependency:
       oldGroupId: org.springdoc
       oldArtifactId: springdoc-openapi-webflux-core
       newArtifactId: springdoc-openapi-starter-webflux-api
-      newVersion: 2.x
+      newVersion: 2.1.x
   - org.openrewrite.java.dependencies.ChangeDependency:
       oldGroupId: org.springdoc
       oldArtifactId: springdoc-openapi-ui
       newArtifactId: springdoc-openapi-starter-webmvc-ui
-      newVersion: 2.x
+      newVersion: 2.1.x
   - org.openrewrite.java.dependencies.ChangeDependency:
       oldGroupId: org.springdoc
       oldArtifactId: springdoc-openapi-webflux-ui
       newArtifactId: springdoc-openapi-starter-webflux-ui
-      newVersion: 2.x
+      newVersion: 2.1.x
   # upgrade all remaining non-renamed modules
   - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
       groupId: org.springdoc
       artifactId: "*"
-      newVersion: 2.x
+      newVersion: 2.1.x
 
 ---
 type: specs.openrewrite.org/v1beta/recipe


### PR DESCRIPTION
## What's changed?
Split up the Springdoc migration recipes

## What's your motivation?
Upgrade according to the compatibility matrix posted here:
https://springdoc.org/#what-is-the-compatibility-matrix-of-springdoc-openapi-with-spring-boot

Spring Boot Versions | Springdoc OpenAPI Versions
-- | --
3.4.x | 2.7.x - 2.8.x
3.3.x | 2.6.x
3.2.x | 2.3.x - 2.5.x
3.1.x | 2.2.x
3.0.x | 2.0.x - 2.1.x
2.7.x, 1.5.x | 1.6.0+
2.6.x, 1.5.x | 1.6.0+
2.5.x, 1.5.x | 1.5.9+
2.4.x, 1.5.x | 1.5.0+
2.3.x, 1.5.x | 1.4.0+
2.2.x, 1.5.x | 1.2.1+
2.0.x, 1.5.x | 1.0.0+

## Any additional context
Reported on https://stackoverflow.com/questions/79667881/classnotfoundexception-org-springframework-web-servlet-resource-litewebjarsreso
