### PR TITLE
Remove AddConfigurationAnnotationIfBeansPresent  from SpringBoot2BestPractices (fixes #1002)

### DIFF
--- a/src/main/resources/META-INF/rewrite/best-practices.yml
+++ b/src/main/resources/META-INF/rewrite/best-practices.yml
@@ -31,7 +31,6 @@ recipeList:
 #  - org.openrewrite.java.spring.ImplicitWebAnnotationNames
   - org.openrewrite.java.spring.boot2.UnnecessarySpringExtension
   - org.openrewrite.java.spring.NoAutowiredOnConstructor
-  - org.openrewrite.java.spring.boot2.AddConfigurationAnnotationIfBeansPresent
   - org.openrewrite.java.spring.boot2.RestTemplateBuilderRequestFactory
   - org.openrewrite.java.spring.boot2.ReplaceDeprecatedEnvironmentTestUtils
   - org.openrewrite.java.spring.SeparateApplicationPropertiesByProfile


### PR DESCRIPTION
- Fix for #1002

## What's changed?
`AddConfigurationAnnotationIfBeansPresent` has been removed from `AddConfigurationAnnotationIfBeansPresent`.  

## What's your motivation?
“Add missing @Configuration annotation” migration (`org.openrewrite.java.spring.boot2.AddConfigurationAnnotationIfBeansPresent` ) added to “Spring Boot 2.x best practices” (`org.openrewrite.java.spring.boot2.SpringBoot2BestPractices`)  breaks Feign client configuration. 
As documented in https://docs.spring.io/spring-cloud-openfeign/reference/spring-cloud-openfeign.html#spring-cloud-feign-overriding-defaults, configuration classes containing beans specific to Feign clients doesn’t need to be annotated with `@Configuration`. This way the scope of these beans will be limitted to specific Feign client only. On the other hand, if `@Configuration` is added, it will cause the beans to be registered in global application scope, which might not be correct setup.


@timtebeek this partially reverts your change done in https://github.com/openrewrite/rewrite-spring/commit/f449874acf0a2454fe08fd13735f3403897ac40b - please make your opinion on that. 