### PR TITLE
Spring batch 6.0 - handle core step package change

### DIFF
--- a/src/main/resources/META-INF/rewrite/spring-batch-6.0.yml
+++ b/src/main/resources/META-INF/rewrite/spring-batch-6.0.yml
@@ -139,3 +139,12 @@ recipeList:
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: org.springframework.batch.core.UnexpectedJobExecutionException
       newFullyQualifiedTypeName: org.springframework.batch.core.job.UnexpectedJobExecutionException
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.springframework.batch.core.Step
+      newFullyQualifiedTypeName: org.springframework.batch.core.step.Step
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.springframework.batch.core.StepContribution
+      newFullyQualifiedTypeName: org.springframework.batch.core.step.StepContribution
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.springframework.batch.core.StepExecution
+      newFullyQualifiedTypeName: org.springframework.batch.core.step.StepExecution


### PR DESCRIPTION
- Related to #831

## What's changed?
`Step`, `StepContribution` and `StepExecution` have been moved from `org.springframework.batch.core` to `org.springframework.batch.core.step`
https://github.com/spring-projects/spring-batch/wiki/Spring-Batch-6.0-Migration-Guide#moved-apis

## What's your motivation?
Support Spring batch latest version 6.0

## Any additional context
spring-batch 5.0.x core package https://github.com/spring-projects/spring-batch/tree/5.0.x/spring-batch-core/src/main/java/org/springframework/batch/core

spring-batch 6.0.x core step package https://github.com/spring-projects/spring-batch/tree/main/spring-batch-core/src/main/java/org/springframework/batch/core/step

@timtebeek 
