### PR TITLE
spring-boot-40: handle rename of spring-boot-starter-validation packages

### DIFF
--- a/src/main/resources/META-INF/rewrite/spring-boot-40-modular-starters.yml
+++ b/src/main/resources/META-INF/rewrite/spring-boot-40-modular-starters.yml
@@ -256,6 +256,11 @@ recipeList:
       oldPackageName: org.springframework.boot.autoconfigure.security.oauth2.resource
       newPackageName: org.springframework.boot.security.oauth2.server.resource.autoconfigure
       recursive: true
+  # spring-boot-starter-validation
+  - org.openrewrite.java.ChangePackage:
+      oldPackageName: org.springframework.boot.autoconfigure.validation
+      newPackageName: org.springframework.boot.validation.autoconfigure
+      recursive: true
   # spring-boot-webmvc
   - org.openrewrite.java.ChangePackage:
       oldPackageName: org.springframework.boot.autoconfigure.web.servlet


### PR DESCRIPTION
## What's changed?
<!-- A brief description of the changes in this pull request -->

Handles package renaming of classes inside spring-boot-starter-validation dependency (Spring Boot 4.0).

eg : 
- in SB 3 : [org.springframework.boot.autoconfigure.validation.ValidationAutoConfiguration](https://github.com/spring-projects/spring-boot/blob/3.5.x/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/validation/ValidationAutoConfiguration.java)
- in SB 4 : [org.springframework.boot.validation.autoconfigure.ValidationAutoConfiguration](https://github.com/spring-projects/spring-boot/blob/main/module/spring-boot-validation/src/main/java/org/springframework/boot/validation/autoconfigure/ValidationAutoConfiguration.java)


### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
