### PR TITLE
Pass cursor to `RemoveAnnotationVisitor` in `AutowiredFieldIntoConstructorParameterVisitor`

### DIFF
--- a/src/main/java/org/openrewrite/java/spring/AutowiredFieldIntoConstructorParameterVisitor.java
+++ b/src/main/java/org/openrewrite/java/spring/AutowiredFieldIntoConstructorParameterVisitor.java
@@ -118,7 +118,7 @@ public class AutowiredFieldIntoConstructorParameterVisitor extends JavaVisitor<E
                 multiVariable.getVariables().size() == 1 &&
                 fieldName.equals(multiVariable.getVariables().get(0).getName().getSimpleName())) {
 
-            mv = (VariableDeclarations) new RemoveAnnotationVisitor(new AnnotationMatcher("@" + AUTOWIRED)).visitNonNull(multiVariable, p);
+            mv = (VariableDeclarations) new RemoveAnnotationVisitor(new AnnotationMatcher("@" + AUTOWIRED)).visit(multiVariable, p, getCursor().getParentOrThrow());
             if (mv != multiVariable && multiVariable.getTypeExpression() != null) {
                 if (mv.getModifiers().stream().noneMatch(m -> m.getType() == J.Modifier.Type.Final)) {
                     Space prefix = Space.firstPrefix(mv.getVariables());


### PR DESCRIPTION
## Summary
- The upstream `RemoveAnnotationVisitor` in `rewrite-java` now relies on its cursor context (e.g. for `maybeRemoveBlankLines` to locate the enclosing `JavaSourceFile`). The previous two-argument `visitNonNull(tree, ctx)` call left it without a cursor, breaking `AutowiredFieldIntoConstructorParameterVisitorTest` (7 of 11 tests failing with `Expected to find enclosing JavaSourceFile`).
- Switch to the three-argument `visit(tree, ctx, cursor)` form. Because we're re-visiting `multiVariable` — the tree the current cursor already points to — we pass `getCursor().getParentOrThrow()` to avoid the `cursorAcyclic` assertion. This mirrors the pattern already used in `NoAutowiredOnConstructor`.

## Test plan
- [x] `./gradlew test --tests org.openrewrite.java.spring.AutowiredFieldIntoConstructorParameterVisitorTest` → all 11 tests pass