### PR TITLE
Move `MigrateHibernateConstraintsToJavax` call into `UpgradeSpringFramework_5_0`

### DIFF
--- a/src/main/resources/META-INF/rewrite/spring-boot-20.yml
+++ b/src/main/resources/META-INF/rewrite/spring-boot-20.yml
@@ -79,7 +79,6 @@ recipeList:
   - org.openrewrite.java.spring.boot2.MigrateSpringBootServletInitializerPackageName
   - org.openrewrite.java.spring.boot2.MigrateHttpMessageConvertersPackageName
   - org.openrewrite.java.spring.boot2.MigrateErrorControllerPackageName
-  - org.openrewrite.java.spring.boot2.MigrateHibernateConstraintsToJavax
   - org.openrewrite.java.spring.boot2.MigrateLocalServerPortAnnotation
   - org.openrewrite.java.spring.boot2.MaybeAddSpringBootStarterActuator
   # Update properties
@@ -173,6 +172,9 @@ recipeList:
       oldFullyQualifiedTypeName: org.springframework.boot.autoconfigure.web.ErrorController
       newFullyQualifiedTypeName: org.springframework.boot.web.servlet.error.ErrorController
 ---
+# TODO: Rename to `org.openrewrite.java.spring.framework.MigrateHibernateConstraintsToJavax`
+# (with a `recipe-rename` entry for backwards compatibility) and move the
+# definition into `spring-framework-50.yml`.
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.spring.boot2.MigrateHibernateConstraintsToJavax
 displayName: Use `javax.validation.constraints`

--- a/src/main/resources/META-INF/rewrite/spring-framework-50.yml
+++ b/src/main/resources/META-INF/rewrite/spring-framework-50.yml
@@ -25,6 +25,7 @@ preconditions:
   - org.openrewrite.Singleton
 recipeList:
   - org.openrewrite.java.spring.framework.MigrateWebMvcConfigurerAdapter
+  - org.openrewrite.java.spring.boot2.MigrateHibernateConstraintsToJavax
   - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
       groupId: org.springframework.security
       artifactId: "*"


### PR DESCRIPTION
## Summary

The `hibernate.validator.constraints` → `javax.validation.constraints` rename happened at the Bean Validation 2.0 / Hibernate Validator 6.0 line, which aligns to **Spring Framework 5.0** — not Spring Boot 2.0 specifically.

This PR moves the call to `MigrateHibernateConstraintsToJavax` out of `UpgradeSpringBoot_2_0` and into `UpgradeSpringFramework_5_0`, so any composite that targets Spring Framework 5.0+ picks it up. Spring Boot 2.0 still inherits the migration transitively through its existing `UpgradeSpringFramework_5_0` call.

A TODO comment is added next to the recipe definition noting that a follow-up could move the definition itself to `spring-framework-50.yml` and rename the recipe's FQN to `org.openrewrite.java.spring.framework.MigrateHibernateConstraintsToJavax` (with a `recipe-rename` entry for backwards compatibility). That work is intentionally deferred to keep this PR focused on relocating the call only.

## Test plan

- [x] `Boot2UpgradeTest.addJavaxValidationApi` and `Boot22UpgradeTest.addJavaxValidationApi` still pass — the `@NotEmpty` rewrite still happens transitively via `UpgradeSpringBoot_2_0` → `UpgradeSpringFramework_5_0` → `MigrateHibernateConstraintsToJavax`.
- [x] `./gradlew recipeCsvValidateCompleteness` passes (no recipe was added or removed, just reparented).