### PR TITLE
Migrating missed `spring.session.mongodb.*` to `spring.session.data.mongodb.*`

### DIFF
--- a/src/main/resources/META-INF/rewrite/spring-boot-40-properties.yml
+++ b/src/main/resources/META-INF/rewrite/spring-boot-40-properties.yml
@@ -263,6 +263,9 @@ recipeList:
       oldPropertyKey: spring.session.redis.save-mode
       newPropertyKey: spring.session.data.redis.save-mode
   - org.openrewrite.java.spring.ChangeSpringPropertyKey:
+      oldPropertyKey: spring.session.mongodb.collection-name
+      newPropertyKey: spring.session.data.mongodb.collection-name
+  - org.openrewrite.java.spring.ChangeSpringPropertyKey:
       oldPropertyKey: spring.test.mockmvc.webclient.enabled
       newPropertyKey: spring.test.mockmvc.htmlunit.webclient.enabled
   - org.openrewrite.java.spring.ChangeSpringPropertyKey:


### PR DESCRIPTION
## What's changed?
- Change `spring.session.mongodb.collection-name` to `spring.session.data.mongodb.collection-name`

## What's your motivation?
Property change for Spring Boot 4: [change](https://github.com/spring-projects/spring-boot/commit/7a595f1b83c9c90443129be1e7eb7a125293d768) & [release notes](https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-4.0-Migration-Guide#spring-session)

### Checklist
- [X] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [X] I've used the IntelliJ IDEA auto-formatter on affected files
