### PR TITLE
Skip adding CrudRepository when already on Spring Data 3.x

### DIFF
--- a/src/main/java/org/openrewrite/java/spring/data/MigratePagingAndSortingRepository.java
+++ b/src/main/java/org/openrewrite/java/spring/data/MigratePagingAndSortingRepository.java
@@ -65,7 +65,12 @@ public class MigratePagingAndSortingRepository extends Recipe {
                     }
                 }
 
+                // Only add CrudRepository when the classpath PagingAndSortingRepository still
+                // extends CrudRepository (Spring Data 2.x). In 3.x the inheritance was removed
+                // intentionally, so not extending CrudRepository may be a conscious choice.
                 if (pagingAndSortingType != null && !alreadyHasCrud &&
+                        TypeUtils.isAssignableTo(crudRepoTarget,
+                                TypeUtils.asFullyQualified(pagingAndSortingType.getType())) &&
                         pagingAndSortingType.getTypeParameters() != null &&
                         pagingAndSortingType.getTypeParameters().size() == 2) {
 

--- a/src/test/java/org/openrewrite/java/spring/data/MigratePagingAndSortingRepositoryTest.java
+++ b/src/test/java/org/openrewrite/java/spring/data/MigratePagingAndSortingRepositoryTest.java
@@ -191,4 +191,29 @@ class MigratePagingAndSortingRepositoryTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void noChangeWhenAlreadyOnSpringData3() {
+        rewriteRun(
+          spec -> spec.parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(),
+                  "spring-data-commons-3.*")),
+          //language=java
+          java(
+            """
+              import org.springframework.data.repository.PagingAndSortingRepository;
+
+              public interface UserRepository extends PagingAndSortingRepository<User, Long> {
+              }
+              """
+          ),
+          //language=java
+          java(
+            """
+              public class User {
+                  private Long id;
+              }
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
## Context

- PR #984 added `MigratePagingAndSortingRepository` to handle the Spring Data 3.0 change where `PagingAndSortingRepository` no longer extends `CrudRepository`. The recipe adds an explicit `CrudRepository` extends to preserve CRUD methods during migration.

- However, as [noted by @DidierLoiseau](https://github.com/openrewrite/rewrite-spring/pull/984#issuecomment-2782804281), the recipe unconditionally adds `CrudRepository` to any interface extending `PagingAndSortingRepository` — even for projects already on Spring Data 3.x where omitting `CrudRepository` may be an intentional design choice.

## What this changes

The recipe now checks whether the classpath version of `PagingAndSortingRepository` still inherits from `CrudRepository` (i.e., Spring Data 2.x) before making changes. Since this recipe runs before the dependency version upgrade step in `UpgradeSpringData_3_0`, the type hierarchy on the classpath reflects the pre-migration state:

- **Spring Data 2.x**: `PagingAndSortingRepository` extends `CrudRepository` → recipe fires, adds explicit `CrudRepository`
- **Spring Data 3.x**: `PagingAndSortingRepository` does not extend `CrudRepository` → recipe is a no-op

This is a single `TypeUtils.isAssignableTo` check on the resolved `PagingAndSortingRepository` type itself.