### PR TITLE
Remove `super.configure(http)` calls in `WebSecurityConfigurerAdapter` migration

### DIFF
--- a/src/main/java/org/openrewrite/java/spring/security5/WebSecurityConfigurerAdapter.java
+++ b/src/main/java/org/openrewrite/java/spring/security5/WebSecurityConfigurerAdapter.java
@@ -344,6 +344,15 @@ public class WebSecurityConfigurerAdapter extends Recipe {
             }
 
             private J.Block handleHttpSecurity(J.Block b, J.MethodDeclaration parentMethod) {
+                b = b.withStatements(ListUtils.map(b.getStatements(), stmt -> {
+                    if (stmt instanceof J.MethodInvocation) {
+                        J.MethodInvocation mi = (J.MethodInvocation) stmt;
+                        if (CONFIGURE_HTTP_SECURITY_METHOD_MATCHER.matches(mi.getMethodType())) {
+                            return null;
+                        }
+                    }
+                    return stmt;
+                }));
                 return JavaTemplate.builder("return #{any(org.springframework.security.config.annotation.SecurityBuilder)}.build();")
                     .contextSensitive()
                     .javaParser(JavaParser.fromJavaVersion()
@@ -354,7 +363,7 @@ public class WebSecurityConfigurerAdapter extends Recipe {
                     .imports("org.springframework.security.config.annotation.SecurityBuilder")
                     .build()
                     .apply(
-                        getCursor(),
+                        updateCursor(b),
                         b.getCoordinates().lastStatement(),
                         ((J.VariableDeclarations) parentMethod.getParameters().get(0)).getVariables().get(0).getName()
                     );

--- a/src/test/java/org/openrewrite/java/spring/security5/WebSecurityConfigurerAdapterTest.java
+++ b/src/test/java/org/openrewrite/java/spring/security5/WebSecurityConfigurerAdapterTest.java
@@ -102,6 +102,63 @@ class WebSecurityConfigurerAdapterTest implements RewriteTest {
     }
 
     @Test
+    void configureHttpSecurityMethodRemovesSuperCall() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              package com.example.websecuritydemo;
+
+              import static org.springframework.security.config.Customizer.withDefaults;
+              import org.springframework.context.annotation.Configuration;
+              import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+              import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+
+              @Configuration
+              public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
+
+                  @Override
+                  protected void configure(HttpSecurity http) throws Exception {
+                      super.configure(http);
+                      http
+                          .authorizeHttpRequests((authz) -> authz
+                              .anyRequest().authenticated()
+                          )
+                          .httpBasic(withDefaults());
+                  }
+
+              }
+              """,
+            """
+              package com.example.websecuritydemo;
+
+              import static org.springframework.security.config.Customizer.withDefaults;
+
+              import org.springframework.context.annotation.Bean;
+              import org.springframework.context.annotation.Configuration;
+              import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+              import org.springframework.security.web.SecurityFilterChain;
+
+              @Configuration
+              public class SecurityConfiguration {
+
+                  @Bean
+                  SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+                      http
+                          .authorizeHttpRequests((authz) -> authz
+                              .anyRequest().authenticated()
+                          )
+                          .httpBasic(withDefaults());
+                      return http.build();
+                  }
+
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void noConfigurationAnnotation() {
         //language=java
         rewriteRun(


### PR DESCRIPTION
## Summary
- When migrating `configure(HttpSecurity)` to a `@Bean SecurityFilterChain` method, any `super.configure(http)` calls are now removed since the class no longer extends `WebSecurityConfigurerAdapter`
- Previously these calls would remain in the migrated code, causing a compilation error

## Test plan
- [x] Added `configureHttpSecurityMethodRemovesSuperCall` test verifying `super.configure(http)` is stripped during migration
- [x] All existing tests continue to pass