### PR TITLE
Emit Kotlin array literal for single-element `@MockBean(types = ...)`

### DIFF
--- a/src/main/java/org/openrewrite/java/spring/boot4/UnwrapMockAndSpyBeanContainers.java
+++ b/src/main/java/org/openrewrite/java/spring/boot4/UnwrapMockAndSpyBeanContainers.java
@@ -188,10 +188,7 @@ public class UnwrapMockAndSpyBeanContainers extends Recipe {
         );
 
         Expression rhs;
-        if (typeExpressions.size() == 1 && !kotlin) {
-            // Java single-element shorthand: types = Foo.class
-            rhs = typeExpressions.get(0).withPrefix(Space.SINGLE_SPACE);
-        } else if (kotlin) {
+        if (kotlin) {
             // Format as [A::class, B::class]
             List<JRightPadded<Expression>> padded = new ArrayList<>();
             for (int i = 0; i < typeExpressions.size(); i++) {
@@ -204,6 +201,9 @@ public class UnwrapMockAndSpyBeanContainers extends Recipe {
                     JContainer.build(Space.EMPTY, padded, Markers.EMPTY),
                     null
             );
+        } else if (typeExpressions.size() == 1) {
+            // Java single-element shorthand: types = Foo.class
+            rhs = typeExpressions.get(0).withPrefix(Space.SINGLE_SPACE);
         } else {
             // Format as {A.class, B.class}
             List<JRightPadded<Expression>> padded = new ArrayList<>();

--- a/src/main/java/org/openrewrite/java/spring/boot4/UnwrapMockAndSpyBeanContainers.java
+++ b/src/main/java/org/openrewrite/java/spring/boot4/UnwrapMockAndSpyBeanContainers.java
@@ -188,7 +188,8 @@ public class UnwrapMockAndSpyBeanContainers extends Recipe {
         );
 
         Expression rhs;
-        if (typeExpressions.size() == 1) {
+        if (typeExpressions.size() == 1 && !kotlin) {
+            // Java single-element shorthand: types = Foo.class
             rhs = typeExpressions.get(0).withPrefix(Space.SINGLE_SPACE);
         } else if (kotlin) {
             // Format as [A::class, B::class]

--- a/src/test/java/org/openrewrite/java/spring/boot4/UnwrapMockAndSpyBeanContainersTest.java
+++ b/src/test/java/org/openrewrite/java/spring/boot4/UnwrapMockAndSpyBeanContainersTest.java
@@ -169,6 +169,8 @@ class UnwrapMockAndSpyBeanContainersTest implements RewriteTest {
 
     @Test
     void kotlinSingleInnerAnnotation() {
+        // Kotlin requires an array literal for Array<KClass<*>> attributes —
+        // the Java single-element shorthand does not compile (Sunbit, customer-requests#2435).
         rewriteRun(
           //language=kotlin
           kotlin(
@@ -184,10 +186,36 @@ class UnwrapMockAndSpyBeanContainersTest implements RewriteTest {
             """
               import org.springframework.boot.test.mock.mockito.MockBean
 
-              @MockBean(types = Foo::class)
+              @MockBean(types = [Foo::class])
               class SomeTest {
               }
               class Foo
+              """
+          )
+        );
+    }
+
+    @Test
+    void javaSingleInnerAnnotationKeepsShorthand() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import org.springframework.boot.test.mock.mockito.MockBean;
+              import org.springframework.boot.test.mock.mockito.MockBeans;
+
+              @MockBeans(@MockBean(Foo.class))
+              class SomeTest {
+              }
+              class Foo {}
+              """,
+            """
+              import org.springframework.boot.test.mock.mockito.MockBean;
+
+              @MockBean(types = Foo.class)
+              class SomeTest {
+              }
+              class Foo {}
               """
           )
         );


### PR DESCRIPTION
## Summary

`UnwrapMockAndSpyBeanContainers` previously emitted the Java single-element annotation-array shorthand (`types = Foo::class`) when a `@MockBeans` / `@SpyBeans` container collapsed to one inner annotation, regardless of source language. Kotlin rejects that shape:

> Argument type mismatch: actual type is `KClass<Foo>`, but `Array<KClass<*>>` was expected.

The fix restricts the shorthand path to Java and lets the existing Kotlin `K.ListLiteral` branch handle `size == 1`. Java output is unchanged.

Before / after (Kotlin):

```diff
-@MockBean(types = Foo::class)
+@MockBean(types = [Foo::class])
```

- PR #1023 made the multi-element Kotlin case correct; this PR completes the single-element case.

- Resolves moderneinc/customer-requests#2435.

## Test plan

- [x] Updated `kotlinSingleInnerAnnotation` to assert the array-literal form — fails without the fix.
- [x] Added `javaSingleInnerAnnotationKeepsShorthand` confirming Java shorthand is preserved.
- [x] `./gradlew test --tests UnwrapMockAndSpyBeanContainersTest` — 8/8 pass (3 Java + 5 Kotlin).

## Scope note

This PR is intentionally narrow to the recipe that produced the reported failure; a broader sweep would be a separate piece of work.