### PR TITLE
Migration Recipe for Spring Security 6.5

### DIFF
--- a/src/main/resources/META-INF/rewrite/spring-boot-35.yml
+++ b/src/main/resources/META-INF/rewrite/spring-boot-35.yml
@@ -28,6 +28,7 @@ recipeList:
   - org.openrewrite.java.spring.boot3.UpgradeSpringBoot_3_4
   - org.openrewrite.java.spring.boot3.SpringBootProperties_3_5
   - org.openrewrite.java.spring.cloud2025.UpgradeSpringCloud_2025
+  - org.openrewrite.java.spring.security6.UpgradeSpringSecurity_6_5
   - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
       groupId: org.springframework.boot
       artifactId: "*"

--- a/src/main/resources/META-INF/rewrite/spring-security-65.yml
+++ b/src/main/resources/META-INF/rewrite/spring-security-65.yml
@@ -1,0 +1,38 @@
+#
+# Copyright 2025 the original author or authors.
+# <p>
+# Licensed under the Moderne Source Available License (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# <p>
+# https://docs.moderne.io/licensing/moderne-source-available-license
+# <p>
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.spring.security6.UpgradeSpringSecurity_6_5
+displayName: Migrate to Spring Security 6.5
+description: >-
+  Migrate applications to the latest Spring Security 6.5 release. This recipe will modify an
+  application's build files, make changes to deprecated/preferred APIs, and migrate configuration settings that have
+  changes between versions.
+tags:
+  - spring
+  - security
+recipeList:
+  - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
+      groupId: org.springframework.security
+      artifactId: "*"
+      newVersion: 6.5.x
+      overrideManagedVersion: false
+  - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
+      groupId: org.springframework.security
+      artifactId: spring-security-oauth2-authorization-server
+      newVersion: 1.5.x
+      overrideManagedVersion: false


### PR DESCRIPTION
Also updated "Migrate to Spring Boot 3.5"

- Refs: #793

- Related to #798