### PR TITLE
Bump Spring Kafka, Spring Integration, and dependency-management-plugin alongside Spring Framework 6

### DIFF
--- a/src/main/resources/META-INF/rewrite/spring-framework-60.yml
+++ b/src/main/resources/META-INF/rewrite/spring-framework-60.yml
@@ -30,7 +30,6 @@ recipeList:
       groupId: org.springframework
       artifactId: "*"
       newVersion: 6.0.x
-  # Companion libraries that must move in lockstep with Spring Framework 6
   - org.openrewrite.java.spring.kafka.UpgradeSpringKafka_3_0
   - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
       groupId: org.springframework.integration

--- a/src/main/resources/META-INF/rewrite/spring-framework-60.yml
+++ b/src/main/resources/META-INF/rewrite/spring-framework-60.yml
@@ -30,6 +30,19 @@ recipeList:
       groupId: org.springframework
       artifactId: "*"
       newVersion: 6.0.x
+  # Companion libraries that must move in lockstep with Spring Framework 6
+  - org.openrewrite.java.spring.kafka.UpgradeSpringKafka_3_0
+  - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
+      groupId: org.springframework.integration
+      artifactId: "*"
+      newVersion: 6.0.x
+  - org.openrewrite.gradle.plugins.UpgradePluginVersion:
+      pluginIdPattern: io.spring.dependency-management
+      newVersion: 1.1.x
+  - org.openrewrite.maven.UpgradePluginVersion:
+      groupId: io.spring.gradle
+      artifactId: dependency-management-plugin
+      newVersion: 1.1.x
   - org.openrewrite.java.spring.framework.MigrateSpringAssert
   - org.openrewrite.apache.httpclient5.UpgradeApacheHttpClient_5
   - org.openrewrite.java.spring.framework.HttpComponentsClientHttpRequestFactoryReadTimeout

--- a/src/test/java/org/openrewrite/java/spring/framework/UpgradeSpringFramework_6_0Test.java
+++ b/src/test/java/org/openrewrite/java/spring/framework/UpgradeSpringFramework_6_0Test.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.spring.framework;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.openrewrite.gradle.Assertions.buildGradle;
+import static org.openrewrite.gradle.toolingapi.Assertions.withToolingApi;
+import static org.openrewrite.maven.Assertions.pomXml;
+
+class UpgradeSpringFramework_6_0Test implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipeFromResources("org.openrewrite.java.spring.framework.UpgradeSpringFramework_6_0")
+          .beforeRecipe(withToolingApi());
+    }
+
+    @Test
+    void upgradesSpringKafka() {
+        rewriteRun(
+          //language=xml
+          pomXml(
+            """
+              <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>app</artifactId>
+                  <version>1.0.0</version>
+                  <dependencies>
+                      <dependency>
+                          <groupId>org.springframework.kafka</groupId>
+                          <artifactId>spring-kafka</artifactId>
+                          <version>2.9.11</version>
+                      </dependency>
+                  </dependencies>
+              </project>
+              """,
+            spec -> spec.after(actual ->
+              assertThat(actual).containsPattern("<version>3\\.0\\.\\d+</version>").actual())
+          )
+        );
+    }
+
+    @Test
+    void upgradesSpringIntegration() {
+        rewriteRun(
+          //language=xml
+          pomXml(
+            """
+              <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>app</artifactId>
+                  <version>1.0.0</version>
+                  <dependencies>
+                      <dependency>
+                          <groupId>org.springframework.integration</groupId>
+                          <artifactId>spring-integration-core</artifactId>
+                          <version>5.5.20</version>
+                      </dependency>
+                  </dependencies>
+              </project>
+              """,
+            spec -> spec.after(actual ->
+              assertThat(actual).containsPattern("<version>6\\.0\\.\\d+</version>").actual())
+          )
+        );
+    }
+
+    @Test
+    void upgradesDependencyManagementPluginInGradle() {
+        rewriteRun(
+          //language=groovy
+          buildGradle(
+            """
+              plugins {
+                  id 'java'
+                  id 'io.spring.dependency-management' version '1.0.6.RELEASE'
+              }
+              """,
+            spec -> spec.after(actual ->
+              assertThat(actual).containsPattern("'1\\.1\\.\\d+'").actual())
+          )
+        );
+    }
+}


### PR DESCRIPTION
## Summary

The Framework 6 upgrade recipe only moved the `org.springframework` artifacts, leaving companion libraries pinned to versions that still require Spring 5 (or pre-Gradle 9). This PR chains the existing `UpgradeSpringKafka_3_0` recipe and adds `UpgradeDependencyVersion` / `UpgradePluginVersion` entries for Spring Integration and `io.spring.dependency-management` so Framework 6 lands with consumers that can actually resolve at runtime.

| Dependency | Before | After |
|---|---|---|
| `org.springframework.kafka:spring-kafka` | left at `2.9.11` | `3.0.x` |
| `org.springframework.integration:*` | left at `4.x`/`5.x` | `6.0.x` |
| `io.spring.dependency-management` (Gradle plugin) | left at `1.0.6.RELEASE` | `1.1.x` |
| `io.spring.gradle:dependency-management-plugin` (Maven) | left at `1.0.6.RELEASE` | `1.1.x` |

- Reported in [moderneinc/customer-requests#2455](https://github.com/moderneinc/customer-requests/issues/2455).

## Test plan
- [x] Added `UpgradeSpringFramework_6_0Test` covering all three companion-library bumps (Maven `pom.xml` for kafka/integration, Gradle `build.gradle` for the dependency-management plugin)
- [x] `./gradlew test --tests org.openrewrite.java.spring.framework.UpgradeSpringFramework_6_0Test` passes