### PR TITLE
Support static imports in `MigrateUriComponentsBuilderMethods`

### DIFF
--- a/src/main/java/org/openrewrite/java/spring/framework/MigrateUriComponentsBuilderMethods.java
+++ b/src/main/java/org/openrewrite/java/spring/framework/MigrateUriComponentsBuilderMethods.java
@@ -52,6 +52,10 @@ public class MigrateUriComponentsBuilderMethods extends Recipe {
             public J visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
                 J.MethodInvocation mi = (J.MethodInvocation) super.visitMethodInvocation(method, ctx);
                 if (FROM_HTTP_URL.matches(mi)) {
+                    if (mi.getSelect() == null) {
+                        maybeRemoveImport(TARGET_CLASS + ".fromHttpUrl");
+                        maybeAddImport(TARGET_CLASS, "fromUriString", false);
+                    }
                     return mi.withName(mi.getName().withSimpleName("fromUriString"));
                 }
                 if (FROM_HTTP_REQUEST.matches(mi)) {

--- a/src/test/java/org/openrewrite/java/spring/framework/MigrateUriComponentsBuilderMethodsTest.java
+++ b/src/test/java/org/openrewrite/java/spring/framework/MigrateUriComponentsBuilderMethodsTest.java
@@ -106,6 +106,35 @@ class MigrateUriComponentsBuilderMethodsTest implements RewriteTest {
     }
 
     @Test
+    void migrateFromHttpUrlToFromUriStringStaticImported() {
+        rewriteRun(
+          // language=java
+          java(
+            """
+              import static org.springframework.web.util.UriComponentsBuilder.fromHttpUrl;
+
+              class A {
+                  void test() {
+                      String url = "https://example.com";
+                      fromHttpUrl(url).queryParam("foo", "bar");
+                  }
+              }
+              """,
+            """
+              import static org.springframework.web.util.UriComponentsBuilder.fromUriString;
+
+              class A {
+                  void test() {
+                      String url = "https://example.com";
+                      fromUriString(url).queryParam("foo", "bar");
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void migrateUriComponentsBuilderMethodsWhenInetSocketAddressIsNull() {
         rewriteRun(
           // language=java


### PR DESCRIPTION
- Fixes #1034

When `UriComponentsBuilder.fromHttpUrl` was statically imported, the recipe renamed the method invocation to `fromUriString` but left the now-invalid `import static ...fromHttpUrl;`, producing uncompilable code.

This updates the `fromHttpUrl` branch to also swap the static import when the invocation has no select (i.e. is statically imported).

Includes the test from the issue's attached patch.