### PR TITLE
spring-boot-40: handle rename of spring-boot-persistence packages

### DIFF
--- a/src/main/resources/META-INF/rewrite/spring-boot-40-modular-starters.yml
+++ b/src/main/resources/META-INF/rewrite/spring-boot-40-modular-starters.yml
@@ -177,6 +177,15 @@ recipeList:
       oldPackageName: org.springframework.boot.autoconfigure.data.jpa
       newPackageName: org.springframework.boot.data.jpa.autoconfigure
       recursive: true
+  # spring-boot-persistence
+  - org.openrewrite.java.ChangePackage:
+      oldPackageName: org.springframework.boot.autoconfigure.domain
+      newPackageName: org.springframework.boot.persistence.autoconfigure
+      recursive: true
+  - org.openrewrite.java.ChangePackage:
+      oldPackageName: org.springframework.boot.autoconfigure.dao
+      newPackageName: org.springframework.boot.persistence.autoconfigure
+      recursive: true
   # spring-boot-hibernate
   - org.openrewrite.java.ChangePackage:
       oldPackageName: org.springframework.boot.autoconfigure.orm.jpa

--- a/src/test/java/org/openrewrite/java/spring/boot4/MigrateToModularStartersTest.java
+++ b/src/test/java/org/openrewrite/java/spring/boot4/MigrateToModularStartersTest.java
@@ -127,6 +127,34 @@ class MigrateToModularStartersTest implements RewriteTest {
         );
     }
 
+    @Test
+    void migrateSpringBootPersistencePackages() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import org.springframework.context.annotation.Configuration;
+              import org.springframework.boot.autoconfigure.domain.EntityScan;
+
+              @Configuration
+              @EntityScan("x.y.z")
+              class PersistenceConfig {
+              }
+              """
+            ,
+            """
+              import org.springframework.context.annotation.Configuration;
+              import org.springframework.boot.persistence.autoconfigure.EntityScan;
+
+              @Configuration
+              @EntityScan("x.y.z")
+              class PersistenceConfig {
+              }
+              """
+          )
+        );
+    }
+
     @Nested
     class RestClientStarter {
 


### PR DESCRIPTION
Handles package renaming of classes inside `spring-boot-persistence` dependency (Spring Boot 4.0).

It contains for example the annotation `@EntityScan`.

See:
- https://docs.spring.io/spring-boot/api/java/org/springframework/boot/persistence/autoconfigure/EntityScan.html
- https://docs.spring.io/spring-boot/how-to/data-access.html#howto.data-access.separate-entity-definitions-from-spring-configuration