### PR TITLE
Also upgrading the version of `spring-kafka` during the `Spring Kafka 3.x` upgrade to ensure compatibility with the included class changes.

### DIFF
--- a/src/main/resources/META-INF/rewrite/spring-kafka-30.yml
+++ b/src/main/resources/META-INF/rewrite/spring-kafka-30.yml
@@ -24,6 +24,10 @@ tags:
   - spring
   - kafka
 recipeList:
+  - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
+      groupId: org.springframework.kafka
+      artifactId: spring-kafka
+      newVersion: 3.0.x
   - org.openrewrite.java.spring.kafka.KafkaOperationsSendReturnType
   - org.openrewrite.java.spring.kafka.KafkaTestUtilsDuration
   - org.openrewrite.java.ChangeType:


### PR DESCRIPTION
## What's changed?
- Also upgrades the version of the `spring-kafka` dependency during the Spring Kafka 3.x, as `CompletableFuture` only exists in `3.x` and above, and it wasn't getting upgraded as part of this already.

## What's your motivation?
- Compilation failures

### Checklist
- [X] I've added unit tests to cover both positive and negative cases
- [X] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [X] I've used the IntelliJ IDEA auto-formatter on affected files
