### PR TITLE
Fix Kotlin tests after K2 compiler upgrade

### DIFF
--- a/src/test/java/org/openrewrite/java/spring/ImplicitWebAnnotationNamesTest.java
+++ b/src/test/java/org/openrewrite/java/spring/ImplicitWebAnnotationNamesTest.java
@@ -37,7 +37,7 @@ class ImplicitWebAnnotationNamesTest implements RewriteTest {
     public void defaults(RecipeSpec spec) {
         spec.recipe(new ImplicitWebAnnotationNames())
           .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(), "spring-web-5.+"))
-          .parser(KotlinParser.builder().classpathFromResources(new InMemoryExecutionContext(), "spring-web-5.+"));
+          .parser(KotlinParser.builder().classpathFromResources(new InMemoryExecutionContext(), "spring-web-5"));
     }
 
     @DocumentExample

--- a/src/test/java/org/openrewrite/java/spring/NoAutowiredOnConstructorTest.java
+++ b/src/test/java/org/openrewrite/java/spring/NoAutowiredOnConstructorTest.java
@@ -34,7 +34,7 @@ class NoAutowiredOnConstructorTest implements RewriteTest {
     public void defaults(RecipeSpec spec) {
         spec.recipe(new NoAutowiredOnConstructor())
           .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(), "spring-beans-5.+", "spring-boot-1.5.+", "spring-context-5.+", "spring-core-5.+"))
-          .parser(KotlinParser.builder().classpathFromResources(new InMemoryExecutionContext(), "spring-beans-5.+", "spring-boot-1.5.+", "spring-context-5.+", "spring-core-5.+"));
+          .parser(KotlinParser.builder().classpathFromResources(new InMemoryExecutionContext(), "spring-beans-5", "spring-boot-1.5", "spring-context-5", "spring-core-5"));
     }
 
     @Issue("https://github.com/openrewrite/rewrite-spring/issues/78")

--- a/src/test/java/org/openrewrite/java/spring/boot2/DatabaseComponentAndBeanInitializationOrderingTest.java
+++ b/src/test/java/org/openrewrite/java/spring/boot2/DatabaseComponentAndBeanInitializationOrderingTest.java
@@ -52,7 +52,7 @@ class DatabaseComponentAndBeanInitializationOrderingTest implements RewriteTest 
         "jooq-3.14.15", "jakarta.persistence-api-2.2.3");
     private final KotlinParser.Builder KOTLIN_PARSER = KotlinParser.builder()
       .classpathFromResources(new InMemoryExecutionContext(),
-        "spring-beans-5.+", "spring-context-5.+", "spring-boot-2.4", "spring-jdbc-4.1.+", "spring-orm-5.3.+",
+        "spring-beans-5", "spring-context-5", "spring-boot-2.4", "spring-jdbc-4.1", "spring-orm-5.3",
         "jooq-3.14.15", "jakarta.persistence-api-2.2.3");
 
     @Override

--- a/src/test/java/org/openrewrite/java/spring/http/SimplifyWebTestClientCallsTest.java
+++ b/src/test/java/org/openrewrite/java/spring/http/SimplifyWebTestClientCallsTest.java
@@ -37,7 +37,7 @@ class SimplifyWebTestClientCallsTest implements RewriteTest {
           .parser(JavaParser.fromJavaVersion()
             .classpathFromResources(new InMemoryExecutionContext(), "spring-web-6.+", "spring-test-6.+"))
           .parser(KotlinParser.builder()
-            .classpathFromResources(new InMemoryExecutionContext(), "spring-web-6.+", "spring-test-6.+"));
+            .classpathFromResources(new InMemoryExecutionContext(), "spring-web-6", "spring-test-6"));
     }
 
     @DocumentExample


### PR DESCRIPTION
## Summary

- Fixes CI failures in 4 Kotlin test files caused by the K2 compiler upgrade (openrewrite/rewrite#6766). The new `KotlinParser.Builder.classpathFromResources()` strips version suffixes with regex `-\d+$` but version patterns with `.+` (e.g., `"spring-beans-5.+"`) don't match the regex and fail to resolve on the runtime classpath.

## Changes

Removes `.+` suffixes from KotlinParser classpath version patterns:
- `NoAutowiredOnConstructorTest`: `"spring-beans-5.+"` → `"spring-beans-5"`, etc. (4 names)
- `ImplicitWebAnnotationNamesTest`: `"spring-web-5.+"` → `"spring-web-5"`
- `DatabaseComponentAndBeanInitializationOrderingTest`: 4 version patterns updated
- `SimplifyWebTestClientCallsTest`: `"spring-web-6.+"`, `"spring-test-6.+"` → remove `.+`

JavaParser calls remain unchanged (still use `dependenciesFromResources`).

## Test Plan

Run the previously failing Kotlin tests:
- `./gradlew test --tests "NoAutowiredOnConstructorTest"`
- `./gradlew test --tests "ImplicitWebAnnotationNamesTest"`
- `./gradlew test --tests "DatabaseComponentAndBeanInitializationOrderingTest"`
- `./gradlew test --tests "SimplifyWebTestClientCallsTest.replaceKotlinInt"`