### PR TITLE
Spring batch 6.0 - handle Mongo DAOs package change

### DIFF
--- a/src/main/resources/META-INF/rewrite/spring-batch-6.0.yml
+++ b/src/main/resources/META-INF/rewrite/spring-batch-6.0.yml
@@ -45,6 +45,10 @@ recipeList:
       oldPackageName: org.springframework.batch.support
       newPackageName: org.springframework.batch.infrastructure.support
       recursive: true
+  - org.openrewrite.java.ChangePackage:
+      oldPackageName: org.springframework.batch.core.explore
+      newPackageName: org.springframework.batch.core.repository.explore
+      recursive: true
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: org.springframework.batch.core.repository.dao.JdbcExecutionContextDao
       newFullyQualifiedTypeName: org.springframework.batch.core.repository.dao.jdbc.JdbcExecutionContextDao
@@ -57,7 +61,18 @@ recipeList:
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: org.springframework.batch.core.repository.dao.JdbcStepExecutionDao
       newFullyQualifiedTypeName: org.springframework.batch.core.repository.dao.jdbc.JdbcStepExecutionDao
-  - org.openrewrite.java.ChangePackage:
-      oldPackageName: org.springframework.batch.core.explore
-      newPackageName: org.springframework.batch.core.repository.explore
-      recursive: true
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.springframework.batch.core.repository.dao.MongoExecutionContextDao
+      newFullyQualifiedTypeName: org.springframework.batch.core.repository.dao.mongo.MongoExecutionContextDao
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.springframework.batch.core.repository.dao.MongoJobExecutionDao
+      newFullyQualifiedTypeName: org.springframework.batch.core.repository.dao.mongo.MongoJobExecutionDao
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.springframework.batch.core.repository.dao.MongoJobInstanceDao
+      newFullyQualifiedTypeName: org.springframework.batch.core.repository.dao.mongo.MongoJobInstanceDao
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.springframework.batch.core.repository.dao.MongoStepExecutionDao
+      newFullyQualifiedTypeName: org.springframework.batch.core.repository.dao.mongo.MongoStepExecutionDao
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.springframework.batch.core.repository.dao.MongoSequenceIncrementer
+      newFullyQualifiedTypeName: org.springframework.batch.core.repository.dao.mongo.MongoSequenceIncrementer


### PR DESCRIPTION
- Related to #831

## What's changed?
`MongoExecutionContextDao`, `MongoJobExecutionDao`, `MongoJobInstanceDao`, `MongoStepExecutionDao` and `MongoSequenceIncrementer` have been moved from `org.springframework.batch.core.repository.dao` to `org.springframework.batch.core.repository.dao.mongo`
https://github.com/spring-projects/spring-batch/wiki/Spring-Batch-6.0-Migration-Guide#moved-apis

## What's your motivation?
Support Spring batch latest version 6.0

## Any additional context
Link to spring-batch 5.0.x core repository dao version https://github.com/spring-projects/spring-batch/tree/5.0.x/spring-batch-core/src/main/java/org/springframework/batch/core/repository/dao

@timtebeek 
