### PR TITLE
Fix bug where KafkaTestUtils duration argument can be something else then a J.Literal

### DIFF
--- a/src/main/java/org/openrewrite/java/spring/kafka/KafkaTestUtilsDuration.java
+++ b/src/main/java/org/openrewrite/java/spring/kafka/KafkaTestUtilsDuration.java
@@ -72,7 +72,7 @@ public class KafkaTestUtilsDuration extends Recipe {
                             if (arg == millis) {
                                 newParameterTypes.set(index, durationType);
                                 maybeAddImport(JAVA_TIME_DURATION);
-                                return JavaTemplate.builder("Duration.ofMillis(#{})")
+                                return JavaTemplate.builder("Duration.ofMillis(#{any()})")
                                         .imports(JAVA_TIME_DURATION)
                                         .build()
                                         .apply(new Cursor(getCursor(), arg), arg.getCoordinates().replace(), millis);

--- a/src/test/java/org/openrewrite/java/spring/kafka/KafkaTestUtilsDurationTest.java
+++ b/src/test/java/org/openrewrite/java/spring/kafka/KafkaTestUtilsDurationTest.java
@@ -44,7 +44,7 @@ class KafkaTestUtilsDurationTest implements RewriteTest {
             """
               import org.apache.kafka.clients.consumer.Consumer;
               import org.springframework.kafka.test.utils.KafkaTestUtils;
-              
+
               class Foo {
                   void bar(Consumer<String, String> consumer) {
                       KafkaTestUtils.getRecords(consumer, 1000L);
@@ -57,15 +57,52 @@ class KafkaTestUtilsDurationTest implements RewriteTest {
             """
               import org.apache.kafka.clients.consumer.Consumer;
               import org.springframework.kafka.test.utils.KafkaTestUtils;
-              
+
               import java.time.Duration;
-              
+
               class Foo {
                   void bar(Consumer<String, String> consumer) {
                       KafkaTestUtils.getRecords(consumer, Duration.ofMillis(1000L));
                       KafkaTestUtils.getRecords(consumer, Duration.ofMillis(1000L), 1);
                       KafkaTestUtils.getSingleRecord(consumer, "topic", Duration.ofMillis(1000L));
                       KafkaTestUtils.getOneRecord("topic", "key", "value", 1, true, true, Duration.ofMillis(1000L));
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void adoptDurationParameter() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import org.apache.kafka.clients.consumer.Consumer;
+              import org.springframework.kafka.test.utils.KafkaTestUtils;
+
+              class Foo {
+                  void bar(Consumer<String, String> consumer, long duration) {
+                      KafkaTestUtils.getRecords(consumer, duration);
+                      KafkaTestUtils.getRecords(consumer, duration, 1);
+                      KafkaTestUtils.getSingleRecord(consumer, "topic", duration);
+                      KafkaTestUtils.getOneRecord("topic", "key", "value", 1, true, true, duration);
+                  }
+              }
+              """,
+            """
+              import org.apache.kafka.clients.consumer.Consumer;
+              import org.springframework.kafka.test.utils.KafkaTestUtils;
+
+              import java.time.Duration;
+
+              class Foo {
+                  void bar(Consumer<String, String> consumer, long duration) {
+                      KafkaTestUtils.getRecords(consumer, Duration.ofMillis(duration));
+                      KafkaTestUtils.getRecords(consumer, Duration.ofMillis(duration), 1);
+                      KafkaTestUtils.getSingleRecord(consumer, "topic", Duration.ofMillis(duration));
+                      KafkaTestUtils.getOneRecord("topic", "key", "value", 1, true, true, Duration.ofMillis(duration));
                   }
               }
               """


### PR DESCRIPTION
The test that I added showed that the template was wrong: 

```
java.lang.IllegalArgumentException: Template parameter 0 cannot be used in an untyped template substitution. Instead of "#{}", indicate the template parameter's type with "#{any(long)}".
  org.openrewrite.java.internal.template.Substitutions.substituteUntyped(Substitutions.java:183)
  org.openrewrite.java.internal.template.Substitutions.lambda$substitute$0(Substitutions.java:83)
  org.openrewrite.internal.PropertyPlaceholderHelper.parseStringValue(PropertyPlaceholderHelper.java:98)
  org.openrewrite.internal.PropertyPlaceholderHelper.replacePlaceholders(PropertyPlaceholderHelper.java:74)
  org.openrewrite.java.internal.template.Substitutions.substitute(Substitutions.java:61)
  org.openrewrite.java.JavaTemplate.apply(JavaTemplate.java:115)
  org.openrewrite.java.spring.kafka.KafkaTestUtilsDuration$1.lambda$visitMethodInvocation$0(KafkaTestUtilsDuration.java:78)
  org.openrewrite.internal.ListUtils.map(ListUtils.java:206)
  org.openrewrite.java.spring.kafka.KafkaTestUtilsDuration$1.visitMethodInvocation(KafkaTestUtilsDuration.java:71)
  org.openrewrite.java.spring.kafka.KafkaTestUtilsDuration$1.visitMethodInvocation(KafkaTestUtilsDuration.java:54)
  org.openrewrite.java.tree.J$MethodInvocation.acceptJava(J.java:4290)
  org.openrewrite.java.tree.J.accept(J.java:60)
  org.openrewrite.TreeVisitor.visit(TreeVisitor.java:245)
  org.openrewrite.TreeVisitor.visitAndCast(TreeVisitor.java:311)
  org.openrewrite.java.JavaVisitor.visitRightPadded(JavaVisitor.java:1310)
  org.openrewrite.java.JavaVisitor.visitMethodInvocation(JavaVisitor.java:870)
```