### PR TITLE
Add more Jackson 3 migrations for Spring Kafka

### DIFF
--- a/src/main/resources/META-INF/rewrite/spring-kafka-40.yml
+++ b/src/main/resources/META-INF/rewrite/spring-kafka-40.yml
@@ -24,7 +24,7 @@ tags:
   - spring
   - kafka
 recipeList:
-  # https://docs.spring.io/spring-kafka/reference/whats-new.html#x40-jackson3-support
+  # https://docs.spring.io/spring-kafka/reference/4.0/whats-new.html#x40-jackson3-support
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: org.springframework.kafka.support.DefaultKafkaHeaderMapper
       newFullyQualifiedTypeName: org.springframework.kafka.support.JsonKafkaHeaderMapper
@@ -46,3 +46,15 @@ recipeList:
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: org.springframework.kafka.support.serializer.JsonSerde
       newFullyQualifiedTypeName: org.springframework.kafka.support.serializer.JacksonJsonSerde
+  # These types are also deprecated for removal but not specifically called out in the 'what's new' section
+  # but mentioned here https://docs.spring.io/spring-kafka/reference/4.0/kafka/serdes.html#messaging-message-conversion
+  # so it is likely that users actually use these types in their code
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.springframework.kafka.support.converter.StringJsonMessageConverter
+      newFullyQualifiedTypeName: org.springframework.kafka.support.converter.StringJacksonJsonMessageConverter
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.springframework.kafka.support.converter.ByteArrayJsonMessageConverter
+      newFullyQualifiedTypeName: org.springframework.kafka.support.converter.ByteArrayJacksonJsonMessageConverter
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.springframework.kafka.support.converter.BytesJsonMessageConverter
+      newFullyQualifiedTypeName: org.springframework.kafka.support.converter.BytesJacksonJsonMessageConverter

--- a/src/test/java/org/openrewrite/java/spring/kafka/UpgradeSpringKafka40Test.java
+++ b/src/test/java/org/openrewrite/java/spring/kafka/UpgradeSpringKafka40Test.java
@@ -44,18 +44,18 @@ class UpgradeSpringKafka40Test implements RewriteTest {
           //language=java
           java(
             """
-              import org.springframework.kafka.support.DefaultKafkaHeaderMapper;
-              import org.springframework.kafka.support.converter.JsonMessageConverter;
-              import org.springframework.kafka.support.converter.ProjectingMessageConverter;
-              import org.springframework.kafka.support.mapping.DefaultJackson2JavaTypeMapper;
-              import org.springframework.kafka.support.serializer.JsonDeserializer;
-              import org.springframework.kafka.support.serializer.JsonSerde;
-              import org.springframework.kafka.support.serializer.JsonSerializer;
+              import org.springframework.kafka.support.*;
+              import org.springframework.kafka.support.converter.*;
+              import org.springframework.kafka.support.mapping.*;
+              import org.springframework.kafka.support.serializer.*;
 
               class Test {
                   DefaultKafkaHeaderMapper mapper = new DefaultKafkaHeaderMapper();
                   JsonMessageConverter converter = new JsonMessageConverter();
                   ProjectingMessageConverter projectingConverter = new ProjectingMessageConverter();
+                  ByteArrayJsonMessageConverter byteArrayJsonMessageConverter = new ByteArrayJsonMessageConverter();
+                  BytesJsonMessageConverter bytesJsonMessageConverter = new BytesJsonMessageConverter();
+                  StringJsonMessageConverter stringJsonMessageConverter = new StringJsonMessageConverter();
                   DefaultJackson2JavaTypeMapper typeMapper = new DefaultJackson2JavaTypeMapper();
                   JsonDeserializer<String> deserializer = new JsonDeserializer<>();
                   JsonSerde<String> serde = new JsonSerde<>();
@@ -63,18 +63,18 @@ class UpgradeSpringKafka40Test implements RewriteTest {
               }
               """,
             """
-              import org.springframework.kafka.support.JsonKafkaHeaderMapper;
-              import org.springframework.kafka.support.converter.JacksonJsonMessageConverter;
-              import org.springframework.kafka.support.converter.JacksonProjectingMessageConverter;
-              import org.springframework.kafka.support.mapping.DefaultJacksonJavaTypeMapper;
-              import org.springframework.kafka.support.serializer.JacksonJsonDeserializer;
-              import org.springframework.kafka.support.serializer.JacksonJsonSerde;
-              import org.springframework.kafka.support.serializer.JacksonJsonSerializer;
+              import org.springframework.kafka.support.*;
+              import org.springframework.kafka.support.converter.*;
+              import org.springframework.kafka.support.mapping.*;
+              import org.springframework.kafka.support.serializer.*;
 
               class Test {
                   JsonKafkaHeaderMapper mapper = new JsonKafkaHeaderMapper();
                   JacksonJsonMessageConverter converter = new JacksonJsonMessageConverter();
                   JacksonProjectingMessageConverter projectingConverter = new JacksonProjectingMessageConverter();
+                  ByteArrayJacksonJsonMessageConverter byteArrayJsonMessageConverter = new ByteArrayJacksonJsonMessageConverter();
+                  BytesJacksonJsonMessageConverter bytesJsonMessageConverter = new BytesJacksonJsonMessageConverter();
+                  StringJacksonJsonMessageConverter stringJsonMessageConverter = new StringJacksonJsonMessageConverter();
                   DefaultJacksonJavaTypeMapper typeMapper = new DefaultJacksonJavaTypeMapper();
                   JacksonJsonDeserializer<String> deserializer = new JacksonJsonDeserializer<>();
                   JacksonJsonSerde<String> serde = new JacksonJsonSerde<>();


### PR DESCRIPTION
These converters are mentioned in the serialization docs with regards to Spring Messaging support

- Contributes to #754

See:
  * https://docs.spring.io/spring-kafka/reference/4.0/kafka/serdes.html#messaging-message-conversion

<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
- Adds 3 more type changes for Spring Kafka 4.x migration, more or less a follow-up for https://github.com/openrewrite/rewrite-spring/pull/901

## What's your motivation?
Skimming through the Spring Kakfa docs I stumbled upon these

## Anything in particular you'd like reviewers to focus on?
Are `*` imports ok for the test cases?

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
