### PR TITLE
Fix broken Flyway starter test and add Gradle coverage

### DIFF
--- a/src/test/java/org/openrewrite/java/spring/boot4/MigrateToModularStartersTest.java
+++ b/src/test/java/org/openrewrite/java/spring/boot4/MigrateToModularStartersTest.java
@@ -27,8 +27,6 @@ import org.openrewrite.test.RewriteTest;
 import org.openrewrite.test.TypeValidation;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.openrewrite.gradle.Assertions.buildGradle;
-import static org.openrewrite.gradle.toolingapi.Assertions.withToolingApi;
 import static org.openrewrite.java.Assertions.*;
 import static org.openrewrite.maven.Assertions.pomXml;
 
@@ -633,7 +631,6 @@ class MigrateToModularStartersTest implements RewriteTest {
     @ValueSource(strings = {"flyway-database-postgresql", "flyway-mysql"})
     void addFlywayStarterWhenDependencyPresent(String artifactId) {
         rewriteRun(
-          spec -> spec.beforeRecipe(withToolingApi()),
           mavenProject("sample",
             pomXml(
               """
@@ -683,40 +680,6 @@ class MigrateToModularStartersTest implements RewriteTest {
                   .contains("<artifactId>%s</artifactId>".formatted(artifactId))
                   .contains("<artifactId>spring-boot-starter-flyway</artifactId>")
                   .containsPattern("<version>4\\.0\\.\\d+</version>")
-                  .actual())
-              ),
-              buildGradle(
-                """
-                  plugins {
-                      id 'java'
-                  }
-
-                  repositories {
-                      mavenCentral()
-                  }
-
-                  dependencies {
-                      implementation('org.springframework.boot:spring-boot-starter-actuator')
-                  }
-                  """),
-              buildGradle(
-                """
-                        plugins {
-                            id 'java'
-                        }
-
-                        repositories {
-                            mavenCentral()
-                        }
-
-                        dependencies {
-                            implementation('org.flywaydb:%s:10.0.0')
-                        }
-                  """.formatted(artifactId),
-                spec -> spec.after(gradle -> assertThat(gradle)
-                  .contains("implementation('org.flywaydb:%s:10.0.0')".formatted(artifactId))
-                  .contains("org.springframework.boot:spring-boot-starter-flyway")
-                  .containsPattern("4\\.0\\.\\d+")
                   .actual())
               )
             )

--- a/src/test/java/org/openrewrite/java/spring/boot4/MigrateToModularStartersTest.java
+++ b/src/test/java/org/openrewrite/java/spring/boot4/MigrateToModularStartersTest.java
@@ -27,6 +27,8 @@ import org.openrewrite.test.RewriteTest;
 import org.openrewrite.test.TypeValidation;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.openrewrite.gradle.Assertions.buildGradle;
+import static org.openrewrite.gradle.toolingapi.Assertions.withToolingApi;
 import static org.openrewrite.java.Assertions.*;
 import static org.openrewrite.maven.Assertions.pomXml;
 
@@ -682,6 +684,45 @@ class MigrateToModularStartersTest implements RewriteTest {
                   .containsPattern("<version>4\\.0\\.\\d+</version>")
                   .actual())
               )
+            )
+          )
+        );
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"flyway-database-postgresql", "flyway-mysql"})
+    void addFlywayStarterWhenGradleDependencyPresent(String artifactId) {
+        rewriteRun(
+          spec -> spec.beforeRecipe(withToolingApi()),
+          mavenProject("sample",
+            srcMainJava(
+              java(
+                """
+                  class AnyClass {
+                      String s = "";
+                  }
+                  """
+              )
+            ),
+            //language=groovy
+            buildGradle(
+              """
+                plugins {
+                    id 'java'
+                    id 'org.springframework.boot' version '3.4.1'
+                }
+                repositories {
+                    mavenCentral()
+                }
+                dependencies {
+                    implementation('org.flywaydb:%s:10.0.0')
+                }
+                """.formatted(artifactId),
+              spec -> spec.after(gradle -> assertThat(gradle)
+                .contains("implementation('org.flywaydb:%s:10.0.0')".formatted(artifactId))
+                .contains("org.springframework.boot:spring-boot-starter-flyway")
+                .containsPattern("4\\.0\\.\\d+")
+                .actual())
             )
           )
         );


### PR DESCRIPTION
## Summary
- The `addFlywayStarterWhenDependencyPresent` test mixed Maven `pomXml` and Gradle `buildGradle` sources in the same `mavenProject`, which doesn't work — a project is either Maven or Gradle, not both
- Remove the `buildGradle()` calls from the Maven test so it tests Maven correctly
- Add a separate `addFlywayStarterWhenGradleDependencyPresent` test with proper `withToolingApi()` setup, Spring Boot plugin, and a Java source file for the `onlyIfUsing` precondition

## Test plan
- [x] `addFlywayStarterWhenDependencyPresent` passes for both `flyway-database-postgresql` and `flyway-mysql` (Maven)
- [x] `addFlywayStarterWhenGradleDependencyPresent` passes for both `flyway-database-postgresql` and `flyway-mysql` (Gradle)
- [x] Full `MigrateToModularStartersTest` class passes