### PR TITLE
Spring batch 6.0 - handle partition package changes

### DIFF
--- a/src/main/resources/META-INF/rewrite/spring-batch-6.0.yml
+++ b/src/main/resources/META-INF/rewrite/spring-batch-6.0.yml
@@ -76,3 +76,15 @@ recipeList:
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: org.springframework.batch.core.repository.dao.MongoSequenceIncrementer
       newFullyQualifiedTypeName: org.springframework.batch.core.repository.dao.mongo.MongoSequenceIncrementer
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.springframework.batch.core.partition.support.Partitioner
+      newFullyQualifiedTypeName: org.springframework.batch.core.partition.Partitioner
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.springframework.batch.core.partition.support.PartitionNameProvider
+      newFullyQualifiedTypeName: org.springframework.batch.core.partition.PartitionNameProvider
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.springframework.batch.core.partition.support.PartitionStep
+      newFullyQualifiedTypeName: org.springframework.batch.core.partition.PartitionStep
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.springframework.batch.core.partition.support.StepExecutionAggregator
+      newFullyQualifiedTypeName: org.springframework.batch.core.partition.StepExecutionAggregator


### PR DESCRIPTION
- Related to #831

## What's changed?
`Partitioner`, `PartitionNameProvider`, `PartitionStep` and `StepExecutionAggregator` have been moved from `org.springframework.batch.core.partition.support` to `org.springframework.batch.core.partition`
https://github.com/spring-projects/spring-batch/wiki/Spring-Batch-6.0-Migration-Guide#moved-apis

## What's your motivation?
Support Spring batch latest version 6.0

## Any additional context
Link to spring-batch 5.0.x version of partition package https://github.com/spring-projects/spring-batch/tree/5.0.x/spring-batch-core/src/main/java/org/springframework/batch/core/partition

@timtebeek 
