### PR TITLE
`SpringBean` Trait for `@Bean` methods

### DIFF
--- a/src/main/java/org/openrewrite/java/spring/trait/SpringBean.java
+++ b/src/main/java/org/openrewrite/java/spring/trait/SpringBean.java
@@ -22,6 +22,7 @@ import org.openrewrite.Tree;
 import org.openrewrite.java.AnnotationMatcher;
 import org.openrewrite.java.service.AnnotationService;
 import org.openrewrite.java.trait.Annotated;
+import org.openrewrite.java.trait.Literal;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.trait.SimpleTraitMatcher;
 import org.openrewrite.trait.Trait;
@@ -47,7 +48,7 @@ public class SpringBean implements Trait<Tree> {
             return new Annotated.Matcher("org.springframework.context.annotation.Bean")
                     .lower(cursor).findFirst()
                     .flatMap(a -> a.getDefaultAttribute("name"))
-                    .map(name -> name.getValue(String.class))
+                    .map(Literal::getString)
                     .orElse(((J.MethodDeclaration) getTree()).getSimpleName());
         }
         return null;

--- a/src/test/java/org/openrewrite/java/spring/trait/SpringBeanTest.java
+++ b/src/test/java/org/openrewrite/java/spring/trait/SpringBeanTest.java
@@ -108,27 +108,25 @@ class SpringBeanTest implements RewriteTest {
                   import org.springframework.context.annotation.Configuration;
 
                   @Configuration
-                  public class BeansConfiguration {
+                  class BeansConfiguration {
                       @Bean
-                      public UserService userService() {
-                          UserService bean = new UserService();
-                          return bean;
+                      UserService userService() {
+                          return new UserService();
                       }
                   }
                   """,
                 //language=java
                 """
-                                  package com.example;
+                  package com.example;
 
                   import org.springframework.context.annotation.Bean;
                   import org.springframework.context.annotation.Configuration;
 
                   @Configuration
-                  public class BeansConfiguration {
+                  class BeansConfiguration {
                       /*~~(userService)~~>*/@Bean
-                      public UserService userService() {
-                          UserService bean = new UserService();
-                          return bean;
+                      UserService userService() {
+                          return new UserService();
                       }
                   }
                   """
@@ -137,7 +135,7 @@ class SpringBeanTest implements RewriteTest {
         }
 
         @Test
-        void expliciteName() {
+        void explicitName() {
             rewriteRun(
               java(
                 //language=java
@@ -148,11 +146,10 @@ class SpringBeanTest implements RewriteTest {
                   import org.springframework.context.annotation.Configuration;
 
                   @Configuration
-                  public class BeansConfiguration {
+                  class BeansConfiguration {
                       @Bean(name="testName")
-                      public UserService userService() {
-                          UserService bean = new UserService();
-                          return bean;
+                      UserService userService() {
+                          return new UserService();
                       }
                   }
                   """,
@@ -164,11 +161,10 @@ class SpringBeanTest implements RewriteTest {
                   import org.springframework.context.annotation.Configuration;
 
                   @Configuration
-                  public class BeansConfiguration {
+                  class BeansConfiguration {
                       /*~~(testName)~~>*/@Bean(name="testName")
-                      public UserService userService() {
-                          UserService bean = new UserService();
-                          return bean;
+                      UserService userService() {
+                          return new UserService();
                       }
                   }
                   """


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
enabled the `SpringBean` Trait to properly detect and forward Spring Bean defining methods. Prior it used to find `J.Annotation`s and tried to provide `J.MethodDeclaration`s leading to class cast exceptions.

## What's your motivation?
Simpler implement Spring Bean discovery

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
Methods that are annotated with `@Bean` define the bean, not the annotation itself.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
