### PR TITLE
Handle non-lambda arguments in SuccessFailureCallbackToBiConsumerVisitor

### DIFF
--- a/src/main/java/org/openrewrite/java/spring/util/concurrent/SuccessFailureCallbackToBiConsumerVisitor.java
+++ b/src/main/java/org/openrewrite/java/spring/util/concurrent/SuccessFailureCallbackToBiConsumerVisitor.java
@@ -55,16 +55,25 @@ class SuccessFailureCallbackToBiConsumerVisitor extends JavaIsoVisitor<Execution
                 return mi;
             }
 
+            if (!(mi.getArguments().get(0) instanceof J.Lambda)) {
+                return mi;
+            }
             J.Lambda successCallback = (J.Lambda) mi.getArguments().get(0);
 
             boolean isKafkaFailureCallback = false;
             J.Lambda failureCallback;
             if (mi.getArguments().get(1) instanceof J.TypeCast) {
+                J.TypeCast typeCast = (J.TypeCast) mi.getArguments().get(1);
+                if (!(typeCast.getExpression() instanceof J.Lambda)) {
+                    return mi;
+                }
                 // In this case, assume it's casted to `org.springframework.kafka.core.KafkaFailureCallback` only
-                failureCallback = (J.Lambda) ((J.TypeCast) mi.getArguments().get(1)).getExpression();
+                failureCallback = (J.Lambda) typeCast.getExpression();
                 isKafkaFailureCallback = true;
-            } else {
+            } else if (mi.getArguments().get(1) instanceof J.Lambda) {
                 failureCallback = (J.Lambda) mi.getArguments().get(1);
+            } else {
+                return mi;
             }
 
             J.Identifier successParam = ((J.VariableDeclarations) successCallback.getParameters().getParameters().get(0)).getVariables().get(0).getName();

--- a/src/test/java/org/openrewrite/java/spring/util/concurrent/ListenableToCompletableFutureTest.java
+++ b/src/test/java/org/openrewrite/java/spring/util/concurrent/ListenableToCompletableFutureTest.java
@@ -264,6 +264,41 @@ class ListenableToCompletableFutureTest implements RewriteTest {
     }
 
     @Test
+    void addSuccessFailureCallbackWithTernaryArguments() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.springframework.util.concurrent.ListenableFuture;
+              import org.springframework.util.concurrent.SuccessCallback;
+              import org.springframework.util.concurrent.FailureCallback;
+              class A {
+                  void test(ListenableFuture<String> future, SuccessCallback<String> successCallback, FailureCallback failureCallback) {
+                      future.addCallback(
+                          successCallback != null ? result -> successCallback.onSuccess(result) : null,
+                          failureCallback != null ? ex -> failureCallback.onFailure(ex) : null);
+                  }
+              }
+              """,
+            """
+              import org.springframework.util.concurrent.SuccessCallback;
+              import org.springframework.util.concurrent.FailureCallback;
+
+              import java.util.concurrent.CompletableFuture;
+
+              class A {
+                  void test(CompletableFuture<String> future, SuccessCallback<String> successCallback, FailureCallback failureCallback) {
+                      future.whenComplete(
+                          successCallback != null ? result -> successCallback.onSuccess(result) : null,
+                          failureCallback != null ? ex -> failureCallback.onFailure(ex) : null);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void addSuccessFailureCallbackWithTypeCast() {
         //language=java
         rewriteRun(


### PR DESCRIPTION
## Summary

- Fix `ClassCastException` when `addCallback()` receives ternary expressions (or other non-lambda arguments) instead of lambdas
- Add `instanceof` checks before casting both success and failure callback arguments, returning early when arguments are not lambdas
- Add test case reproducing the ternary argument scenario

## Context

The `SuccessFailureCallbackToBiConsumerVisitor` assumed both arguments to `addCallback(SuccessCallback, FailureCallback)` would always be `J.Lambda` instances. When code like this was encountered:

```java
delegate.addCallback(
    successCallback != null ? new TraceContextSuccessCallback<>(successCallback, this) : null,
    failureCallback != null ? new TraceContextFailureCallback(failureCallback, this) : null);
```

A `ClassCastException` was thrown: `J$Ternary cannot be cast to J$Lambda`.

The fix adds guard clauses that skip the lambda-merging transformation when arguments are not lambdas, preventing the crash.