### PR TITLE
Skip scoped `.class` references in AddConfigurationAnnotationIfBeansPresent

### DIFF
--- a/src/main/java/org/openrewrite/java/spring/boot2/AddConfigurationAnnotationIfBeansPresent.java
+++ b/src/main/java/org/openrewrite/java/spring/boot2/AddConfigurationAnnotationIfBeansPresent.java
@@ -23,14 +23,17 @@ import org.openrewrite.java.JavaParser;
 import org.openrewrite.java.JavaTemplate;
 import org.openrewrite.java.search.UsesType;
 import org.openrewrite.java.service.AnnotationService;
+import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaType;
 import org.openrewrite.java.tree.Statement;
 import org.openrewrite.java.tree.TypeUtils;
 
 import java.util.Comparator;
+import java.util.HashSet;
+import java.util.Set;
 
-public class AddConfigurationAnnotationIfBeansPresent extends Recipe {
+public class AddConfigurationAnnotationIfBeansPresent extends ScanningRecipe<Set<String>> {
 
     private static final String FQN_BEAN = "org.springframework.context.annotation.Bean";
     private static final String CONFIGURATION_PACKAGE = "org.springframework.context.annotation";
@@ -39,20 +42,85 @@ public class AddConfigurationAnnotationIfBeansPresent extends Recipe {
     private static final AnnotationMatcher BEAN_ANNOTATION_MATCHER = new AnnotationMatcher("@" + FQN_BEAN, true);
     private static final AnnotationMatcher CONFIGURATION_ANNOTATION_MATCHER = new AnnotationMatcher("@" + FQN_CONFIGURATION, true);
 
+    // Annotations whose `configuration` / `defaultConfiguration` attributes declare a scoped,
+    // non-global configuration class that should not be globally registered with `@Configuration`.
+    private static final String FQN_FEIGN_CLIENT = "org.springframework.cloud.openfeign.FeignClient";
+    private static final String FQN_ENABLE_FEIGN_CLIENTS = "org.springframework.cloud.openfeign.EnableFeignClients";
+    private static final String FQN_LOAD_BALANCER_CLIENT = "org.springframework.cloud.loadbalancer.annotation.LoadBalancerClient";
+    private static final String FQN_LOAD_BALANCER_CLIENTS = "org.springframework.cloud.loadbalancer.annotation.LoadBalancerClients";
 
     @Getter
     final String displayName = "Add missing `@Configuration` annotation";
 
     @Getter
-    final String description = "Class having `@Bean` annotation over any methods but missing `@Configuration` annotation over the declaring class would have `@Configuration` annotation added.";
+    final String description = "Class having `@Bean` annotation over any methods but missing `@Configuration` annotation over the declaring class would have `@Configuration` annotation added. " +
+            "Classes referenced as scoped configuration via `.class` (e.g. `@FeignClient(configuration = X.class)`) are skipped to preserve their intended per-client scope.";
 
     @Override
-    public TreeVisitor<?, ExecutionContext> getVisitor() {
+    public Set<String> getInitialValue(ExecutionContext ctx) {
+        return new HashSet<>();
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getScanner(Set<String> scopedConfigurationClasses) {
+        return new JavaIsoVisitor<ExecutionContext>() {
+            @Override
+            public J.Annotation visitAnnotation(J.Annotation annotation, ExecutionContext ctx) {
+                JavaType.FullyQualified annoType = TypeUtils.asFullyQualified(annotation.getType());
+                if (annoType != null) {
+                    String fqn = annoType.getFullyQualifiedName();
+                    if (FQN_FEIGN_CLIENT.equals(fqn) || FQN_LOAD_BALANCER_CLIENT.equals(fqn)) {
+                        collectClassLiterals(annotation, "configuration", scopedConfigurationClasses);
+                    } else if (FQN_ENABLE_FEIGN_CLIENTS.equals(fqn) || FQN_LOAD_BALANCER_CLIENTS.equals(fqn)) {
+                        collectClassLiterals(annotation, "defaultConfiguration", scopedConfigurationClasses);
+                    }
+                }
+                return super.visitAnnotation(annotation, ctx);
+            }
+        };
+    }
+
+    private static void collectClassLiterals(J.Annotation annotation, String attributeName, Set<String> acc) {
+        if (annotation.getArguments() == null) {
+            return;
+        }
+        for (Expression arg : annotation.getArguments()) {
+            if (arg instanceof J.Assignment) {
+                J.Assignment assignment = (J.Assignment) arg;
+                if (assignment.getVariable() instanceof J.Identifier &&
+                        attributeName.equals(((J.Identifier) assignment.getVariable()).getSimpleName())) {
+                    collectClassLiteralsFromExpression(assignment.getAssignment(), acc);
+                }
+            }
+        }
+    }
+
+    private static void collectClassLiteralsFromExpression(Expression expr, Set<String> acc) {
+        if (expr instanceof J.FieldAccess) {
+            J.FieldAccess fa = (J.FieldAccess) expr;
+            if ("class".equals(fa.getSimpleName())) {
+                JavaType.FullyQualified fq = TypeUtils.asFullyQualified(fa.getTarget().getType());
+                if (fq != null) {
+                    acc.add(fq.getFullyQualifiedName());
+                }
+            }
+        } else if (expr instanceof J.NewArray) {
+            J.NewArray na = (J.NewArray) expr;
+            if (na.getInitializer() != null) {
+                for (Expression e : na.getInitializer()) {
+                    collectClassLiteralsFromExpression(e, acc);
+                }
+            }
+        }
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor(Set<String> scopedConfigurationClasses) {
         return Preconditions.check(new UsesType<>(FQN_BEAN, false), new JavaIsoVisitor<ExecutionContext>() {
             @Override
             public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration classDecl, ExecutionContext ctx) {
                 J.ClassDeclaration c = super.visitClassDeclaration(classDecl, ctx);
-                if (isApplicableClass(c, getCursor())) {
+                if (isApplicableClass(c, getCursor()) && !isScopedConfiguration(c, scopedConfigurationClasses)) {
                     c = addConfigurationAnnotation(c);
                 }
                 return c;
@@ -114,6 +182,10 @@ public class AddConfigurationAnnotationIfBeansPresent extends Recipe {
         });
     }
 
+    private static boolean isScopedConfiguration(J.ClassDeclaration classDecl, Set<String> scopedConfigurationClasses) {
+        JavaType.FullyQualified type = TypeUtils.asFullyQualified(classDecl.getType());
+        return type != null && scopedConfigurationClasses.contains(type.getFullyQualifiedName());
+    }
 
     private static boolean isBeanMethod(J.MethodDeclaration methodDecl) {
         for (J.Modifier m : methodDecl.getModifiers()) {

--- a/src/main/java/org/openrewrite/java/spring/boot2/AddConfigurationAnnotationIfBeansPresent.java
+++ b/src/main/java/org/openrewrite/java/spring/boot2/AddConfigurationAnnotationIfBeansPresent.java
@@ -48,6 +48,8 @@ public class AddConfigurationAnnotationIfBeansPresent extends ScanningRecipe<Set
     private static final String FQN_ENABLE_FEIGN_CLIENTS = "org.springframework.cloud.openfeign.EnableFeignClients";
     private static final String FQN_LOAD_BALANCER_CLIENT = "org.springframework.cloud.loadbalancer.annotation.LoadBalancerClient";
     private static final String FQN_LOAD_BALANCER_CLIENTS = "org.springframework.cloud.loadbalancer.annotation.LoadBalancerClients";
+    private static final String FQN_RIBBON_CLIENT = "org.springframework.cloud.netflix.ribbon.RibbonClient";
+    private static final String FQN_RIBBON_CLIENTS = "org.springframework.cloud.netflix.ribbon.RibbonClients";
 
     @Getter
     final String displayName = "Add missing `@Configuration` annotation";
@@ -69,9 +71,9 @@ public class AddConfigurationAnnotationIfBeansPresent extends ScanningRecipe<Set
                 JavaType.FullyQualified annoType = TypeUtils.asFullyQualified(annotation.getType());
                 if (annoType != null) {
                     String fqn = annoType.getFullyQualifiedName();
-                    if (FQN_FEIGN_CLIENT.equals(fqn) || FQN_LOAD_BALANCER_CLIENT.equals(fqn)) {
+                    if (FQN_FEIGN_CLIENT.equals(fqn) || FQN_LOAD_BALANCER_CLIENT.equals(fqn) || FQN_RIBBON_CLIENT.equals(fqn)) {
                         collectClassLiterals(annotation, "configuration", scopedConfigurationClasses);
-                    } else if (FQN_ENABLE_FEIGN_CLIENTS.equals(fqn) || FQN_LOAD_BALANCER_CLIENTS.equals(fqn)) {
+                    } else if (FQN_ENABLE_FEIGN_CLIENTS.equals(fqn) || FQN_LOAD_BALANCER_CLIENTS.equals(fqn) || FQN_RIBBON_CLIENTS.equals(fqn)) {
                         collectClassLiterals(annotation, "defaultConfiguration", scopedConfigurationClasses);
                     }
                 }

--- a/src/test/java/org/openrewrite/java/spring/boot3/AddConfigurationAnnotationIfBeansPresentTest.java
+++ b/src/test/java/org/openrewrite/java/spring/boot3/AddConfigurationAnnotationIfBeansPresentTest.java
@@ -34,7 +34,8 @@ class AddConfigurationAnnotationIfBeansPresentTest implements RewriteTest {
             .classpathFromResources(new InMemoryExecutionContext(),
               "spring-boot-autoconfigure-3", "spring-boot-3",
               "spring-beans-6", "spring-context-6", "spring-web-6", "spring-core-6",
-              "spring-security-core-6", "spring-security-config-6"));
+              "spring-security-core-6", "spring-security-config-6",
+              "spring-cloud-openfeign-core"));
     }
 
     @DocumentExample
@@ -136,4 +137,122 @@ class AddConfigurationAnnotationIfBeansPresentTest implements RewriteTest {
         );
     }
 
+    @Test
+    void feignClientScopedConfiguration() {
+        rewriteRun(
+          java(
+            """
+              import org.springframework.context.annotation.Bean;
+
+              public class MyFeignConfiguration {
+                  @Bean
+                  public String authInterceptor() {
+                      return "interceptor";
+                  }
+              }
+              """
+          ),
+          java(
+            """
+              import org.springframework.cloud.openfeign.FeignClient;
+
+              @FeignClient(name = "my-service", configuration = MyFeignConfiguration.class)
+              public interface MyFeignClient {
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void feignClientScopedConfigurationArray() {
+        rewriteRun(
+          java(
+            """
+              import org.springframework.context.annotation.Bean;
+
+              public class FeignConfigA {
+                  @Bean String a() { return "a"; }
+              }
+              """
+          ),
+          java(
+            """
+              import org.springframework.context.annotation.Bean;
+
+              public class FeignConfigB {
+                  @Bean String b() { return "b"; }
+              }
+              """
+          ),
+          java(
+            """
+              import org.springframework.cloud.openfeign.FeignClient;
+
+              @FeignClient(name = "svc", configuration = {FeignConfigA.class, FeignConfigB.class})
+              public interface SvcClient {
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void enableFeignClientsDefaultConfiguration() {
+        rewriteRun(
+          java(
+            """
+              import org.springframework.context.annotation.Bean;
+
+              public class DefaultFeignConfig {
+                  @Bean String defaultBean() { return "default"; }
+              }
+              """
+          ),
+          java(
+            """
+              import org.springframework.cloud.openfeign.EnableFeignClients;
+              import org.springframework.context.annotation.Configuration;
+
+              @Configuration
+              @EnableFeignClients(defaultConfiguration = DefaultFeignConfig.class)
+              public class App {
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void beansClassNotReferencedStillGetsConfiguration() {
+        rewriteRun(
+          java(
+            """
+              import org.springframework.context.annotation.Bean;
+
+              public class UsedElsewhereConfig {
+                  @Bean String bean() { return "bean"; }
+              }
+              """,
+            """
+              import org.springframework.context.annotation.Bean;
+              import org.springframework.context.annotation.Configuration;
+
+              @Configuration
+              public class UsedElsewhereConfig {
+                  @Bean String bean() { return "bean"; }
+              }
+              """
+          ),
+          java(
+            """
+              import org.springframework.cloud.openfeign.FeignClient;
+
+              @FeignClient(name = "unrelated")
+              public interface UnrelatedClient {
+              }
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- Convert `AddConfigurationAnnotationIfBeansPresent` to a `ScanningRecipe` that first collects FQNs of classes referenced as scoped configuration via `.class` literals in `@FeignClient` / `@LoadBalancerClient` (`configuration` attr) and `@EnableFeignClients` / `@LoadBalancerClients` (`defaultConfiguration` attr).
- Skip adding `@Configuration` to those collected classes so their per-client / per-target scope is preserved, addressing the concern from https://github.com/openrewrite/rewrite-spring/pull/1003#issuecomment-4295421357.
- Adds tests covering single-class, array-form, and `defaultConfiguration` attributes, plus a negative test ensuring unrelated configs still get `@Configuration`.
- Fixes https://github.com/openrewrite/rewrite-spring/issues/1002
- Closes https://github.com/openrewrite/rewrite-spring/pull/1003

## Test plan
- [x] `./gradlew test --tests AddConfigurationAnnotationIfBeansPresentTest` (9/9 pass)