### PR TITLE
Bump spring ws when moving to spring boot 3

### DIFF
--- a/src/main/resources/META-INF/rewrite/spring-boot-30.yml
+++ b/src/main/resources/META-INF/rewrite/spring-boot-30.yml
@@ -47,6 +47,10 @@ recipeList:
       groupId: org.springframework
       artifactId: "*"
       newVersion: 6.0.x
+  - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
+      groupId: org.springframework.ws
+      artifactId: "*"
+      newVersion: 4.x
   - org.openrewrite.maven.UpgradePluginVersion:
       groupId: org.springframework.boot
       artifactId: spring-boot-maven-plugin


### PR DESCRIPTION
This is the version of Spring WS you’ll need if you are building SOAP-based applications with Spring Boot 3.0.

more information can be found [here](https://spring.io/blog/2022/11/21/spring-web-services-4-0-0-is-now-ga)

We will immediately bump to [4.1.0](https://spring.io/blog/2025/05/20/spring-ws-4-1-0-available-now)