### PR TITLE
Apply ClientHttpResponse#getRawStatusCode() migration as of Spring Framework 6.0

### DIFF
--- a/src/main/resources/META-INF/rewrite/spring-framework-60.yml
+++ b/src/main/resources/META-INF/rewrite/spring-framework-60.yml
@@ -47,6 +47,7 @@ recipeList:
   - org.openrewrite.java.spring.framework.HttpComponentsClientHttpRequestFactoryReadTimeout
   - org.openrewrite.java.spring.framework.MigrateResponseEntityExceptionHandlerHttpStatusToHttpStatusCode
   - org.openrewrite.java.spring.framework.MigrateResponseStatusException
+  - org.openrewrite.java.spring.framework.MigrateClientHttpResponseGetRawStatusCodeMethod
   - org.openrewrite.java.spring.data.UpgradeSpringData_3_0
   - org.openrewrite.java.spring.data.JdbcTemplateQueryForLongMigration
 ---

--- a/src/main/resources/META-INF/rewrite/spring-framework-62.yml
+++ b/src/main/resources/META-INF/rewrite/spring-framework-62.yml
@@ -36,7 +36,6 @@ recipeList:
   - org.openrewrite.java.spring.framework.MigrateResourceHttpMessageWriterAddHeadersMethod
   - org.openrewrite.java.spring.framework.MigrateUriComponentsBuilderMethods
   - org.openrewrite.java.spring.framework.MigrateWebExchangeBindExceptionResolveErrorMethod
-  - org.openrewrite.java.spring.framework.MigrateClientHttpResponseGetRawStatusCodeMethod
   - org.openrewrite.java.spring.framework.HttpComponentsClientHttpRequestFactoryConnectTimeout
 
   - org.openrewrite.java.ReplaceConstantWithAnotherConstant:


### PR DESCRIPTION
`ClientHttpResponse#getRawStatusCode()` was deprecated and its sibling `getStatusCode()` changed its return type from `HttpStatus` to `HttpStatusCode` in Spring Framework **6.0**. The recipe that handles this, `MigrateClientHttpResponseGetRawStatusCodeMethod`, was only wired into `UpgradeSpringFramework_6_2`, so applications migrating to 6.0 (the version that actually introduced the change) did not get the fix.

This moves the recipe into `UpgradeSpringFramework_6_0`, alongside the related `MigrateResponseStatusException` migration. It is still applied for 6.1 and 6.2 since those chain through `UpgradeSpringFramework_6_0`, so the direct entry in `UpgradeSpringFramework_6_2` is removed to avoid duplication.

- Reported via customer feedback (moderneinc/customer-requests#2462).