### PR TITLE
Spring batch 6.0 - Rename JobExplorerFactoryBean to JdbcJobExplorerFactoryBean

### DIFF
--- a/src/main/resources/META-INF/rewrite/spring-batch-6.0.yml
+++ b/src/main/resources/META-INF/rewrite/spring-batch-6.0.yml
@@ -184,3 +184,6 @@ recipeList:
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: org.springframework.batch.core.repository.support.JobRepositoryFactoryBean
       newFullyQualifiedTypeName: org.springframework.batch.core.repository.support.JdbcJobRepositoryFactoryBean
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.springframework.batch.core.repository.explore.support.JobExplorerFactoryBean
+      newFullyQualifiedTypeName: org.springframework.batch.core.repository.explore.support.JdbcJobExplorerFactoryBean


### PR DESCRIPTION
- Related to #831

## What's changed?
`org.springframework.batch.core.repository.explore.support.JobExplorerFactoryBean`: renamed to `JdbcJobExplorerFactoryBean`
https://github.com/spring-projects/spring-batch/wiki/Spring-Batch-6.0-Migration-Guide#moved-apis

## What's your motivation?
Support Spring batch latest version 6.0

## Any additional context
spring-batch 5.0.x version https://github.com/spring-projects/spring-batch/blob/5.0.x/spring-batch-core/src/main/java/org/springframework/batch/core/explore/support/JobExplorerFactoryBean.java

spring-batch 6.0.x version https://github.com/spring-projects/spring-batch/blob/main/spring-batch-core/src/main/java/org/springframework/batch/core/repository/explore/support/JdbcJobExplorerFactoryBean.java

@timtebeek 
