### PR TITLE
Add recipe to migrate Tomcat LegacyCookieProcessor to Rfc6265CookieProcessor

### DIFF
--- a/src/main/resources/META-INF/rewrite/tomcat.yml
+++ b/src/main/resources/META-INF/rewrite/tomcat.yml
@@ -1,0 +1,34 @@
+#
+# Copyright 2026 the original author or authors.
+# <p>
+# Licensed under the Moderne Source Available License (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# <p>
+# https://docs.moderne.io/licensing/moderne-source-available-license
+# <p>
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.spring.boot3.UseRfc6265CookieProcessor
+displayName: Use `Rfc6265CookieProcessor` instead of `LegacyCookieProcessor`
+description: >-
+  Replace the legacy Tomcat `LegacyCookieProcessor` with the RFC 6265 compliant `Rfc6265CookieProcessor` in
+  Tomcat configuration files such as `context.xml` and `server.xml`. `Rfc6265CookieProcessor` is the default
+  cookie processor since Tomcat 8.5 and `LegacyCookieProcessor` is provided only for backwards compatibility.
+  Note that RFC 6265 parsing is stricter than the legacy behavior, so review applications that rely on legacy
+  cookie handling before applying this recipe.
+tags:
+  - tomcat
+recipeList:
+  - org.openrewrite.xml.ChangeTagAttribute:
+      elementName: CookieProcessor
+      attributeName: className
+      oldValue: org.apache.tomcat.util.http.LegacyCookieProcessor
+      newValue: org.apache.tomcat.util.http.Rfc6265CookieProcessor

--- a/src/test/java/org/openrewrite/java/spring/boot3/UseRfc6265CookieProcessorTest.java
+++ b/src/test/java/org/openrewrite/java/spring/boot3/UseRfc6265CookieProcessorTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.spring.boot3;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.xml.Assertions.xml;
+
+class UseRfc6265CookieProcessorTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipeFromResources("org.openrewrite.java.spring.boot3.UseRfc6265CookieProcessor");
+    }
+
+    @DocumentExample
+    @Test
+    void replaceLegacyCookieProcessorInContextXml() {
+        rewriteRun(
+          xml(
+            """
+              <?xml version="1.0" encoding="UTF-8"?>
+              <Context>
+                  <CookieProcessor className="org.apache.tomcat.util.http.LegacyCookieProcessor"/>
+              </Context>
+              """,
+            """
+              <?xml version="1.0" encoding="UTF-8"?>
+              <Context>
+                  <CookieProcessor className="org.apache.tomcat.util.http.Rfc6265CookieProcessor"/>
+              </Context>
+              """,
+            spec -> spec.path("src/main/webapp/META-INF/context.xml")
+          )
+        );
+    }
+
+    @Test
+    void leavesRfc6265CookieProcessorUnchanged() {
+        rewriteRun(
+          xml(
+            """
+              <?xml version="1.0" encoding="UTF-8"?>
+              <Context>
+                  <CookieProcessor className="org.apache.tomcat.util.http.Rfc6265CookieProcessor"/>
+              </Context>
+              """,
+            spec -> spec.path("src/main/webapp/META-INF/context.xml")
+          )
+        );
+    }
+
+    @Test
+    void leavesUnrelatedCookieProcessorClassUnchanged() {
+        rewriteRun(
+          xml(
+            """
+              <?xml version="1.0" encoding="UTF-8"?>
+              <Context>
+                  <CookieProcessor className="com.example.CustomCookieProcessor"/>
+              </Context>
+              """,
+            spec -> spec.path("src/main/webapp/META-INF/context.xml")
+          )
+        );
+    }
+}


### PR DESCRIPTION
Adds `org.openrewrite.java.spring.boot3.UseRfc6265CookieProcessor`, a declarative recipe that rewrites the `className` attribute of the Tomcat `<CookieProcessor>` element from `org.apache.tomcat.util.http.LegacyCookieProcessor` to `org.apache.tomcat.util.http.Rfc6265CookieProcessor` in Tomcat configuration files (e.g. `context.xml`, `server.xml`).

```xml
<Context>
    <CookieProcessor className="org.apache.tomcat.util.http.LegacyCookieProcessor"/>
</Context>
```
becomes
```xml
<Context>
    <CookieProcessor className="org.apache.tomcat.util.http.Rfc6265CookieProcessor"/>
</Context>
```

`Rfc6265CookieProcessor` has been the Tomcat default since 8.5; `LegacyCookieProcessor` is retained only for backwards compatibility. The recipe is intentionally **not** wired into any version upgrade because RFC 6265 parsing is stricter than the legacy behavior, so it is offered as an opt-in change. The `oldValue` guard ensures only the legacy class is rewritten, leaving custom or already-migrated cookie processors untouched (covered by tests).

- Reported via customer feedback (moderneinc/customer-requests#2462).