### PR TITLE
Spring batch 6.0 - Rename ChunkHandler to ChunkRequestHandler

### DIFF
--- a/src/main/resources/META-INF/rewrite/spring-batch-6.0.yml
+++ b/src/main/resources/META-INF/rewrite/spring-batch-6.0.yml
@@ -178,3 +178,6 @@ recipeList:
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: org.springframework.batch.core.StepExecution
       newFullyQualifiedTypeName: org.springframework.batch.core.step.StepExecution
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.springframework.batch.integration.chunk.ChunkHandler
+      newFullyQualifiedTypeName: org.springframework.batch.integration.chunk.ChunkRequestHandler


### PR DESCRIPTION
- Related to #831

## What's changed?
The class `org.springframework.batch.integration.chunk.ChunkHandler` was renamed to `org.springframework.batch.integration.chunk.ChunkRequestHandler`
https://github.com/spring-projects/spring-batch/wiki/Spring-Batch-6.0-Migration-Guide#moved-apis

## What's your motivation?
Support Spring batch latest version 6.0

## Any additional context
spring-batch 5.0.x integration chunk package https://github.com/spring-projects/spring-batch/tree/5.0.x/spring-batch-integration/src/main/java/org/springframework/batch/integration/chunk

spring-batch 6.0.x integration chunk package https://github.com/spring-projects/spring-batch/tree/main/spring-batch-integration/src/main/java/org/springframework/batch/integration/chunk

@timtebeek 
