### PR TITLE
Make UnwrapMockAndSpyBeanContainers Kotlin-aware

### DIFF
--- a/src/main/java/org/openrewrite/java/spring/boot4/UnwrapMockAndSpyBeanContainers.java
+++ b/src/main/java/org/openrewrite/java/spring/boot4/UnwrapMockAndSpyBeanContainers.java
@@ -25,6 +25,9 @@ import org.openrewrite.java.AnnotationMatcher;
 import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.search.UsesType;
 import org.openrewrite.java.tree.*;
+import org.openrewrite.kotlin.marker.AnnotationConstructor;
+import org.openrewrite.kotlin.marker.Modifier;
+import org.openrewrite.kotlin.tree.K;
 import org.openrewrite.marker.Markers;
 
 import java.util.ArrayList;
@@ -61,6 +64,7 @@ public class UnwrapMockAndSpyBeanContainers extends Recipe {
                     @Override
                     public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration classDecl, ExecutionContext ctx) {
                         J.ClassDeclaration cd = super.visitClassDeclaration(classDecl, ctx);
+                        boolean isKotlin = getCursor().firstEnclosing(K.CompilationUnit.class) != null;
                         return cd.withLeadingAnnotations(ListUtils.map(cd.getLeadingAnnotations(), annotation -> {
                             boolean isMockBeans = MOCK_BEANS_MATCHER.matches(annotation);
                             boolean isSpyBeans = SPY_BEANS_MATCHER.matches(annotation);
@@ -80,10 +84,19 @@ public class UnwrapMockAndSpyBeanContainers extends Recipe {
                                 allTypes.addAll(extractTypeExpressions(inner));
                             }
 
-                            return innerAnnotations.get(0)
+                            J.Annotation lifted = innerAnnotations.get(0);
+                            if (isKotlin) {
+                                // Inner annotations in Kotlin containers carry markers that suppress the
+                                // leading `@`; strip them so the lifted annotation prints with `@`.
+                                Markers m = lifted.getMarkers();
+                                m = m.removeByType(AnnotationConstructor.class);
+                                m = m.removeByType(Modifier.class);
+                                lifted = lifted.withMarkers(m);
+                            }
+                            return lifted
                                     .withPrefix(annotation.getPrefix())
                                     .withArguments(singletonList(
-                                            createTypesAssignment(allTypes)));
+                                            createTypesAssignment(allTypes, isKotlin)));
                         }));
                     }
                 }
@@ -98,38 +111,34 @@ public class UnwrapMockAndSpyBeanContainers extends Recipe {
         }
 
         for (Expression arg : args) {
-            if (arg instanceof J.NewArray) {
-                // @MockBeans({@MockBean(A.class), @MockBean(B.class)})
-                J.NewArray newArray = (J.NewArray) arg;
-                if (newArray.getInitializer() != null) {
-                    for (Expression init : newArray.getInitializer()) {
-                        if (init instanceof J.Annotation) {
-                            annotations.add((J.Annotation) init);
-                        }
-                    }
-                }
-            } else if (arg instanceof J.Annotation) {
-                // @MockBeans(@MockBean(A.class))
-                annotations.add((J.Annotation) arg);
-            } else if (arg instanceof J.Assignment) {
-                // @MockBeans(value = {...})
-                J.Assignment assignment = (J.Assignment) arg;
-                Expression value = assignment.getAssignment();
-                if (value instanceof J.NewArray) {
-                    J.NewArray newArray = (J.NewArray) value;
-                    if (newArray.getInitializer() != null) {
-                        for (Expression init : newArray.getInitializer()) {
-                            if (init instanceof J.Annotation) {
-                                annotations.add((J.Annotation) init);
-                            }
-                        }
-                    }
-                } else if (value instanceof J.Annotation) {
-                    annotations.add((J.Annotation) value);
-                }
-            }
+            collectAnnotationArgument(arg, annotations);
         }
         return annotations;
+    }
+
+    private static void collectAnnotationArgument(Expression arg, List<J.Annotation> annotations) {
+        if (arg instanceof J.NewArray) {
+            // Java: @MockBeans({@MockBean(A.class), @MockBean(B.class)})
+            J.NewArray newArray = (J.NewArray) arg;
+            if (newArray.getInitializer() != null) {
+                for (Expression init : newArray.getInitializer()) {
+                    collectAnnotationArgument(init, annotations);
+                }
+            }
+        } else if (arg instanceof K.ListLiteral) {
+            // Kotlin: @MockBeans([MockBean(A::class), MockBean(B::class)])
+            for (Expression element : ((K.ListLiteral) arg).getElements()) {
+                collectAnnotationArgument(element, annotations);
+            }
+        } else if (arg instanceof J.Annotation) {
+            // Java single-arg: @MockBeans(@MockBean(A.class))
+            // Kotlin variadic:  @MockBeans(MockBean(A::class), MockBean(B::class))
+            annotations.add((J.Annotation) arg);
+        } else if (arg instanceof J.Assignment) {
+            // @MockBeans(value = ...)
+            J.Assignment assignment = (J.Assignment) arg;
+            collectAnnotationArgument(assignment.getAssignment(), annotations);
+        }
     }
 
     private static List<Expression> extractTypeExpressions(J.Annotation annotation) {
@@ -139,31 +148,40 @@ public class UnwrapMockAndSpyBeanContainers extends Recipe {
         }
 
         for (Expression arg : annotation.getArguments()) {
-            if (arg instanceof J.Assignment) {
-                J.Assignment assignment = (J.Assignment) arg;
-                if (assignment.getVariable() instanceof J.Identifier) {
-                    String name = ((J.Identifier) assignment.getVariable()).getSimpleName();
-                    if ("value".equals(name) || "classes".equals(name)) {
-                        Expression value = assignment.getAssignment();
-                        if (value instanceof J.NewArray && ((J.NewArray) value).getInitializer() != null) {
-                            types.addAll(((J.NewArray) value).getInitializer());
-                        } else {
-                            types.add(value);
-                        }
-                    }
-                }
-            } else if (arg instanceof J.FieldAccess && "class".equals(((J.FieldAccess) arg).getSimpleName())) {
-                // Implicit value: @MockBean(ClassA.class)
-                types.add(arg);
-            } else if (arg instanceof J.NewArray && ((J.NewArray) arg).getInitializer() != null) {
-                // Implicit value: @MockBean({A.class, B.class})
-                types.addAll(((J.NewArray) arg).getInitializer());
-            }
+            collectTypeExpression(arg, types);
         }
         return types;
     }
 
-    private static J.Assignment createTypesAssignment(List<Expression> typeExpressions) {
+    private static void collectTypeExpression(Expression arg, List<Expression> types) {
+        if (arg instanceof J.Assignment) {
+            J.Assignment assignment = (J.Assignment) arg;
+            if (assignment.getVariable() instanceof J.Identifier) {
+                String name = ((J.Identifier) assignment.getVariable()).getSimpleName();
+                if ("value".equals(name) || "classes".equals(name) || "types".equals(name)) {
+                    collectTypeExpression(assignment.getAssignment(), types);
+                }
+            }
+        } else if (arg instanceof J.NewArray && ((J.NewArray) arg).getInitializer() != null) {
+            // Java: {A.class, B.class}
+            for (Expression init : ((J.NewArray) arg).getInitializer()) {
+                collectTypeExpression(init, types);
+            }
+        } else if (arg instanceof K.ListLiteral) {
+            // Kotlin: [A::class, B::class]
+            for (Expression element : ((K.ListLiteral) arg).getElements()) {
+                collectTypeExpression(element, types);
+            }
+        } else if (arg instanceof J.FieldAccess && "class".equals(((J.FieldAccess) arg).getSimpleName())) {
+            // Java: A.class
+            types.add(arg);
+        } else if (arg instanceof J.MemberReference && "class".equals(((J.MemberReference) arg).getReference().getSimpleName())) {
+            // Kotlin: A::class
+            types.add(arg);
+        }
+    }
+
+    private static J.Assignment createTypesAssignment(List<Expression> typeExpressions, boolean kotlin) {
         J.Identifier typesIdent = new J.Identifier(
                 randomId(), Space.EMPTY, Markers.EMPTY,
                 emptyList(), "types", null, null
@@ -172,16 +190,25 @@ public class UnwrapMockAndSpyBeanContainers extends Recipe {
         Expression rhs;
         if (typeExpressions.size() == 1) {
             rhs = typeExpressions.get(0).withPrefix(Space.SINGLE_SPACE);
+        } else if (kotlin) {
+            // Format as [A::class, B::class]
+            List<JRightPadded<Expression>> padded = new ArrayList<>();
+            for (int i = 0; i < typeExpressions.size(); i++) {
+                Expression expr = typeExpressions.get(i);
+                expr = expr.withPrefix(i == 0 ? Space.EMPTY : Space.format(" "));
+                padded.add(JRightPadded.build(expr));
+            }
+            rhs = new K.ListLiteral(
+                    randomId(), Space.SINGLE_SPACE, Markers.EMPTY,
+                    JContainer.build(Space.EMPTY, padded, Markers.EMPTY),
+                    null
+            );
         } else {
             // Format as {A.class, B.class}
             List<JRightPadded<Expression>> padded = new ArrayList<>();
             for (int i = 0; i < typeExpressions.size(); i++) {
                 Expression expr = typeExpressions.get(i);
-                if (i == 0) {
-                    expr = expr.withPrefix(Space.EMPTY);
-                } else {
-                    expr = expr.withPrefix(Space.format(" "));
-                }
+                expr = expr.withPrefix(i == 0 ? Space.EMPTY : Space.format(" "));
                 padded.add(JRightPadded.build(expr));
             }
             rhs = new J.NewArray(

--- a/src/test/java/org/openrewrite/java/spring/boot4/UnwrapMockAndSpyBeanContainersTest.java
+++ b/src/test/java/org/openrewrite/java/spring/boot4/UnwrapMockAndSpyBeanContainersTest.java
@@ -1,0 +1,223 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.spring.boot4;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.InMemoryExecutionContext;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.kotlin.KotlinParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+import static org.openrewrite.kotlin.Assertions.kotlin;
+
+class UnwrapMockAndSpyBeanContainersTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(new UnwrapMockAndSpyBeanContainers())
+          .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(),
+            "spring-boot-test-3", "mockito-core-5"))
+          .parser(KotlinParser.builder().classpathFromResources(new InMemoryExecutionContext(),
+            "spring-boot-test-3", "mockito-core-5"));
+    }
+
+    @DocumentExample
+    @Test
+    void mergesMockBeansContainer() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import org.springframework.boot.test.mock.mockito.MockBean;
+              import org.springframework.boot.test.mock.mockito.MockBeans;
+
+              @MockBeans({@MockBean(Foo.class), @MockBean(Bar.class)})
+              class SomeTest {
+              }
+              class Foo {}
+              class Bar {}
+              """,
+            """
+              import org.springframework.boot.test.mock.mockito.MockBean;
+
+              @MockBean(types = {Foo.class, Bar.class})
+              class SomeTest {
+              }
+              class Foo {}
+              class Bar {}
+              """
+          )
+        );
+    }
+
+    @Test
+    void mergesSpyBeansContainer() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import org.springframework.boot.test.mock.mockito.SpyBean;
+              import org.springframework.boot.test.mock.mockito.SpyBeans;
+
+              @SpyBeans({@SpyBean(Foo.class), @SpyBean(Bar.class)})
+              class SomeTest {
+              }
+              class Foo {}
+              class Bar {}
+              """,
+            """
+              import org.springframework.boot.test.mock.mockito.SpyBean;
+
+              @SpyBean(types = {Foo.class, Bar.class})
+              class SomeTest {
+              }
+              class Foo {}
+              class Bar {}
+              """
+          )
+        );
+    }
+
+    @Test
+    void leavesUnrelatedAnnotationsAlone() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import org.springframework.boot.test.mock.mockito.MockBean;
+
+              @MockBean(Foo.class)
+              class SomeTest {
+              }
+              class Foo {}
+              """
+          )
+        );
+    }
+
+    @Test
+    void kotlinVariadicMockBeansWithClassLiteral() {
+        rewriteRun(
+          //language=kotlin
+          kotlin(
+            """
+              import org.springframework.boot.test.mock.mockito.MockBean
+              import org.springframework.boot.test.mock.mockito.MockBeans
+
+              @MockBeans(MockBean(Foo::class), MockBean(Bar::class))
+              class SomeTest {
+              }
+              class Foo
+              class Bar
+              """,
+            """
+              import org.springframework.boot.test.mock.mockito.MockBean
+
+              @MockBean(types = [Foo::class, Bar::class])
+              class SomeTest {
+              }
+              class Foo
+              class Bar
+              """
+          )
+        );
+    }
+
+    @Test
+    void kotlinSpyBeansVariadic() {
+        rewriteRun(
+          //language=kotlin
+          kotlin(
+            """
+              import org.springframework.boot.test.mock.mockito.SpyBean
+              import org.springframework.boot.test.mock.mockito.SpyBeans
+
+              @SpyBeans(SpyBean(Foo::class), SpyBean(Bar::class))
+              class SomeTest {
+              }
+              class Foo
+              class Bar
+              """,
+            """
+              import org.springframework.boot.test.mock.mockito.SpyBean
+
+              @SpyBean(types = [Foo::class, Bar::class])
+              class SomeTest {
+              }
+              class Foo
+              class Bar
+              """
+          )
+        );
+    }
+
+    @Test
+    void kotlinSingleInnerAnnotation() {
+        rewriteRun(
+          //language=kotlin
+          kotlin(
+            """
+              import org.springframework.boot.test.mock.mockito.MockBean
+              import org.springframework.boot.test.mock.mockito.MockBeans
+
+              @MockBeans(MockBean(Foo::class))
+              class SomeTest {
+              }
+              class Foo
+              """,
+            """
+              import org.springframework.boot.test.mock.mockito.MockBean
+
+              @MockBean(types = Foo::class)
+              class SomeTest {
+              }
+              class Foo
+              """
+          )
+        );
+    }
+
+    @Test
+    void kotlinNamedValueAttribute() {
+        rewriteRun(
+          //language=kotlin
+          kotlin(
+            """
+              import org.springframework.boot.test.mock.mockito.MockBean
+              import org.springframework.boot.test.mock.mockito.MockBeans
+
+              @MockBeans(value = [MockBean(Foo::class), MockBean(Bar::class)])
+              class SomeTest {
+              }
+              class Foo
+              class Bar
+              """,
+            """
+              import org.springframework.boot.test.mock.mockito.MockBean
+
+              @MockBean(types = [Foo::class, Bar::class])
+              class SomeTest {
+              }
+              class Foo
+              class Bar
+              """
+          )
+        );
+    }
+}


### PR DESCRIPTION
## Summary

`UnwrapMockAndSpyBeanContainers` previously assumed Java syntax shapes and produced invalid output on Kotlin sources. Two failure modes were observed:

- Container partially mutated, leaving Java-style `{A.class, B.class}` in a Kotlin file → "Expecting a top level declaration" / "Function declaration must have a name" syntax errors.
- Container left untouched (extraction returned empty), so the downstream `ChangeType MockBean → MockitoBean` rewrote only the inner annotations, producing `@MockBeans(MockitoBean(...), MockitoBean(...))` — Kotlin reads `MockitoBean(...)` there as an expression, and the surviving `org.springframework.boot.test.mock.mockito.MockBeans` import points at a package removed in Spring Boot 4.

The visitor is now Kotlin-aware:

- detects Kotlin via `K.CompilationUnit` on the cursor
- accepts `K.ListLiteral` alongside `J.NewArray` for container contents and merged arrays
- accepts `J.MemberReference` (`A::class`) alongside `J.FieldAccess` (`A.class`), and recognises `types`/`value`/`classes` attribute names
- builds the merged `types = [...]` as a `K.ListLiteral` for Kotlin output and keeps `{...}` `J.NewArray` for Java
- strips `AnnotationConstructor`/`Modifier` markers on the lifted inner annotation so the Kotlin printer emits the leading `@`

Java behaviour is unchanged.

- Resolves moderneinc/customer-requests#2390.

## Test plan

- [x] `./gradlew test --tests UnwrapMockAndSpyBeanContainersTest` — 7/7 pass (3 Java + 4 Kotlin)
- [ ] Reviewer: confirm the merge-to-`types` strategy is still the right end-state for `@MockitoBean` (it is `@Repeatable` from Spring 6.2; hoist-and-drop-container is a possible follow-up if preferred)