### PR TITLE
Prepare formatting refactor by addressing a test expectation difference

### DIFF
--- a/src/test/java/org/openrewrite/java/spring/batch/RemoveDefaultBatchConfigurerTest.java
+++ b/src/test/java/org/openrewrite/java/spring/batch/RemoveDefaultBatchConfigurerTest.java
@@ -159,7 +159,7 @@ class RemoveDefaultBatchConfigurerTest implements RewriteTest {
             """
               import org.springframework.batch.core.configuration.annotation.BatchConfigurer;
               import org.springframework.batch.core.configuration.annotation.DefaultBatchConfigurer;
-              class FooConfig  {
+              class FooConfig {
                   public BatchConfigurer bean(javax.sql.DataSource dataSource) {
                       return new DefaultBatchConfigurer(dataSource);
                   }


### PR DESCRIPTION
After running the updated formatting locally, this test would fail. It also passes in the current formatting setup with this change, so changing here before merging upstream.

Reason for changing expectation here: We're removing a class internal modifier and not expecting a formatting change in the upper class declaration -> we should not format the entire class as we remove 1 method in it.