### PR TITLE
Rename `HealthIndicator.getHealth()` to `health()` for Spring Boot 4

### DIFF
--- a/src/main/resources/META-INF/rewrite/spring-boot-40-modular-starters.yml
+++ b/src/main/resources/META-INF/rewrite/spring-boot-40-modular-starters.yml
@@ -448,6 +448,16 @@ recipeList:
       oldPackageName: org.springframework.boot.actuate.health
       newPackageName: org.springframework.boot.health.contributor
       recursive: true
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: org.springframework.boot.actuate.health.Health getHealth(..)
+      newMethodName: health
+      matchOverrides: true
+      ignoreDefinition: false
+  # spring-boot-micrometer-metrics
+  - org.openrewrite.java.ChangePackage:
+      oldPackageName: org.springframework.boot.actuate.autoconfigure.metrics.export.*
+      newPackageName: org.springframework.boot.micrometer.metrics.autoconfigure.export.*
+      recursive: true
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.spring.boot4.AddSpringBootStarterFlyway

--- a/src/main/resources/META-INF/rewrite/spring-boot-40-modular-starters.yml
+++ b/src/main/resources/META-INF/rewrite/spring-boot-40-modular-starters.yml
@@ -454,11 +454,6 @@ recipeList:
       newMethodName: health
       matchOverrides: true
       ignoreDefinition: false
-  # spring-boot-micrometer-metrics
-  - org.openrewrite.java.ChangePackage:
-      oldPackageName: org.springframework.boot.actuate.autoconfigure.metrics.export.dynatrace
-      newPackageName: org.springframework.boot.micrometer.metrics.autoconfigure.export.dynatrace
-      recursive: true
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.spring.boot4.AddSpringBootStarterFlyway

--- a/src/main/resources/META-INF/rewrite/spring-boot-40-modular-starters.yml
+++ b/src/main/resources/META-INF/rewrite/spring-boot-40-modular-starters.yml
@@ -448,15 +448,16 @@ recipeList:
       oldPackageName: org.springframework.boot.actuate.health
       newPackageName: org.springframework.boot.health.contributor
       recursive: true
+  # the functional interface HealthIndicator lost the method getHealth(boolean includeDetails) in favor of health(boolean includeDetails)
   - org.openrewrite.java.ChangeMethodName:
-      methodPattern: org.springframework.boot.actuate.health.Health getHealth(..)
+      methodPattern: org.springframework.boot.health.contributor.HealthIndicator getHealth(..)
       newMethodName: health
       matchOverrides: true
       ignoreDefinition: false
   # spring-boot-micrometer-metrics
   - org.openrewrite.java.ChangePackage:
-      oldPackageName: org.springframework.boot.actuate.autoconfigure.metrics.export.*
-      newPackageName: org.springframework.boot.micrometer.metrics.autoconfigure.export.*
+      oldPackageName: org.springframework.boot.actuate.autoconfigure.metrics.export.dynatrace
+      newPackageName: org.springframework.boot.micrometer.metrics.autoconfigure.export.dynatrace
       recursive: true
 ---
 type: specs.openrewrite.org/v1beta/recipe

--- a/src/main/resources/META-INF/rewrite/spring-boot-40-modular-starters.yml
+++ b/src/main/resources/META-INF/rewrite/spring-boot-40-modular-starters.yml
@@ -443,17 +443,17 @@ recipeList:
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: org.springframework.boot.actuate.health.ReactiveHealthContributorRegistry
       newFullyQualifiedTypeName: org.springframework.boot.health.registry.ReactiveHealthContributorRegistry
+  # Remaining types move to health.contributor (catch-all)
+  - org.openrewrite.java.ChangePackage:
+      oldPackageName: org.springframework.boot.actuate.health
+      newPackageName: org.springframework.boot.health.contributor
+      recursive: true
   # the functional interface HealthIndicator lost the method getHealth(boolean includeDetails) in favor of health(boolean includeDetails)
   - org.openrewrite.java.ChangeMethodName:
       methodPattern: org.springframework.boot.health.contributor.HealthIndicator getHealth(..)
       newMethodName: health
       matchOverrides: true
       ignoreDefinition: false
-  # Remaining types move to health.contributor (catch-all)
-  - org.openrewrite.java.ChangePackage:
-      oldPackageName: org.springframework.boot.actuate.health
-      newPackageName: org.springframework.boot.health.contributor
-      recursive: true
   # spring-boot-micrometer-metrics
   - org.openrewrite.java.ChangePackage:
       oldPackageName: org.springframework.boot.actuate.autoconfigure.metrics.export.dynatrace

--- a/src/main/resources/META-INF/rewrite/spring-boot-40-modular-starters.yml
+++ b/src/main/resources/META-INF/rewrite/spring-boot-40-modular-starters.yml
@@ -443,17 +443,17 @@ recipeList:
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: org.springframework.boot.actuate.health.ReactiveHealthContributorRegistry
       newFullyQualifiedTypeName: org.springframework.boot.health.registry.ReactiveHealthContributorRegistry
-  # Remaining types move to health.contributor (catch-all)
-  - org.openrewrite.java.ChangePackage:
-      oldPackageName: org.springframework.boot.actuate.health
-      newPackageName: org.springframework.boot.health.contributor
-      recursive: true
   # the functional interface HealthIndicator lost the method getHealth(boolean includeDetails) in favor of health(boolean includeDetails)
   - org.openrewrite.java.ChangeMethodName:
       methodPattern: org.springframework.boot.health.contributor.HealthIndicator getHealth(..)
       newMethodName: health
       matchOverrides: true
       ignoreDefinition: false
+  # Remaining types move to health.contributor (catch-all)
+  - org.openrewrite.java.ChangePackage:
+      oldPackageName: org.springframework.boot.actuate.health
+      newPackageName: org.springframework.boot.health.contributor
+      recursive: true
   # spring-boot-micrometer-metrics
   - org.openrewrite.java.ChangePackage:
       oldPackageName: org.springframework.boot.actuate.autoconfigure.metrics.export.dynatrace

--- a/src/test/java/org/openrewrite/java/spring/boot4/MigrateToModularStartersTest.java
+++ b/src/test/java/org/openrewrite/java/spring/boot4/MigrateToModularStartersTest.java
@@ -15,7 +15,6 @@
  */
 package org.openrewrite.java.spring.boot4;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -466,41 +465,29 @@ class MigrateToModularStartersTest implements RewriteTest {
         }
 
         @Test
-        @Disabled("test doesa not work as expected")
         void migrateGetHealthMethodRenaming() {
             rewriteRun(
-              spec -> spec.typeValidationOptions(TypeValidation.none()),
               //language=java
               java(
                 """
-                  import org.springframework.boot.actuate.health.AbstractHealthIndicator;
                   import org.springframework.boot.actuate.health.Health;
                   import org.springframework.boot.actuate.health.HealthIndicator;
 
-                  class MyHealthIndicator extends AbstractHealthIndicator {
+                  class MyHealthIndicator implements HealthIndicator {
                       @Override
-                      protected void doHealthCheck(Health.Builder builder) {
-                          builder.up().build();
-                      }
-
-                      protected Health myHealth(Health.Builder builder) {
-                          return builder.up().build().getHealth();
+                      public Health getHealth() {
+                          return Health.up().build();
                       }
                   }
                   """,
                 """
-                  import org.springframework.boot.health.contributor.AbstractHealthIndicator;
                   import org.springframework.boot.health.contributor.Health;
                   import org.springframework.boot.health.contributor.HealthIndicator;
 
-                  class MyHealthIndicator extends AbstractHealthIndicator {
+                  class MyHealthIndicator implements HealthIndicator {
                       @Override
-                      protected void doHealthCheck(Health.Builder builder) {
-                          builder.up().build();
-                      }
-
-                      protected Health myHealth(Health.Builder builder) {
-                          return builder.up().build().health();
+                      public Health health() {
+                          return Health.up().build();
                       }
                   }
                   """
@@ -773,9 +760,9 @@ class MigrateToModularStartersTest implements RewriteTest {
     }
 
     @Test
-    @Disabled("LST contains missing or invalid type information which causes the recipe to not be applied")
     void migrateDynatraceMeticsConfiguration() {
         rewriteRun(
+          spec -> spec.typeValidationOptions(TypeValidation.none()),
           //language=java
           java(
             """

--- a/src/test/java/org/openrewrite/java/spring/boot4/MigrateToModularStartersTest.java
+++ b/src/test/java/org/openrewrite/java/spring/boot4/MigrateToModularStartersTest.java
@@ -15,6 +15,7 @@
  */
 package org.openrewrite.java.spring.boot4;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -443,6 +444,48 @@ class MigrateToModularStartersTest implements RewriteTest {
               //language=java
               java(
                 """
+                  import org.springframework.boot.actuate.health.AbstractHealthIndicator;
+                  import org.springframework.boot.actuate.health.Health;
+                  import org.springframework.boot.actuate.health.HealthIndicator;
+
+                  class MyHealthIndicator extends AbstractHealthIndicator {
+                      @Override
+                      protected void doHealthCheck(Health.Builder builder) {
+                          builder.up().build();
+                      }
+
+                      protected HealthIndicator getHealthIndicator(Health.Builder builder) {
+                          return builder.up().build().getHealth();
+                      }
+                  }
+                  """,
+                """
+                  import org.springframework.boot.health.contributor.AbstractHealthIndicator;
+                  import org.springframework.boot.health.contributor.Health;
+                  import org.springframework.boot.health.contributor.HealthIndicator;
+
+                  class MyHealthIndicator extends AbstractHealthIndicator {
+                      @Override
+                      protected void doHealthCheck(Health.Builder builder) {
+                          builder.up().build();
+                      }
+
+                      protected HealthIndicator getHealthIndicator(Health.Builder builder) {
+                          return builder.up().build().health();
+                      }
+                  }
+                  """
+              )
+            );
+        }
+
+        @Test
+        void migrategetHealthMethodRenaming() {
+            rewriteRun(
+              spec -> spec.typeValidationOptions(TypeValidation.none()),
+              //language=java
+              java(
+                """
                   import org.springframework.boot.actuate.autoconfigure.security.servlet.EndpointRequest;
 
                   class A {
@@ -724,6 +767,39 @@ class MigrateToModularStartersTest implements RewriteTest {
                 .containsPattern("4\\.0\\.\\d+")
                 .actual())
             )
+          )
+        );
+    }
+
+    @Test
+    @Disabled("LST contains missing or invalid type information which causes the recipe to not be applied")
+    void migrateDynatraceMeticsConfiguration() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+              import org.springframework.boot.actuate.autoconfigure.metrics.export.dynatrace.DynatraceMetricsExportAutoConfiguration;
+              import org.springframework.context.annotation.Configuration;
+              import org.springframework.context.annotation.Import;
+
+               @Configuration
+               @ConditionalOnProperty("vcap.services.dynatrace.instance_name")
+               @Import(DynatraceMetricsExportAutoConfiguration.class)
+               class CustomDynatraceRegistryConfiguration {}
+              """
+            ,
+            """
+              import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+              import org.springframework.boot.micrometer.metrics.autoconfigure.export.dynatrace.DynatraceMetricsExportAutoConfiguration;
+              import org.springframework.context.annotation.Configuration;
+              import org.springframework.context.annotation.Import;
+
+               @Configuration
+               @ConditionalOnProperty("vcap.services.dynatrace.instance_name")
+               @Import(DynatraceMetricsExportAutoConfiguration.class)
+               class CustomDynatraceRegistryConfiguration {}
+              """
           )
         );
     }

--- a/src/test/java/org/openrewrite/java/spring/boot4/MigrateToModularStartersTest.java
+++ b/src/test/java/org/openrewrite/java/spring/boot4/MigrateToModularStartersTest.java
@@ -759,36 +759,4 @@ class MigrateToModularStartersTest implements RewriteTest {
         );
     }
 
-    @Test
-    void migrateDynatraceMeticsConfiguration() {
-        rewriteRun(
-          spec -> spec.typeValidationOptions(TypeValidation.none()),
-          //language=java
-          java(
-            """
-              import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-              import org.springframework.boot.actuate.autoconfigure.metrics.export.dynatrace.DynatraceMetricsExportAutoConfiguration;
-              import org.springframework.context.annotation.Configuration;
-              import org.springframework.context.annotation.Import;
-
-               @Configuration
-               @ConditionalOnProperty("vcap.services.dynatrace.instance_name")
-               @Import(DynatraceMetricsExportAutoConfiguration.class)
-               class CustomDynatraceRegistryConfiguration {}
-              """
-            ,
-            """
-              import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-              import org.springframework.boot.micrometer.metrics.autoconfigure.export.dynatrace.DynatraceMetricsExportAutoConfiguration;
-              import org.springframework.context.annotation.Configuration;
-              import org.springframework.context.annotation.Import;
-
-               @Configuration
-               @ConditionalOnProperty("vcap.services.dynatrace.instance_name")
-               @Import(DynatraceMetricsExportAutoConfiguration.class)
-               class CustomDynatraceRegistryConfiguration {}
-              """
-          )
-        );
-    }
 }

--- a/src/test/java/org/openrewrite/java/spring/boot4/MigrateToModularStartersTest.java
+++ b/src/test/java/org/openrewrite/java/spring/boot4/MigrateToModularStartersTest.java
@@ -444,6 +444,35 @@ class MigrateToModularStartersTest implements RewriteTest {
               //language=java
               java(
                 """
+                  import org.springframework.boot.actuate.autoconfigure.security.servlet.EndpointRequest;
+
+                  class A {
+                      void m() {
+                          Object o = EndpointRequest.toAnyEndpoint();
+                      }
+                  }
+                  """,
+                """
+                  import org.springframework.boot.security.autoconfigure.actuate.web.servlet.EndpointRequest;
+
+                  class A {
+                      void m() {
+                          Object o = EndpointRequest.toAnyEndpoint();
+                      }
+                  }
+                  """
+              )
+            );
+        }
+
+        @Test
+        @Disabled("test doesa not work as expected")
+        void migrateGetHealthMethodRenaming() {
+            rewriteRun(
+              spec -> spec.typeValidationOptions(TypeValidation.none()),
+              //language=java
+              java(
+                """
                   import org.springframework.boot.actuate.health.AbstractHealthIndicator;
                   import org.springframework.boot.actuate.health.Health;
                   import org.springframework.boot.actuate.health.HealthIndicator;
@@ -454,7 +483,7 @@ class MigrateToModularStartersTest implements RewriteTest {
                           builder.up().build();
                       }
 
-                      protected HealthIndicator getHealthIndicator(Health.Builder builder) {
+                      protected Health myHealth(Health.Builder builder) {
                           return builder.up().build().getHealth();
                       }
                   }
@@ -470,36 +499,8 @@ class MigrateToModularStartersTest implements RewriteTest {
                           builder.up().build();
                       }
 
-                      protected HealthIndicator getHealthIndicator(Health.Builder builder) {
+                      protected Health myHealth(Health.Builder builder) {
                           return builder.up().build().health();
-                      }
-                  }
-                  """
-              )
-            );
-        }
-
-        @Test
-        void migrategetHealthMethodRenaming() {
-            rewriteRun(
-              spec -> spec.typeValidationOptions(TypeValidation.none()),
-              //language=java
-              java(
-                """
-                  import org.springframework.boot.actuate.autoconfigure.security.servlet.EndpointRequest;
-
-                  class A {
-                      void m() {
-                          Object o = EndpointRequest.toAnyEndpoint();
-                      }
-                  }
-                  """,
-                """
-                  import org.springframework.boot.security.autoconfigure.actuate.web.servlet.EndpointRequest;
-
-                  class A {
-                      void m() {
-                          Object o = EndpointRequest.toAnyEndpoint();
                       }
                   }
                   """


### PR DESCRIPTION
## What's changed?
This PR is not satisfying and tries to address 2 issues.

## What's your motivation?
failing SB4 upgrades

## Anything in particular you'd like reviewers to focus on?
the functional interface HealthIndicator lost the method getHealth(boolean includeDetails) in favor of health(boolean includeDetails)

Also package renamings:

  - org.openrewrite.java.ChangePackage:
      oldPackageName: org.springframework.boot.actuate.autoconfigure.metrics.export.dynatrace
      newPackageName: org.springframework.boot.micrometer.metrics.autoconfigure.export.dynatrace
where dynatrace could also be replaced by a glob * for other technologies ..

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
