### PR TITLE
Skip spring.data.redis.ssl rename when ssl has child keys

### DIFF
--- a/src/main/resources/META-INF/rewrite/spring-boot-31-properties.yml
+++ b/src/main/resources/META-INF/rewrite/spring-boot-31-properties.yml
@@ -28,12 +28,15 @@ recipeList:
   - org.openrewrite.java.spring.ChangeSpringPropertyKey:
       oldPropertyKey: spring.cassandra.ssl
       newPropertyKey: spring.cassandra.ssl.enabled
+      except: [bundle]
   - org.openrewrite.java.spring.ChangeSpringPropertyKey:
       oldPropertyKey: spring.data.cassandra.ssl
       newPropertyKey: spring.cassandra.ssl.enabled
+      except: [bundle]
   - org.openrewrite.java.spring.ChangeSpringPropertyKey:
       oldPropertyKey: spring.data.redis.ssl
       newPropertyKey: spring.data.redis.ssl.enabled
+      except: [bundle]
   - org.openrewrite.java.spring.ChangeSpringPropertyKey:
       oldPropertyKey: spring.kafka.streams.cache-max-size-buffering
       newPropertyKey: spring.kafka.streams.state-store-cache-max-size

--- a/src/test/java/org/openrewrite/java/spring/ChangeSpringPropertyKeyTest.java
+++ b/src/test/java/org/openrewrite/java/spring/ChangeSpringPropertyKeyTest.java
@@ -247,6 +247,80 @@ class ChangeSpringPropertyKeyTest implements RewriteTest {
         );
     }
 
+    @Issue("https://github.com/openrewrite/rewrite-spring/issues/1027")
+    @Test
+    void redisSslBundleNotMangled() {
+        rewriteRun(
+          spec -> spec.recipeFromResource("/META-INF/rewrite/spring-boot-31-properties.yml", "org.openrewrite.java.spring.boot3.SpringBootProperties_3_1"),
+          mavenProject("project",
+            srcMainResources(
+              //language=properties
+              properties(
+                """
+                  spring.data.redis.ssl.bundle=redis
+                  spring.cassandra.ssl.bundle=cassandra
+                  """
+              ),
+              //language=yaml
+              yaml(
+                """
+                  spring:
+                    data:
+                      redis:
+                        ssl:
+                          bundle: redis
+                    cassandra:
+                      ssl:
+                        bundle: cassandra
+                  """
+              )
+            )
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite-spring/issues/1027")
+    @Test
+    void redisSslBooleanStillRenamed() {
+        rewriteRun(
+          spec -> spec.recipeFromResource("/META-INF/rewrite/spring-boot-31-properties.yml", "org.openrewrite.java.spring.boot3.SpringBootProperties_3_1"),
+          mavenProject("project",
+            srcMainResources(
+              //language=properties
+              properties(
+                """
+                  spring.data.redis.ssl=true
+                  spring.cassandra.ssl=true
+                  """,
+                """
+                  spring.data.redis.ssl.enabled=true
+                  spring.cassandra.ssl.enabled=true
+                  """
+              ),
+              //language=yaml
+              yaml(
+                """
+                  spring:
+                    data:
+                      redis:
+                        ssl: true
+                    cassandra:
+                      ssl: true
+                  """,
+                """
+                  spring:
+                    data:
+                      redis:
+                        ssl.enabled: true
+                    cassandra:
+                      ssl.enabled: true
+                  """
+              )
+            )
+          )
+        );
+    }
+
     @Disabled
     @Issue("https://github.com/openrewrite/rewrite-spring/issues/436")
     @Test


### PR DESCRIPTION
## Summary

`SpringBootProperties_3_1` renames `spring.data.redis.ssl` → `spring.data.redis.ssl.enabled` (and the cassandra equivalents). The underlying YAML `ChangePropertyKey` matches on the `ssl` *node*, so when `ssl` is already a map with child keys (the 3.1+ shape), the whole subtree is relocated:

```yaml
spring:
  data:
    redis:
      ssl:
        bundle: redis
```

…becomes…

```yaml
spring:
  data:
    redis:
      ssl.enabled:
        bundle: redis
```

i.e. `spring.data.redis.ssl.bundle` silently turns into `spring.data.redis.ssl.enabled.bundle`.

Adding `except: [bundle]` to the three affected `ChangeSpringPropertyKey` entries tells the recipe to skip the rename whenever `ssl` has a `bundle` child, while still renaming the plain boolean `ssl: true` case. Same pattern is already used in `spring-boot-22-properties.yml`, `spring-boot-24-properties.yml`, and `spring-cloud-2025.yml`.

## Test plan

- [x] New `redisSslBundleNotMangled` test in `ChangeSpringPropertyKeyTest` confirms `spring.data.redis.ssl.bundle` and `spring.cassandra.ssl.bundle` are left untouched in both YAML and properties files.
- [x] New `redisSslBooleanStillRenamed` test confirms the original boolean → `.enabled` rename still works.
- [x] Full `ChangeSpringPropertyKeyTest` passes locally.

## Follow-up

While writing the test I noticed a separate quirk on the cross-tree rename `spring.data.cassandra.ssl` → `spring.cassandra.ssl.enabled`: with `except: [bundle]` set and a `bundle` child present, an empty top-level `cassandra.ssl.enabled:` node gets created. The same-parent renames covered here are correct; the cross-tree case looks like a pre-existing issue in the underlying `org.openrewrite.yaml.ChangePropertyKey` and probably deserves a separate fix in `openrewrite/rewrite`.

- Closes #1027