### PR TITLE
Explain JSpecify annotation migration in Spring Framework 7 description

### DIFF
--- a/src/main/resources/META-INF/rewrite/spring-framework-70.yml
+++ b/src/main/resources/META-INF/rewrite/spring-framework-70.yml
@@ -18,7 +18,10 @@
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.spring.framework.UpgradeSpringFramework_7_0
 displayName: Migrate to Spring Framework 7.0
-description: Migrate applications to the latest Spring Framework 7.0 release.
+description: >-
+  Migrate applications to the latest Spring Framework 7.0 release. This includes migrating Spring's
+  `@Nullable` and `@NonNull` annotations to JSpecify, which Spring Framework 7 has adopted as its
+  nullability annotation standard.
 preconditions:
   - org.openrewrite.Singleton
 recipeList:


### PR DESCRIPTION
## Summary
- Updated `UpgradeSpringFramework_7_0` recipe description to mention the JSpecify annotation migration

Customers running Spring Boot 4 migrations were confused about why `org.springframework.lang.@Nullable` and `@NonNull` were being changed. The description now explains that Spring Framework 7 has adopted JSpecify as its nullability annotation standard.

- Closes moderneinc/customer-requests#1869