### PR TITLE
Moving away from deprecated no-args constructor for `CoalesceProperties` and its visitor

### DIFF
--- a/src/main/java/org/openrewrite/java/spring/boot2/MergeBootstrapYamlWithApplicationYaml.java
+++ b/src/main/java/org/openrewrite/java/spring/boot2/MergeBootstrapYamlWithApplicationYaml.java
@@ -117,7 +117,7 @@ public class MergeBootstrapYamlWithApplicationYaml extends ScanningRecipe<MergeB
                     assert b != null;
 
                     //noinspection unchecked
-                    source = new CoalescePropertiesVisitor<Integer>().visitDocuments(a.withDocuments(ListUtils.map(a.getDocuments(), doc -> {
+                    source = new CoalescePropertiesVisitor<Integer>(null, null).visitDocuments(a.withDocuments(ListUtils.map(a.getDocuments(), doc -> {
                         if (doc == null) {
                             return null;
                         }

--- a/src/main/java/org/openrewrite/java/spring/boot2/MigrateDatabaseCredentialsForToolYaml.java
+++ b/src/main/java/org/openrewrite/java/spring/boot2/MigrateDatabaseCredentialsForToolYaml.java
@@ -60,7 +60,7 @@ class MigrateDatabaseCredentialsForToolYaml extends Recipe {
             public Yaml visitDocuments(Yaml.Documents documents, ExecutionContext ctx) {
                 doAfterVisit(new MergeYaml("$.spring." + tool, "username: ${spring.datasource.username}", true, null, null, null, null, null).getVisitor());
                 doAfterVisit(new MergeYaml("$.spring." + tool, "password: ${spring.datasource.password}", true, null, null, null, null, null).getVisitor());
-                doAfterVisit(new CoalesceProperties().getVisitor());
+                doAfterVisit(new CoalesceProperties(null, null).getVisitor());
                 return documents;
             }
         });


### PR DESCRIPTION
### Checklist
- [X] I've added unit tests to cover both positive and negative cases
- [X] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [X] I've used the IntelliJ IDEA auto-formatter on affected files
