### PR TITLE
Quote YAML values containing colons in `AddSpringProperty`

### DIFF
--- a/src/main/java/org/openrewrite/java/spring/AddSpringProperty.java
+++ b/src/main/java/org/openrewrite/java/spring/AddSpringProperty.java
@@ -27,7 +27,6 @@ import org.openrewrite.yaml.tree.Yaml;
 
 import java.nio.file.Path;
 import java.util.List;
-import java.util.regex.Pattern;
 
 /**
  * A recipe to uniformly add a property to Spring configuration file. This recipe supports adding properties to
@@ -129,16 +128,7 @@ public class AddSpringProperty extends Recipe {
             yaml.append(indent).append(part).append(":");
             indent = indent + "  ";
         }
-        if (quoteValue(value)) {
-            yaml.append(" \"").append(value).append('"');
-        } else {
-            yaml.append(" ").append(value);
-        }
+        yaml.append(" ").append(org.openrewrite.yaml.internal.StringUtils.quoteIfNeeded(value));
         return new MergeYaml("$", yaml.toString(), true, null, null, null, null, null);
-    }
-
-    private static final Pattern scalarNeedsAQuote = Pattern.compile("[^a-zA-Z\\d\\s]*");
-    private boolean quoteValue(String value) {
-        return scalarNeedsAQuote.matcher(value).matches();
     }
 }

--- a/src/test/java/org/openrewrite/java/spring/AddSpringPropertyTest.java
+++ b/src/test/java/org/openrewrite/java/spring/AddSpringPropertyTest.java
@@ -176,6 +176,36 @@ class AddSpringPropertyTest implements RewriteTest {
     }
 
     @Test
+    void quoteValueContainingColon() {
+        rewriteRun(
+          spec -> spec.recipe(new AddSpringProperty("my.property", "TODO: Follow this link https://example.com/page", null, List.of("*"))),
+          //language=properties
+          properties(
+            """
+              server.port=8080
+              """,
+            """
+              my.property=TODO: Follow this link https://example.com/page
+              server.port=8080
+              """
+          ),
+          //language=yaml
+          yaml(
+            """
+              server:
+                port: 8080
+              """,
+            """
+              server:
+                port: 8080
+              my:
+                property: 'TODO: Follow this link https://example.com/page'
+              """
+          )
+        );
+    }
+
+    @Test
     void doNotChangeToFilesThatDoNotMatch() {
         rewriteRun(
           spec -> spec.recipe(new AddSpringProperty("server.servlet.path", "/tmp/my-server-path", null, List.of("**/application.properties", "**/application.yml"))),

--- a/src/test/java/org/openrewrite/java/spring/doc/MigrateDocketBeanToGroupedOpenApiBeanTest.java
+++ b/src/test/java/org/openrewrite/java/spring/doc/MigrateDocketBeanToGroupedOpenApiBeanTest.java
@@ -58,7 +58,7 @@ class MigrateDocketBeanToGroupedOpenApiBeanTest implements RewriteTest {
                     path: /v3/api-docs
                   swagger-ui:
                     path: /swagger-ui.html
-                  paths-to-match: "/**"
+                  paths-to-match: /**
                 """,
               spec -> spec.path("application.yaml")
             )


### PR DESCRIPTION
## Summary
- Replaces the ad-hoc `quoteValue` regex in `AddSpringProperty.createMergeYamlVisitor()` with a call to `StringUtils.quoteIfNeeded()` from rewrite-yaml (added in openrewrite/rewrite#7416).
- The previous regex only quoted values made up entirely of special characters, so mixed values like `TODO: Follow this link https://example.com/page` slipped through unquoted and broke `MergeYaml` parsing.
- Adds a regression test covering that exact scenario for both `.yml` and `.properties`.

- Fixes #999

## Test plan
- [x] `./gradlew test --tests "org.openrewrite.java.spring.AddSpringPropertyTest"`