### PR TITLE
Revert inline Maven mirror (now in gh-automation#95)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,4 +27,6 @@ jobs:
       sonatype_token: ${{ secrets.SONATYPE_TOKEN }}
       ossrh_signing_key: ${{ secrets.OSSRH_SIGNING_KEY }}
       ossrh_signing_password: ${{ secrets.OSSRH_SIGNING_PASSWORD }}
+      artifactory_username: ${{ secrets.ARTIFACTORY_USERNAME }}
+      artifactory_password: ${{ secrets.ARTIFACTORY_PASSWORD }}
       OPS_GITHUB_ACTIONS_WEBHOOK: ${{ secrets.OPS_GITHUB_ACTIONS_WEBHOOK }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,38 +20,11 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
-    if: github.event_name != 'schedule' || github.repository_owner == 'openrewrite' || github.repository_owner == 'moderneinc'
-    steps:
-      - uses: openrewrite/gh-automation/.github/actions/setup@main
-        with:
-          develocity_access_key: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
-
-      # Route Maven resolution through Moderne's Artifactory cache to avoid
-      # Maven Central rate-limiting (HTTP 429) under parallel test load.
-      - uses: s4u/maven-settings-action@v4.0.0
-        with:
-          mirrors: '[{"id": "moderne-cache", "name": "Moderne Artifactory Cache", "mirrorOf": "*", "url": "https://artifactory.moderne.ninja/artifactory/moderne-cache-3/"}]'
-          servers: ${{ secrets.ARTIFACTORY_USERNAME != '' && format('[{{"id":"moderne-cache","username":"{0}","password":"{1}"}}]', secrets.ARTIFACTORY_USERNAME, secrets.ARTIFACTORY_PASSWORD) || '[]' }}
-
-      - uses: openrewrite/gh-automation/.github/actions/build@main
-        env:
-          REWRITE_GRADLE_MIRROR_URL: https://artifactory.moderne.ninja/artifactory/moderne-cache-3/
-          REWRITE_GRADLE_MIRROR_USERNAME: ${{ secrets.AST_PUBLISH_USERNAME }}
-          REWRITE_GRADLE_MIRROR_PASSWORD: ${{ secrets.AST_PUBLISH_PASSWORD }}
-
-      - if: failure() && github.event_name == 'schedule' && (github.repository_owner == 'openrewrite' || github.repository_owner == 'moderneinc')
-        uses: openrewrite/gh-automation/.github/actions/slack-failure@main
-        with:
-          webhook: ${{ secrets.OPS_GITHUB_ACTIONS_WEBHOOK }}
-
-      - if: >
-          github.event_name != 'pull_request' &&
-          github.ref == 'refs/heads/main' &&
-          (github.repository_owner == 'openrewrite' || github.repository_owner == 'moderneinc')
-        uses: openrewrite/gh-automation/.github/actions/publish-snapshots@main
-        with:
-          sonatype_username: ${{ secrets.SONATYPE_USERNAME }}
-          sonatype_token: ${{ secrets.SONATYPE_TOKEN }}
-          ossrh_signing_key: ${{ secrets.OSSRH_SIGNING_KEY }}
-          ossrh_signing_password: ${{ secrets.OSSRH_SIGNING_PASSWORD }}
+    uses: openrewrite/gh-automation/.github/workflows/ci-gradle.yml@main
+    secrets:
+      gradle_enterprise_access_key: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+      sonatype_username: ${{ secrets.SONATYPE_USERNAME }}
+      sonatype_token: ${{ secrets.SONATYPE_TOKEN }}
+      ossrh_signing_key: ${{ secrets.OSSRH_SIGNING_KEY }}
+      ossrh_signing_password: ${{ secrets.OSSRH_SIGNING_PASSWORD }}
+      OPS_GITHUB_ACTIONS_WEBHOOK: ${{ secrets.OPS_GITHUB_ACTIONS_WEBHOOK }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,56 +11,12 @@ concurrency:
   group: publish-${{ github.ref }}
   cancel-in-progress: false
 
-env:
-  GRADLE_SWITCHES: --console=plain --info --stacktrace --warning-mode=all --no-daemon
-  ORG_GRADLE_PROJECT_sonatypeUsername: ${{ secrets.SONATYPE_USERNAME }}
-  ORG_GRADLE_PROJECT_sonatypePassword: ${{ secrets.SONATYPE_TOKEN }}
-  ORG_GRADLE_PROJECT_signingKey: ${{ secrets.OSSRH_SIGNING_KEY }}
-  ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.OSSRH_SIGNING_PASSWORD }}
-
 jobs:
   release:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: openrewrite/gh-automation/.github/actions/setup@main
-        with:
-          develocity_access_key: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
-
-      # Route Maven resolution through Moderne's Artifactory cache to avoid
-      # Maven Central rate-limiting (HTTP 429) under parallel test load.
-      - uses: s4u/maven-settings-action@v4.0.0
-        with:
-          mirrors: '[{"id": "moderne-cache", "name": "Moderne Artifactory Cache", "mirrorOf": "*", "url": "https://artifactory.moderne.ninja/artifactory/moderne-cache-3/"}]'
-          servers: ${{ secrets.ARTIFACTORY_USERNAME != '' && format('[{{"id":"moderne-cache","username":"{0}","password":"{1}"}}]', secrets.ARTIFACTORY_USERNAME, secrets.ARTIFACTORY_PASSWORD) || '[]' }}
-
-      - name: publish-candidate
-        if: contains(github.ref, '-rc.')
-        env:
-          REWRITE_GRADLE_MIRROR_URL: https://artifactory.moderne.ninja/artifactory/moderne-cache-3/
-          REWRITE_GRADLE_MIRROR_USERNAME: ${{ secrets.AST_PUBLISH_USERNAME }}
-          REWRITE_GRADLE_MIRROR_PASSWORD: ${{ secrets.AST_PUBLISH_PASSWORD }}
-        run: |
-          ./gradlew \
-          ${{ env.GRADLE_SWITCHES }} \
-          -Preleasing \
-          -Prelease.disableGitChecks=true \
-          -Prelease.useLastTag=true \
-          candidate \
-          publish \
-          closeAndReleaseSonatypeStagingRepository
-
-      - name: publish-release
-        if: (!contains(github.ref, '-rc.'))
-        env:
-          REWRITE_GRADLE_MIRROR_URL: https://artifactory.moderne.ninja/artifactory/moderne-cache-3/
-          REWRITE_GRADLE_MIRROR_USERNAME: ${{ secrets.AST_PUBLISH_USERNAME }}
-          REWRITE_GRADLE_MIRROR_PASSWORD: ${{ secrets.AST_PUBLISH_PASSWORD }}
-        run: |
-          ./gradlew \
-          ${{ env.GRADLE_SWITCHES }} \
-          -Preleasing \
-          -Prelease.disableGitChecks=true \
-          -Prelease.useLastTag=true \
-          final \
-          publish \
-          closeAndReleaseSonatypeStagingRepository
+    uses: openrewrite/gh-automation/.github/workflows/publish-gradle.yml@main
+    secrets:
+      gradle_enterprise_access_key: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+      sonatype_username: ${{ secrets.SONATYPE_USERNAME }}
+      sonatype_token: ${{ secrets.SONATYPE_TOKEN }}
+      ossrh_signing_key: ${{ secrets.OSSRH_SIGNING_KEY }}
+      ossrh_signing_password: ${{ secrets.OSSRH_SIGNING_PASSWORD }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,3 +20,5 @@ jobs:
       sonatype_token: ${{ secrets.SONATYPE_TOKEN }}
       ossrh_signing_key: ${{ secrets.OSSRH_SIGNING_KEY }}
       ossrh_signing_password: ${{ secrets.OSSRH_SIGNING_PASSWORD }}
+      artifactory_username: ${{ secrets.ARTIFACTORY_USERNAME }}
+      artifactory_password: ${{ secrets.ARTIFACTORY_PASSWORD }}


### PR DESCRIPTION
## Summary
- Revert the inline Maven mirror configuration. The same configuration now lives centrally in [openrewrite/gh-automation#95](https://github.com/openrewrite/gh-automation/pull/95), so callers of `ci-gradle.yml` / `publish-gradle.yml` inherit it automatically.

This restores the thin-caller form (single `uses:` of the reusable workflow). No behavioral change — Maven resolution still routes through `https://artifactory.moderne.ninja/artifactory/moderne-cache-3/` to avoid Maven Central rate-limiting (HTTP 429).

## Test plan
- [ ] CI passes (the reusable workflow now applies the mirror centrally)
- [ ] No `HTTP 429` lines in build logs