### PR TITLE
Add JUnit6BestPractices migration to spring-boot-40.yml

### DIFF
--- a/src/main/resources/META-INF/rewrite/spring-boot-40.yml
+++ b/src/main/resources/META-INF/rewrite/spring-boot-40.yml
@@ -32,7 +32,7 @@ recipeList:
   - org.openrewrite.java.spring.boot4.SpringBootProperties_4_0
   - org.openrewrite.java.spring.boot4.ReplaceMockBeanAndSpyBean
   - org.openrewrite.hibernate.MigrateToHibernate71
-  - org.openrewrite.java.testing.junit.JUnit6BestPractices
+  - org.openrewrite.java.testing.junit6.JUnit5to6Migration
   - org.openrewrite.java.testing.testcontainers.Testcontainers2Migration
   - org.openrewrite.java.spring.boot4.MigrateToModularStarters
   - org.openrewrite.java.dependencies.UpgradeDependencyVersion:


### PR DESCRIPTION
Since SpringBoot 4 is using JUnit6, we should have a recipe that upgrade to JUnit6 API.
 I'm not sure what's best between `org.openrewrite.java.testing.junit.JUnit6BestPractices` and `org.openrewrite.java.testing.junit6.JUnit5to6Migration`, since junit recipes are a bit of a mess.