### PR TITLE
Chain `UpgradeSpringFramework_5_1` from `UpgradeSpringBoot_2_1`

### DIFF
--- a/src/main/resources/META-INF/rewrite/spring-boot-21.yml
+++ b/src/main/resources/META-INF/rewrite/spring-boot-21.yml
@@ -32,6 +32,7 @@ preconditions:
   - org.openrewrite.Singleton
 recipeList:
   - org.openrewrite.java.spring.boot2.UpgradeSpringBoot_2_0
+  - org.openrewrite.java.spring.framework.UpgradeSpringFramework_5_1
   - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
       groupId: org.springframework.boot
       artifactId: "*"


### PR DESCRIPTION
## Summary

Spring Boot 2.1 targets Spring Framework 5.1 — the [Spring Boot 2.1 release notes](https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.1-Release-Notes) state:

> Spring Boot 2.1 builds on and requires Spring Framework 5.1.

However, [`UpgradeSpringBoot_2_1`](https://github.com/openrewrite/rewrite-spring/blob/main/src/main/resources/META-INF/rewrite/spring-boot-21.yml) only invokes `UpgradeSpringBoot_2_0` (which transitively invokes `UpgradeSpringFramework_5_0`). The matching [`UpgradeSpringFramework_5_1`](https://github.com/openrewrite/rewrite-spring/blob/main/src/main/resources/META-INF/rewrite/spring-framework-51.yml) aggregator was never wired in, so a customer running `UpgradeSpringBoot_2_1` directly bumps Boot to `2.1.x` but the Framework migration stops at 5.0.

Every other Spring Boot aggregator that crosses a Spring Framework version bump invokes the matching SF aggregator directly:

| Spring Boot | SF aggregator invoked? |
|---|---|
| `_2_0` | `_5_0` |
| `_2_1` | (this PR) |
| `_2_2` | `_5_2` |
| `_2_4` | `_5_3` |
| `_3_0` | `_6_0` |
| `_3_2` | `_6_1` |
| `_3_4` | `_6_2` |

`UpgradeSpringFramework_5_1`'s body (`EnvironmentAcceptsProfiles`, the `@Required` → `@Autowired` migration) is currently reachable only when a caller invokes `UpgradeSpringBoot_2_2` or higher (which pulls in `_5_2` → `_5_1`). Adding the missing edge to `_2_1` restores symmetry and makes the recipe self-contained.

## Test plan

- [x] `./gradlew check -x test` passes locally (including `recipeCsvValidateCompleteness` / `recipeCsvValidateContent`)
- [x] No existing tests reference `UpgradeSpringBoot_2_1` or `UpgradeSpringFramework_5_1`; behavior change is a `recipeList` edit only — no visitor logic touched