### PR TITLE
Migrate Spring Framework null annotations to JSpecify

### DIFF
--- a/src/main/resources/META-INF/rewrite/spring-framework-70.yml
+++ b/src/main/resources/META-INF/rewrite/spring-framework-70.yml
@@ -27,9 +27,4 @@ recipeList:
       newVersion: 7.0.x
   - org.openrewrite.java.testing.junit6.JUnit5to6Migration
   - org.openrewrite.java.jackson.UpgradeJackson_2_3
-  - org.openrewrite.java.ChangeType:
-      oldFullyQualifiedTypeName: 'org.springframework.lang.Nullable'
-      newFullyQualifiedTypeName: 'org.jspecify.annotations.Nullable'
-  - org.openrewrite.java.ChangeType:
-      oldFullyQualifiedTypeName: 'org.springframework.lang.NonNull'
-      newFullyQualifiedTypeName: 'org.jspecify.annotations.NonNull'
+  - org.openrewrite.java.jspecify.MigrateFromSpringFrameworkAnnotations


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->
Add annotation replacement for `@org.springframework.lang.Nullable` & `@org.springframework.lang.NonNull` following the information in spring framework release note : https://github.com/spring-projects/spring-framework/wiki/Spring-Framework-7.0-Release-Notes#null-safety

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->

- Complete spring framework 7 receipe and close part of this comment : https://github.com/openrewrite/rewrite-spring/issues/754#issuecomment-3213351898

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->
This is my first contribution i hope i have make it correctly :-)
 
### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
