### PR TITLE
Migrate HttpHeaders methods removed in Spring Framework 7.0

### DIFF
--- a/src/main/java/org/openrewrite/java/spring/framework/MigrateHttpHeadersMultiValueMapMethods.java
+++ b/src/main/java/org/openrewrite/java/spring/framework/MigrateHttpHeadersMultiValueMapMethods.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.spring.framework;
+
+import lombok.Getter;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Preconditions;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.search.UsesType;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.TypeUtils;
+
+public class MigrateHttpHeadersMultiValueMapMethods extends Recipe {
+
+    private static final String HTTP_HEADERS = "org.springframework.http.HttpHeaders";
+
+    @Getter
+    final String displayName = "Migrate `HttpHeaders` methods removed when `MultiValueMap` contract was dropped";
+
+    @Getter
+    final String description = "Spring Framework 7.0 changed `HttpHeaders` to no longer implement `MultiValueMap`. " +
+            "This recipe replaces removed inherited method calls: " +
+            "`containsKey()` with `containsHeader()`, `keySet()` with `headerNames()`, " +
+            "and `entrySet()` with `headerSet()`.";
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return Preconditions.check(
+                new UsesType<>(HTTP_HEADERS, false),
+                new JavaIsoVisitor<ExecutionContext>() {
+                    @Override
+                    public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
+                        J.MethodInvocation mi = super.visitMethodInvocation(method, ctx);
+                        if (mi.getSelect() != null &&
+                            TypeUtils.isOfClassType(mi.getSelect().getType(), HTTP_HEADERS)) {
+                            String name = mi.getSimpleName();
+                            if ("containsKey".equals(name)) {
+                                return mi.withName(mi.getName().withSimpleName("containsHeader"));
+                            }
+                            if ("keySet".equals(name)) {
+                                return mi.withName(mi.getName().withSimpleName("headerNames"));
+                            }
+                            if ("entrySet".equals(name)) {
+                                return mi.withName(mi.getName().withSimpleName("headerSet"));
+                            }
+                        }
+                        return mi;
+                    }
+                }
+        );
+    }
+}

--- a/src/main/resources/META-INF/rewrite/spring-framework-70.yml
+++ b/src/main/resources/META-INF/rewrite/spring-framework-70.yml
@@ -25,6 +25,7 @@ recipeList:
       groupId: org.springframework
       artifactId: "*"
       newVersion: 7.0.x
+  - org.openrewrite.java.spring.framework.MigrateHttpHeadersMultiValueMapMethods
   - org.openrewrite.java.testing.junit6.JUnit5to6Migration
   - org.openrewrite.java.jackson.UpgradeJackson_2_3
   - org.openrewrite.java.spring.kafka.UpgradeSpringKafka_4_0

--- a/src/test/java/org/openrewrite/java/spring/framework/MigrateHttpHeadersMultiValueMapMethodsTest.java
+++ b/src/test/java/org/openrewrite/java/spring/framework/MigrateHttpHeadersMultiValueMapMethodsTest.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.spring.framework;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+class MigrateHttpHeadersMultiValueMapMethodsTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec
+          .recipe(new MigrateHttpHeadersMultiValueMapMethods())
+          //language=java
+          .parser(JavaParser.fromJavaVersion().dependsOn(
+            """
+              package org.springframework.http;
+
+              import java.util.HashMap;
+              import java.util.List;
+
+              public class HttpHeaders extends HashMap<String, List<String>> {
+                  public String getFirst(String headerName) {
+                      List<String> values = get(headerName);
+                      return values != null && !values.isEmpty() ? values.get(0) : null;
+                  }
+                  public void add(String headerName, String headerValue) {
+                  }
+              }
+              """
+          ));
+    }
+
+    @DocumentExample
+    @Test
+    void migrateContainsKeyToContainsHeader() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import org.springframework.http.HttpHeaders;
+
+              class A {
+                  void foo(HttpHeaders headers) {
+                      boolean hasAuth = headers.containsKey("Authorization");
+                  }
+              }
+              """,
+            """
+              import org.springframework.http.HttpHeaders;
+
+              class A {
+                  void foo(HttpHeaders headers) {
+                      boolean hasAuth = headers.containsHeader("Authorization");
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void migrateKeySetToHeaderNames() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import org.springframework.http.HttpHeaders;
+              import java.util.Set;
+
+              class A {
+                  void foo(HttpHeaders headers) {
+                      Set<String> names = headers.keySet();
+                  }
+              }
+              """,
+            """
+              import org.springframework.http.HttpHeaders;
+              import java.util.Set;
+
+              class A {
+                  void foo(HttpHeaders headers) {
+                      Set<String> names = headers.headerNames();
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void migrateEntrySetToHeaderSet() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import org.springframework.http.HttpHeaders;
+              import java.util.List;
+              import java.util.Map;
+              import java.util.Set;
+
+              class A {
+                  void foo(HttpHeaders headers) {
+                      Set<Map.Entry<String, List<String>>> entries = headers.entrySet();
+                  }
+              }
+              """,
+            """
+              import org.springframework.http.HttpHeaders;
+              import java.util.List;
+              import java.util.Map;
+              import java.util.Set;
+
+              class A {
+                  void foo(HttpHeaders headers) {
+                      Set<Map.Entry<String, List<String>>> entries = headers.headerSet();
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void doesNotModifyNonHttpHeadersMap() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.util.Map;
+              import java.util.HashMap;
+
+              class A {
+                  void foo() {
+                      Map<String, String> map = new HashMap<>();
+                      boolean hasKey = map.containsKey("key");
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void doesNotModifyHttpHeadersMethodsNotRemoved() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import org.springframework.http.HttpHeaders;
+
+              class A {
+                  void foo(HttpHeaders headers) {
+                      headers.add("X-Custom", "value");
+                      String first = headers.getFirst("X-Custom");
+                      boolean empty = headers.isEmpty();
+                      int size = headers.size();
+                  }
+              }
+              """
+          )
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Add `MigrateHttpHeadersMultiValueMapMethods` recipe to handle `HttpHeaders` API changes in Spring Framework 7.0
- Wire the recipe into the `UpgradeSpringFramework_7_0` recipe chain

## Problem

Spring Framework 7.0 changed `HttpHeaders` to no longer implement `MultiValueMap`. Several inherited `Map` methods were removed. Code that calls these methods on `HttpHeaders` instances will no longer compile after upgrading to Spring 7.

## Solution

New recipe replaces the removed inherited method calls on `HttpHeaders` instances:

| Before (Spring 6.x) | After (Spring 7.0) |
|---|---|
| `headers.containsKey(name)` | `headers.containsHeader(name)` |
| `headers.keySet()` | `headers.headerNames()` |
| `headers.entrySet()` | `headers.headerSet()` |

The recipe only transforms calls where the receiver is typed as `HttpHeaders` — other `Map` usages are unaffected.

## Test plan

- [x] Existing tests pass
- [x] New tests cover each method rename (`containsKey`, `keySet`, `entrySet`)
- [x] Negative tests verify non-HttpHeaders maps and non-removed HttpHeaders methods are untouched

- Fixes moderneinc/customer-requests#1747