### PR TITLE
Fix old Spring Cloud Gateway starter names

### DIFF
--- a/src/main/resources/META-INF/rewrite/spring-cloud-2025.yml
+++ b/src/main/resources/META-INF/rewrite/spring-cloud-2025.yml
@@ -108,11 +108,11 @@ recipeList:
       newArtifactId: spring-cloud-gateway-server-webmvc
   - org.openrewrite.java.dependencies.ChangeDependency:
       oldGroupId: org.springframework.cloud
-      oldArtifactId: spring-cloud-starter-gateway-server
+      oldArtifactId: spring-cloud-starter-gateway
       newArtifactId: spring-cloud-starter-gateway-server-webflux
   - org.openrewrite.java.dependencies.ChangeDependency:
       oldGroupId: org.springframework.cloud
-      oldArtifactId: spring-cloud-starter-gateway-server-mvc
+      oldArtifactId: spring-cloud-starter-gateway-mvc
       newArtifactId: spring-cloud-starter-gateway-server-webmvc
   - org.openrewrite.java.dependencies.ChangeDependency:
       oldGroupId: org.springframework.cloud


### PR DESCRIPTION
## What's changed?
- Use correct package name for old Spring Cloud Gateway starters. See spring-cloud/spring-cloud-release#452.

## What's your motivation?
The names that were specified in the release notes do not actually exist. 😏

## Anything in particular you'd like reviewers to focus on?
~Maybe wait for some feedback on the above issue?~ Edit: already fixed in the release notes!

## Anyone you would like to review specifically?
- No, just an FYI for @sruffatti as these were implemented in #770

## Have you considered any alternatives or workarounds?
N/A

## Any additional context
N/A

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
  - These changes aren’t covered by tests.
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files – N/A