### PR TITLE
Migrate UriComponentsBuilder.fromHttpUrl to fromUriString

### DIFF
--- a/src/main/java/org/openrewrite/java/spring/framework/MigrateUriComponentsBuilderMethods.java
+++ b/src/main/java/org/openrewrite/java/spring/framework/MigrateUriComponentsBuilderMethods.java
@@ -33,13 +33,17 @@ public class MigrateUriComponentsBuilderMethods extends Recipe {
 
     private static final MethodMatcher FROM_HTTP_REQUEST = new MethodMatcher(TARGET_CLASS + " fromHttpRequest(org.springframework.http.HttpRequest)");
 
+    private static final MethodMatcher FROM_HTTP_URL = new MethodMatcher(TARGET_CLASS + " fromHttpUrl(String)");
+
     private static final MethodMatcher PARSE_FORWARDED_FOR = new MethodMatcher(TARGET_CLASS + " parseForwardedFor(org.springframework.http.HttpRequest, java.net.InetSocketAddress)");
 
     @Getter
-    final String displayName = "Migrate `UriComponentsBuilder.fromHttpRequest` and `parseForwardedFor`";
+    final String displayName = "Migrate deprecated `UriComponentsBuilder` methods";
 
     @Getter
-    final String description = "The `fromHttpRequest` and `parseForwardedFor` methods in `org.springframework.web.util.UriComponentsBuilder` were deprecated, in favor of `org.springframework.web.util.ForwardedHeaderUtils`.";
+    final String description = "Migrates deprecated methods in `org.springframework.web.util.UriComponentsBuilder`: " +
+            "`fromHttpRequest` and `parseForwardedFor` to `ForwardedHeaderUtils`, " +
+            "and `fromHttpUrl` to `fromUriString`.";
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
@@ -47,6 +51,9 @@ public class MigrateUriComponentsBuilderMethods extends Recipe {
             @Override
             public J visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
                 J.MethodInvocation mi = (J.MethodInvocation) super.visitMethodInvocation(method, ctx);
+                if (FROM_HTTP_URL.matches(mi)) {
+                    return mi.withName(mi.getName().withSimpleName("fromUriString"));
+                }
                 if (FROM_HTTP_REQUEST.matches(mi)) {
                     maybeRemoveImport("org.springframework.web.util.UriComponentsBuilder");
                     maybeAddImport("org.springframework.web.util.ForwardedHeaderUtils");

--- a/src/test/java/org/openrewrite/java/spring/framework/MigrateUriComponentsBuilderMethodsTest.java
+++ b/src/test/java/org/openrewrite/java/spring/framework/MigrateUriComponentsBuilderMethodsTest.java
@@ -73,6 +73,35 @@ class MigrateUriComponentsBuilderMethodsTest implements RewriteTest {
     }
 
     @Test
+    void migrateFromHttpUrlToFromUriString() {
+        rewriteRun(
+          // language=java
+          java(
+            """
+              import org.springframework.web.util.UriComponentsBuilder;
+
+              class A {
+                  void test() {
+                      String url = "https://example.com";
+                      UriComponentsBuilder.fromHttpUrl(url).queryParam("foo", "bar");
+                  }
+              }
+              """,
+            """
+              import org.springframework.web.util.UriComponentsBuilder;
+
+              class A {
+                  void test() {
+                      String url = "https://example.com";
+                      UriComponentsBuilder.fromUriString(url).queryParam("foo", "bar");
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void migrateUriComponentsBuilderMethodsWhenInetSocketAddressIsNull() {
         rewriteRun(
           // language=java


### PR DESCRIPTION
## Summary

- Add migration for deprecated `UriComponentsBuilder.fromHttpUrl(String)` → `fromUriString(String)` (deprecated since Spring Framework 6.2)
- Update recipe display name and description to cover all three deprecated method migrations

## Problem

The `MigrateUriComponentsBuilderMethods` recipe handles `fromHttpRequest` and `parseForwardedFor` deprecations but was missing `fromHttpUrl` → `fromUriString`, which was also deprecated in Spring Framework 6.2.

## Solution

Add a `MethodMatcher` for `fromHttpUrl(String)` and rename the method invocation to `fromUriString`. This is a simple same-class method rename with no import changes needed.

## Test plan

- [x] Existing tests pass (fromHttpRequest and parseForwardedFor migrations)
- [x] New test added for fromHttpUrl → fromUriString migration

- Fixes moderneinc/customer-requests#1953