### PR TITLE
Spring batch 6.0 - handle core explore package change

### DIFF
--- a/src/main/resources/META-INF/rewrite/spring-batch-6.0.yml
+++ b/src/main/resources/META-INF/rewrite/spring-batch-6.0.yml
@@ -45,3 +45,7 @@ recipeList:
       oldPackageName: org.springframework.batch.support
       newPackageName: org.springframework.batch.infrastructure.support
       recursive: true
+  - org.openrewrite.java.ChangePackage:
+      oldPackageName: org.springframework.batch.core.explore
+      newPackageName: org.springframework.batch.core.repository.explore
+      recursive: true


### PR DESCRIPTION
- Related to #831

## What's changed?
All APIs under **org.springframework.batch.core.explore** package have been moved under **org.springframework.batch.core.repository.explore**
https://github.com/spring-projects/spring-batch/wiki/Spring-Batch-6.0-Migration-Guide#moved-apis

## What's your motivation?
Support Spring batch latest version 6.0

## Any additional context
Link to spring-batch 5.0.x core explore version https://github.com/spring-projects/spring-batch/tree/5.0.x/spring-batch-core/src/main/java/org/springframework/batch/core/explore

@timtebeek 