### PR TITLE
Add tests for Spring Boot 4 migration with legacy buildscript pattern

### DIFF
--- a/src/test/java/org/openrewrite/gradle/spring/UpgradeSpringBoot40GradleBuildscriptTest.java
+++ b/src/test/java/org/openrewrite/gradle/spring/UpgradeSpringBoot40GradleBuildscriptTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.gradle.spring;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.openrewrite.gradle.Assertions.buildGradle;
+import static org.openrewrite.gradle.toolingapi.Assertions.withToolingApi;
+
+class UpgradeSpringBoot40GradleBuildscriptTest implements RewriteTest {
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipeFromResources("org.openrewrite.java.spring.boot4.UpgradeSpringBoot_4_0")
+          .beforeRecipe(withToolingApi())
+          .expectedCyclesThatMakeChanges(2)
+          .cycles(2);
+    }
+
+    @Test
+    void upgradesLegacyBuildscriptApplyPluginPattern() {
+        rewriteRun(
+          buildGradle(
+            //language=gradle
+            """
+              buildscript {
+                  ext {
+                      springBootVersion = '3.5.5'
+                  }
+                  repositories {
+                      mavenCentral()
+                  }
+                  dependencies {
+                      classpath group: 'org.springframework.boot', name: 'spring-boot-gradle-plugin', version: "${springBootVersion}"
+                  }
+              }
+
+              apply plugin: 'java'
+              apply plugin: 'org.springframework.boot'
+              apply plugin: 'io.spring.dependency-management'
+
+              repositories {
+                  mavenCentral()
+              }
+
+              dependencies {
+                  implementation(group: 'org.springframework.boot', name: 'spring-boot-starter-web')
+                  implementation(group: 'org.springframework.boot', name: 'spring-boot-starter-actuator')
+                  testImplementation(group: 'org.springframework.boot', name: 'spring-boot-starter-test')
+              }
+              """,
+            spec -> spec.after(gradle -> {
+                assertThat(gradle).as("Spring Boot version should be upgraded to 4.0.x")
+                  .containsPattern("springBootVersion = '4\\.0\\.\\d+'");
+                assertThat(gradle).as("spring-boot-starter-web should be renamed to spring-boot-starter-webmvc")
+                  .contains("spring-boot-starter-webmvc");
+                assertThat(gradle).as("spring-boot-starter-web should no longer be present")
+                  .doesNotContain("spring-boot-starter-web'");
+                return gradle;
+            })
+          )
+        );
+    }
+
+    @Test
+    void upgradesLegacyBuildscriptWithGroupAndAdditionalDeps() {
+        rewriteRun(
+          buildGradle(
+            //language=gradle
+            """
+              group 'com.example'
+              buildscript {
+                  ext {
+                      springBootVersion = '3.5.5'
+                  }
+                  repositories {
+                      mavenCentral()
+                  }
+                  dependencies {
+                      classpath group: 'org.springframework.boot', name: 'spring-boot-gradle-plugin', version: "${springBootVersion}"
+                  }
+              }
+
+              apply plugin: 'java'
+              apply plugin: 'org.springframework.boot'
+              apply plugin: 'io.spring.dependency-management'
+
+              sourceCompatibility = 17
+
+              repositories {
+                  mavenCentral()
+              }
+
+              dependencies {
+                  implementation(group: 'org.springframework.boot', name: 'spring-boot-starter-web')
+                  implementation(group: 'org.springframework.boot', name: 'spring-boot-starter-actuator')
+                  implementation(group: 'org.springframework.boot', name: 'spring-boot-starter-data-jpa')
+                  implementation(group: 'org.springframework.boot', name: 'spring-boot-configuration-processor')
+                  testImplementation(group: 'org.springframework.boot', name: 'spring-boot-starter-test')
+                  implementation(group: 'org.projectlombok', name: 'lombok', version: '1.18.30')
+                  annotationProcessor(group: 'org.projectlombok', name: 'lombok', version: '1.18.30')
+              }
+              """,
+            spec -> spec.after(gradle -> {
+                assertThat(gradle).as("Spring Boot version should be upgraded to 4.0.x")
+                  .containsPattern("springBootVersion = '4\\.0\\.\\d+'");
+                assertThat(gradle).as("spring-boot-starter-web should be renamed to spring-boot-starter-webmvc")
+                  .contains("spring-boot-starter-webmvc");
+                return gradle;
+            })
+          )
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- Add end-to-end tests verifying `UpgradeSpringBoot_4_0` works with the legacy `buildscript`/`apply plugin` Gradle pattern
- Tests use map notation dependencies with GString version variables (`classpath group: '...', name: '...', version: "${springBootVersion}"`)
- Validates both version upgrade and starter renames (e.g., `spring-boot-starter-web` → `spring-boot-starter-webmvc`)

## Context
Written while investigating a customer report that the Spring Boot 4 migration recipe was not making changes on a build.gradle using the legacy buildscript pattern. The investigation confirmed the recipe works correctly for this pattern.

## Notes
The recipe currently requires 2 cycles to stabilize for this pattern (`expectedCyclesThatMakeChanges(2)`). This appears to be a recipe stability issue where a second cycle is triggered, though all meaningful changes happen in cycle 1. This should be investigated separately.

## Test plan
- [x] `upgradesLegacyBuildscriptApplyPluginPattern` - basic buildscript pattern with map notation
- [x] `upgradesLegacyBuildscriptWithGroupAndAdditionalDeps` - buildscript with group statement, additional deps