### PR TITLE
`Could not parse as Java` in `UseNewSecurityMatchers`

### DIFF
--- a/src/testWithSpringSecurity_5_8/java/org/openrewrite/spring/security5/UpgradeSpringSecurityTest.java
+++ b/src/testWithSpringSecurity_5_8/java/org/openrewrite/spring/security5/UpgradeSpringSecurityTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.spring.security5;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+class UpgradeSpringSecurityTest implements RewriteTest {
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.parser(JavaParser.fromJavaVersion().classpath(
+                "spring-core-5.3.+", "spring-context-5.3.+", "spring-beans-5.3.+", "spring-web-5.3.+", "spring-security-web-5.8.+", "spring-security-config-5.8.+", "spring-security-core-5.8.+", "tomcat-embed"))
+          .recipeFromResources("org.openrewrite.java.spring.security5.UpgradeSpringSecurity_5_8");
+    }
+
+    @Test
+    @DocumentExample
+    void canBeUpgradedIfAuthenticationManagerBuilderConfigurationPresent() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              package com.example;
+
+              import org.springframework.context.annotation.Configuration;
+              import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+              import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+              import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+              import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+              import org.springframework.security.config.http.SessionCreationPolicy;
+
+              /**
+               * Security configuration.
+               */
+              @Configuration
+              @EnableWebSecurity
+              public class  WebSecurityConfig extends WebSecurityConfigurerAdapter {
+
+                  @Configuration
+                  public static class AdminWebSecurityConfig extends WebSecurityConfigurerAdapter {
+
+                      @Override
+                      protected void configure( final AuthenticationManagerBuilder auth ) throws Exception {}
+
+                      @Override
+                      protected void configure( final HttpSecurity http ) throws Exception {
+                          http.antMatcher( "***" )
+                              .authorizeRequests().anyRequest().hasAuthority( "***" )
+                              .and()
+                              .sessionManagement().sessionCreationPolicy( SessionCreationPolicy.STATELESS )
+                              .and().httpBasic().authenticationEntryPoint( null )
+                              .and().csrf().disable();
+                      }
+                  }
+              }
+              """,
+            """
+            package com.example;
+
+            import org.springframework.context.annotation.Configuration;
+            import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+            import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+            import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+            import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+            import org.springframework.security.config.http.SessionCreationPolicy;
+
+            /**
+             * Security configuration.
+             */
+            @Configuration
+            @EnableWebSecurity
+            public class  WebSecurityConfig {
+
+                @Configuration
+                public static class AdminWebSecurityConfig extends WebSecurityConfigurerAdapter {
+
+                    /*~~(Migrate manually based on https://spring.io/blog/2022/02/21/spring-security-without-the-websecurityconfigureradapter)~~>*/@Override
+                    protected void configure( final AuthenticationManagerBuilder auth ) throws Exception {}
+
+                    @Override
+                    protected void configure( final HttpSecurity http ) throws Exception {
+                        http.securityMatcher("***")
+                                .authorizeHttpRequests(requests -> requests.anyRequest().hasAuthority("***"))
+                                .sessionManagement(management -> management.sessionCreationPolicy(SessionCreationPolicy.STATELESS)).httpBasic(basic -> basic.authenticationEntryPoint(null)).csrf(csrf -> csrf.disable());
+                    }
+                }
+            }
+            """
+          )
+        );
+    }
+
+}


### PR DESCRIPTION
Now here's a weird issue that I am investigating. 
Created a Draft PR to share status and allow others to check the issue also. 

Reproduce: Run the `canBeUpgradedIfAuthenticationManagerBuilderConfigurationPresent` test in `UpgradeSpringSecurityTest` 
Output of this run will be a `java.lang.IllegalArgumentException: Could not parse as Java:`

This is caused by the `JavaTemplateParser` line 196 `compileTemplate(stub)` throwing an error. 
Going into this method is what is triggering weird behaviour. 
When I put a breakpoint after building the `jp` `Parser` (line 273) I can see that only the first invocation of 
`jp.reset().parse(ctx, stub).findFirst()` gives back a J.ParseError. Any subsequent call makes the same call return a `J.CompilationUnit` after which the test is successfully updating the code as expected. 
So By doing `jp.reset().parse(ctx, stub)).findFirst()` once in my debug session before the code does it, I can impact the test to become green. By default the test is failing. 

> I also see a strange stub but verified this is NOT the root cause of this issue by removing the extra template_stops from the stub during debugging. Still wonder if we also need to report/fix that one though. 