### PR TITLE
Spring batch 6.0 - rename JobRepositoryFactoryBean to JdbcJobRepositoryFactoryBean

### DIFF
--- a/src/main/resources/META-INF/rewrite/spring-batch-6.0.yml
+++ b/src/main/resources/META-INF/rewrite/spring-batch-6.0.yml
@@ -181,3 +181,6 @@ recipeList:
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: org.springframework.batch.integration.chunk.ChunkHandler
       newFullyQualifiedTypeName: org.springframework.batch.integration.chunk.ChunkRequestHandler
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.springframework.batch.core.repository.support.JobRepositoryFactoryBean
+      newFullyQualifiedTypeName: org.springframework.batch.core.repository.support.JdbcJobRepositoryFactoryBean


### PR DESCRIPTION
- Related to #831

## What's changed?
`org.springframework.batch.core.repository.support.JobRepositoryFactoryBean` is renamed to `JdbcJobRepositoryFactoryBean` 
https://github.com/spring-projects/spring-batch/wiki/Spring-Batch-6.0-Migration-Guide#moved-apis

## What's your motivation?
Support Spring batch latest version 6.0

## Any additional context
spring-batch 5.0.x core repository support package https://github.com/spring-projects/spring-batch/tree/5.0.x/spring-batch-core/src/main/java/org/springframework/batch/core/repository/support

spring-batch 6.0.x core repository support package https://github.com/spring-projects/spring-batch/tree/main/spring-batch-core/src/main/java/org/springframework/batch/core/repository/support

@timtebeek 
