### PR TITLE
Fixing `services` to `downloads` for subdomain on Gradle distributions, retaining test showing it can migrate that for you as well.

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.1-bin.zip
+distributionUrl=https\://downloads.gradle.org/distributions/gradle-9.3.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/resources/META-INF/rewrite/examples.yml
+++ b/src/main/resources/META-INF/rewrite/examples.yml
@@ -2107,13 +2107,13 @@ examples:
   - before: |
       distributionBase=GRADLE_USER_HOME
       distributionPath=wrapper/dists
-      distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-bin.zip
+      distributionUrl=https\://downloads.gradle.org/distributions/gradle-6.7-bin.zip
       zipStoreBase=GRADLE_USER_HOME
       zipStorePath=wrapper/dists
     after: |
       distributionBase=GRADLE_USER_HOME
       distributionPath=wrapper/dists
-      distributionUrl=https\://services.gradle.org/distributions/gradle-6.9.4-bin.zip
+      distributionUrl=https\://downloads.gradle.org/distributions/gradle-6.9.4-bin.zip
       zipStoreBase=GRADLE_USER_HOME
       zipStorePath=wrapper/dists
       distributionSha256Sum=3e240228538de9f18772a574e99a0ba959e83d6ef351014381acd9631781389a

--- a/src/test/java/org/openrewrite/gradle/spring/UpdateGradleTest.java
+++ b/src/test/java/org/openrewrite/gradle/spring/UpdateGradleTest.java
@@ -92,7 +92,7 @@ class UpdateGradleTest implements RewriteTest {
             """
               distributionBase=GRADLE_USER_HOME
               distributionPath=wrapper/dists
-              distributionUrl=https\\://services.gradle.org/distributions/gradle-6.7-bin.zip
+              distributionUrl=https\\://downloads.gradle.org/distributions/gradle-6.7-bin.zip
               zipStoreBase=GRADLE_USER_HOME
               zipStorePath=wrapper/dists
               """,
@@ -100,7 +100,7 @@ class UpdateGradleTest implements RewriteTest {
             """
               distributionBase=GRADLE_USER_HOME
               distributionPath=wrapper/dists
-              distributionUrl=https\\://services.gradle.org/distributions/gradle-6.9.4-bin.zip
+              distributionUrl=https\\://downloads.gradle.org/distributions/gradle-6.9.4-bin.zip
               zipStoreBase=GRADLE_USER_HOME
               zipStorePath=wrapper/dists
               distributionSha256Sum=3e240228538de9f18772a574e99a0ba959e83d6ef351014381acd9631781389a
@@ -130,6 +130,32 @@ class UpdateGradleTest implements RewriteTest {
           other(
             "",
             spec -> spec.path("gradle/wrapper/gradle-wrapper.jar")
+          )
+        );
+    }
+
+    @Test
+    void handlesUpdatingGradleUrlFromServicesToDownloads() {
+        rewriteRun(
+          properties(
+            //language=properties
+            """
+              distributionBase=GRADLE_USER_HOME
+              distributionPath=wrapper/dists
+              distributionUrl=https\\://services.gradle.org/distributions/gradle-6.7-bin.zip
+              zipStoreBase=GRADLE_USER_HOME
+              zipStorePath=wrapper/dists
+              """,
+            //language=properties
+            """
+              distributionBase=GRADLE_USER_HOME
+              distributionPath=wrapper/dists
+              distributionUrl=https\\://downloads.gradle.org/distributions/gradle-6.9.4-bin.zip
+              zipStoreBase=GRADLE_USER_HOME
+              zipStorePath=wrapper/dists
+              distributionSha256Sum=3e240228538de9f18772a574e99a0ba959e83d6ef351014381acd9631781389a
+              """,
+            spec -> spec.path("gradle/wrapper/gradle-wrapper.properties")
           )
         );
     }
@@ -183,7 +209,7 @@ class UpdateGradleTest implements RewriteTest {
             """
               distributionBase=GRADLE_USER_HOME
               distributionPath=wrapper/dists
-              distributionUrl=https\\://services.gradle.org/distributions/gradle-6.7-bin.zip
+              distributionUrl=https\\://downloads.gradle.org/distributions/gradle-6.7-bin.zip
               zipStoreBase=GRADLE_USER_HOME
               zipStorePath=wrapper/dists
               """,
@@ -191,7 +217,7 @@ class UpdateGradleTest implements RewriteTest {
             """
               distributionBase=GRADLE_USER_HOME
               distributionPath=wrapper/dists
-              distributionUrl=https\\://services.gradle.org/distributions/gradle-6.9.4-bin.zip
+              distributionUrl=https\\://downloads.gradle.org/distributions/gradle-6.9.4-bin.zip
               zipStoreBase=GRADLE_USER_HOME
               zipStorePath=wrapper/dists
               distributionSha256Sum=3e240228538de9f18772a574e99a0ba959e83d6ef351014381acd9631781389a


### PR DESCRIPTION
## What's changed?
- `services` URLs have changed to `downloads` for Gradle distributions. While we can migrate from the old `services` to `downloads`, the test was still expected the old `services` subdomain.

### Checklist
- [X] I've added unit tests to cover both positive and negative cases
- [X] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [X] I've used the IntelliJ IDEA auto-formatter on affected files
