### PR TITLE
Spring batch 6.0 - handle infrastructure package change

### DIFF
--- a/src/main/resources/META-INF/rewrite/spring-batch-6.0.yml
+++ b/src/main/resources/META-INF/rewrite/spring-batch-6.0.yml
@@ -29,3 +29,19 @@ recipeList:
       artifactId: "*"
       newVersion: 6.0.x
       overrideManagedVersion: false
+  - org.openrewrite.java.ChangePackage:
+      oldPackageName: org.springframework.batch.item
+      newPackageName: org.springframework.batch.infrastructure.item
+      recursive: true
+  - org.openrewrite.java.ChangePackage:
+      oldPackageName: org.springframework.batch.poller
+      newPackageName: org.springframework.batch.infrastructure.poller
+      recursive: true
+  - org.openrewrite.java.ChangePackage:
+      oldPackageName: org.springframework.batch.repeat
+      newPackageName: org.springframework.batch.infrastructure.repeat
+      recursive: true
+  - org.openrewrite.java.ChangePackage:
+      oldPackageName: org.springframework.batch.support
+      newPackageName: org.springframework.batch.infrastructure.support
+      recursive: true


### PR DESCRIPTION
- Related to #831

## What's changed?
All APIs defined in the spring-batch-infrastructure module were moved from **org.springframework.batch.*** to **org.springframework.batch.infrastructure.***
https://github.com/spring-projects/spring-batch/wiki/Spring-Batch-6.0-Migration-Guide#moved-apis

## What's your motivation?
Support Spring batch latest version 6.0

## Any additional context
spring-batch-infrastructure contains 4 packages in org.springframework.batch : **item**, **poller**, **repeat** and **support**
https://github.com/spring-projects/spring-batch/tree/5.0.x/spring-batch-infrastructure/src/main/java/org/springframework/batch

@timtebeek 