### PR TITLE
Fix package for `MockReset` once migrating SpyBean/MockBean to MockitoSpyBean/MockitoBean

### DIFF
--- a/src/main/resources/META-INF/rewrite/replace-mock-and-spybean.yml
+++ b/src/main/resources/META-INF/rewrite/replace-mock-and-spybean.yml
@@ -46,3 +46,7 @@ recipeList:
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: org.springframework.boot.test.mock.mockito.SpyBean
       newFullyQualifiedTypeName: org.springframework.test.context.bean.override.mockito.MockitoSpyBean
+
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.springframework.boot.test.mock.mockito.MockReset
+      newFullyQualifiedTypeName: org.springframework.test.context.bean.override.mockito.MockReset

--- a/src/testWithSpringBoot_3_4/java/org/openrewrite/java/spring/boot3/ReplaceMockBeanAndSpyBeanTest.java
+++ b/src/testWithSpringBoot_3_4/java/org/openrewrite/java/spring/boot3/ReplaceMockBeanAndSpyBeanTest.java
@@ -197,6 +197,41 @@ class ReplaceMockBeanAndSpyBeanTest implements RewriteTest {
     }
 
     @Test
+    void replacesMockBeanWithMockitoBeanAndSpyBeanWithMockitoSpyBeanResolvingProperlyMockResetImport() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import org.springframework.boot.test.mock.mockito.MockBean;
+              import org.springframework.boot.test.mock.mockito.MockReset;
+              import org.springframework.boot.test.mock.mockito.SpyBean;
+
+              public class SomeTest {
+                  @SpyBean(reset = MockReset.NONE)
+                  private String someService;
+
+                  @MockBean(reset = MockReset.NONE)
+                  private String someMockService;
+              }
+              """,
+            """
+              import org.springframework.test.context.bean.override.mockito.MockReset;
+              import org.springframework.test.context.bean.override.mockito.MockitoBean;
+              import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
+
+              public class SomeTest {
+                  @MockitoSpyBean(reset = MockReset.NONE)
+                  private String someService;
+
+                  @MockitoBean(reset = MockReset.NONE)
+                  private String someMockService;
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void replacesSpyBeanWithMockitoSpyBean() {
         rewriteRun(
           //language=java


### PR DESCRIPTION
Fixes: #696 

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
