### PR TITLE
Stop deleting user-defined `swagger.*` properties in `SwaggerToSpringDoc`

### DIFF
--- a/src/main/resources/META-INF/rewrite/springdoc.yml
+++ b/src/main/resources/META-INF/rewrite/springdoc.yml
@@ -55,12 +55,6 @@ preconditions:
 recipeList:
   - org.openrewrite.openapi.swagger.SwaggerToOpenAPI
   - org.openrewrite.java.spring.doc.RemoveBeanValidatorPluginsConfiguration
-  - org.openrewrite.java.spring.DeleteSpringProperty:
-      propertyKey: swagger.title
-  - org.openrewrite.java.spring.DeleteSpringProperty:
-      propertyKey: swagger.description
-  - org.openrewrite.java.spring.DeleteSpringProperty:
-      propertyKey: swagger.contact
   - org.openrewrite.java.RemoveAnnotation:
       annotationPattern: '@springfox.documentation.swagger2.annotations.EnableSwagger2'
   - org.openrewrite.java.spring.doc.MigrateDocketBeanToGroupedOpenApiBean


### PR DESCRIPTION
## Summary

- `swagger.title`, `swagger.description`, and `swagger.contact` are not SpringFox-defined properties — SpringFox auto-config lives under `springfox.documentation.*`. They're a user-invented namespace typically read via `@Value`, so the SpringFox→springdoc migration should not touch them.
- Drops the three `DeleteSpringProperty` calls from `SwaggerToSpringDoc` so user properties survive the migration.

- Fixes #1019

## Test plan

- [ ] `./gradlew test --tests "*SpringFoxToSpringDoc*" --tests "DeleteSpringPropertyKeyTest"`