### PR TITLE
Only add int cast when context expects int in Spring Batch migration

### DIFF
--- a/src/test/java/org/openrewrite/java/spring/batch/ConvertReceiveTypeWhenCallStepExecutionMethodTest.java
+++ b/src/test/java/org/openrewrite/java/spring/batch/ConvertReceiveTypeWhenCallStepExecutionMethodTest.java
@@ -188,6 +188,107 @@ class ConvertReceiveTypeWhenCallStepExecutionMethodTest implements RewriteTest {
     }
 
     @Test
+    void noCastForLongAssignment() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              package test;
+
+              import org.springframework.batch.core.StepExecution;
+              public class ProfileUpdateWriter {
+
+                  private void populateJobMetrics(StepExecution stepExecution) {
+                    long v = stepExecution.getRollbackCount();
+                  }
+
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void noCastForLongMethodArgument() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              package test;
+
+              import org.springframework.batch.core.StepExecution;
+              public class ProfileUpdateWriter {
+
+                  private void populateJobMetrics(StepExecution stepExecution) {
+                    setLong(stepExecution.getRollbackCount());
+                  }
+
+                  private void setLong(long l) {
+                  }
+
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void noCastForLongReturn() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              package test;
+
+              import org.springframework.batch.core.StepExecution;
+              public class ProfileUpdateWriter {
+
+                  private long getCount(StepExecution stepExecution) {
+                    return stepExecution.getRollbackCount();
+                  }
+
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void mixedIntAndLongAssignment() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              package test;
+
+              import org.springframework.batch.core.StepExecution;
+              public class ProfileUpdateWriter {
+
+                  private void populateJobMetrics(StepExecution stepExecution) {
+                    int intVal = stepExecution.getRollbackCount();
+                    long longVal = stepExecution.getReadCount();
+                  }
+
+              }
+              """,
+            """
+              package test;
+
+              import org.springframework.batch.core.StepExecution;
+              public class ProfileUpdateWriter {
+
+                  private void populateJobMetrics(StepExecution stepExecution) {
+                    int intVal = (int) stepExecution.getRollbackCount();
+                    long longVal = stepExecution.getReadCount();
+                  }
+
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void unrelatedJavadoc() {
         rewriteRun(
           java(


### PR DESCRIPTION
## Summary

- Skip `(int)` cast in `ConvertReceiveTypeWhenCallStepExecutionMethod` when the receiving context already expects `long`
- Add `contextExpectsInt()` check that inspects variable declarations, return types, and method parameter types
- Add 4 new test cases covering `long` assignment, `long` method argument, `long` return, and mixed `int`/`long` contexts

## Problem

The `ConvertReceiveTypeWhenCallStepExecutionMethod` recipe adds `(int)` casts to `StepExecution.get*Count()` methods unconditionally. When the receiving context already expects `long` or `Long` (e.g. `Map<String, Long>`), the cast is unnecessary and potentially data-lossy. Customers have to manually remove these casts after running the Spring Batch migration.

## Solution

Added a `contextExpectsInt()` helper in the `AddCast` visitor that checks the parent context before applying the cast:

- **Variable declaration**: only cast if declared type is `int`
- **Return statement**: only cast if enclosing method returns `int`
- **Method argument**: only cast if parameter type is `int`
- **Unknown context**: default to adding cast (safe fallback)

## Test plan

- [x] Existing tests pass (int assignment, int method argument, Mockito, Javadoc, method reference)
- [x] New test: `noCastForLongAssignment` — no cast when assigned to `long`
- [x] New test: `noCastForLongMethodArgument` — no cast when passed to `method(long)`
- [x] New test: `noCastForLongReturn` — no cast when returning from `long` method
- [x] New test: `mixedIntAndLongAssignment` — cast for `int`, no cast for `long` in same method

- Fixes moderneinc/customer-requests#1895