### PR TITLE
spring-boot-40: upgrade to neo4j-migrations-spring-boot-starter 3.0

### DIFF
--- a/src/main/resources/META-INF/rewrite/spring-boot-40.yml
+++ b/src/main/resources/META-INF/rewrite/spring-boot-40.yml
@@ -90,6 +90,11 @@ recipeList:
 
   # Additional dependencies that need to move in sync
   - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
+      groupId: eu.michael-simons.neo4j
+      artifactId: neo4j-migrations-spring-boot-starter
+      newVersion: 3.0.x
+      overrideManagedVersion: true
+  - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
       groupId: io.github.wimdeblauwe
       artifactId: error-handling-spring-boot-starter
       newVersion: 5.0.x


### PR DESCRIPTION
spring-boot and neo4j-migrations-spring-boot-starter dependencies need to move in sync

<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
