### PR TITLE
Avoid uncompilable output when migrating `JobBuilderFactory`/`StepBuilderFactory`

### DIFF
--- a/src/main/java/org/openrewrite/java/spring/batch/MigrateJobBuilderFactory.java
+++ b/src/main/java/org/openrewrite/java/spring/batch/MigrateJobBuilderFactory.java
@@ -24,7 +24,9 @@ import org.openrewrite.Tree;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.internal.ListUtils;
 import org.openrewrite.java.*;
+import org.openrewrite.java.search.FindMethods;
 import org.openrewrite.java.search.UsesMethod;
+import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaType;
 import org.openrewrite.java.tree.Space;
@@ -32,11 +34,15 @@ import org.openrewrite.java.tree.Statement;
 import org.openrewrite.java.tree.TypeUtils;
 import org.openrewrite.marker.Markers;
 
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static java.util.Collections.emptyList;
 import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toSet;
 
 public class MigrateJobBuilderFactory extends Recipe {
     private static final MethodMatcher JOB_BUILDER_FACTORY = new MethodMatcher(
@@ -93,28 +99,45 @@ public class MigrateJobBuilderFactory extends Recipe {
     @RequiredArgsConstructor
     private static class RemoveJobBuilderFactoryVisitor extends JavaIsoVisitor<ExecutionContext> {
 
+        private static final String JOB_BUILDER_FACTORY_FQN =
+                "org.springframework.batch.core.configuration.annotation.JobBuilderFactory";
+
         private final J.ClassDeclaration scope;
 
         private final J.MethodDeclaration enclosingMethod;
 
+        // Set true before children are visited when the class has references to a
+        // JobBuilderFactory field that the visitor will not rewrite (getters/setters,
+        // helper methods). In that case we leave the field, constructor parameters,
+        // and constructor body assignments intact rather than producing broken code.
+        private boolean preserveField;
+
+        private Set<String> jobBuilderFactoryFieldNames = new HashSet<>();
+
         @Override
         public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration classDecl, ExecutionContext ctx) {
+            if (classDecl.equals(scope)) {
+                jobBuilderFactoryFieldNames = collectJobBuilderFactoryFieldNames(classDecl);
+                preserveField = !jobBuilderFactoryFieldNames.isEmpty() &&
+                        hasReferencesOutsideRewrittenMethods(classDecl, jobBuilderFactoryFieldNames);
+            }
+
             J.ClassDeclaration cd = super.visitClassDeclaration(classDecl, ctx);
 
-            if (!cd.equals(scope)) {
+            if (!cd.equals(scope) || preserveField) {
                 return cd;
             }
             cd = cd.withBody(cd.getBody().withStatements(ListUtils.map(cd.getBody().getStatements(), statement -> {
                 if (statement instanceof J.VariableDeclarations && ((J.VariableDeclarations) statement).getTypeExpression() != null) {
                     if (TypeUtils.isOfClassType(((J.VariableDeclarations) statement).getTypeExpression().getType(),
-                            "org.springframework.batch.core.configuration.annotation.JobBuilderFactory")) {
+                            JOB_BUILDER_FACTORY_FQN)) {
                         //noinspection DataFlowIssue
                         return null;
                     }
                 }
                 return statement;
             })));
-            maybeRemoveImport("org.springframework.batch.core.configuration.annotation.JobBuilderFactory");
+            maybeRemoveImport(JOB_BUILDER_FACTORY_FQN);
             return cd;
         }
 
@@ -125,6 +148,17 @@ public class MigrateJobBuilderFactory extends Recipe {
             if (!enclosingMethod.equals(md) && !md.isConstructor()) {
                 return md;
             }
+
+            // When the field is preserved (external references exist), leave constructors alone too —
+            // their parameter + body assignment form a wired-up trio with the field.
+            if (preserveField && md.isConstructor() && !enclosingMethod.equals(md)) {
+                return md;
+            }
+
+            Set<String> removedParamNames = md.getParameters().stream()
+                    .filter(this::isJobBuilderFactoryParameter)
+                    .map(p -> ((J.VariableDeclarations) p).getVariables().get(0).getSimpleName())
+                    .collect(toSet());
 
             List<Object> params = md.getParameters().stream()
                     .filter(j -> !(j instanceof J.Empty) && !isJobBuilderFactoryParameter(j))
@@ -151,7 +185,10 @@ public class MigrateJobBuilderFactory extends Recipe {
 
             md = paramsTemplate.apply(getCursor(), md.getCoordinates().replaceParameters(), params.toArray());
 
-            maybeRemoveImport("org.springframework.batch.core.configuration.annotation.JobBuilderFactory");
+            // Remove orphaned `this.<field> = <removedParam>;` assignments left behind by parameter removal.
+            md = removeOrphanedFieldAssignments(md, removedParamNames);
+
+            maybeRemoveImport(JOB_BUILDER_FACTORY_FQN);
             maybeRemoveImport("org.springframework.beans.factory.annotation.Autowired");
             maybeAddImport("org.springframework.batch.core.repository.JobRepository");
             return md;
@@ -166,7 +203,91 @@ public class MigrateJobBuilderFactory extends Recipe {
         private boolean isJobBuilderFactoryParameter(Statement statement) {
             return statement instanceof J.VariableDeclarations &&
                     TypeUtils.isOfClassType(((J.VariableDeclarations) statement).getType(),
-                            "org.springframework.batch.core.configuration.annotation.JobBuilderFactory");
+                            JOB_BUILDER_FACTORY_FQN);
+        }
+
+        private Set<String> collectJobBuilderFactoryFieldNames(J.ClassDeclaration cd) {
+            Set<String> names = new HashSet<>();
+            for (Statement stmt : cd.getBody().getStatements()) {
+                if (stmt instanceof J.VariableDeclarations) {
+                    J.VariableDeclarations vd = (J.VariableDeclarations) stmt;
+                    if (vd.getTypeExpression() != null &&
+                            TypeUtils.isOfClassType(vd.getTypeExpression().getType(), JOB_BUILDER_FACTORY_FQN)) {
+                        vd.getVariables().forEach(v -> names.add(v.getSimpleName()));
+                    }
+                }
+            }
+            return names;
+        }
+
+        private boolean hasReferencesOutsideRewrittenMethods(J.ClassDeclaration cd, Set<String> fieldNames) {
+            for (Statement stmt : cd.getBody().getStatements()) {
+                if (!(stmt instanceof J.MethodDeclaration)) {
+                    continue;
+                }
+                J.MethodDeclaration m = (J.MethodDeclaration) stmt;
+                // Constructors get rewritten by visitMethodDeclaration
+                if (m.isConstructor()) {
+                    continue;
+                }
+                // The enclosingMethod for this visitor instance gets rewritten
+                if (m.equals(enclosingMethod)) {
+                    continue;
+                }
+                // Other methods containing JobBuilderFactory.get(...) are handled by other visitor instances
+                if (!FindMethods.find(m, JOB_BUILDER_FACTORY_FQN + " get(java.lang.String)").isEmpty()) {
+                    continue;
+                }
+                if (containsFieldReference(m, fieldNames)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        private boolean containsFieldReference(J.MethodDeclaration m, Set<String> fieldNames) {
+            AtomicBoolean found = new AtomicBoolean();
+            JavaType scopeType = scope.getType();
+            new JavaIsoVisitor<AtomicBoolean>() {
+                @Override
+                public J.Identifier visitIdentifier(J.Identifier identifier, AtomicBoolean flag) {
+                    JavaType.Variable fieldType = identifier.getFieldType();
+                    // getFieldType() is non-null only for field references; local variables
+                    // and parameters that happen to share the field's simple name are skipped.
+                    if (fieldType != null &&
+                            fieldNames.contains(identifier.getSimpleName()) &&
+                            TypeUtils.isOfType(fieldType.getOwner(), scopeType)) {
+                        flag.set(true);
+                    }
+                    return super.visitIdentifier(identifier, flag);
+                }
+            }.visit(m, found);
+            return found.get();
+        }
+
+        private J.MethodDeclaration removeOrphanedFieldAssignments(J.MethodDeclaration md, Set<String> removedParamNames) {
+            if (md.getBody() == null || removedParamNames.isEmpty()) {
+                return md;
+            }
+            return md.withBody(md.getBody().withStatements(ListUtils.map(md.getBody().getStatements(), stmt -> {
+                J.Assignment assign = unwrapAssignment(stmt);
+                if (assign == null) {
+                    return stmt;
+                }
+                Expression rhs = assign.getAssignment();
+                if (rhs instanceof J.Identifier && removedParamNames.contains(((J.Identifier) rhs).getSimpleName())) {
+                    //noinspection DataFlowIssue
+                    return null;
+                }
+                return stmt;
+            })));
+        }
+
+        private J.Assignment unwrapAssignment(Statement stmt) {
+            if (stmt instanceof J.Assignment) {
+                return (J.Assignment) stmt;
+            }
+            return null;
         }
     }
 }

--- a/src/main/java/org/openrewrite/java/spring/batch/MigrateJobBuilderFactory.java
+++ b/src/main/java/org/openrewrite/java/spring/batch/MigrateJobBuilderFactory.java
@@ -246,9 +246,8 @@ public class MigrateJobBuilderFactory extends Recipe {
         }
 
         private boolean containsFieldReference(J.MethodDeclaration m, Set<String> fieldNames) {
-            AtomicBoolean found = new AtomicBoolean();
             JavaType scopeType = scope.getType();
-            new JavaIsoVisitor<AtomicBoolean>() {
+            return new JavaIsoVisitor<AtomicBoolean>() {
                 @Override
                 public J.Identifier visitIdentifier(J.Identifier identifier, AtomicBoolean flag) {
                     JavaType.Variable fieldType = identifier.getFieldType();
@@ -261,8 +260,7 @@ public class MigrateJobBuilderFactory extends Recipe {
                     }
                     return super.visitIdentifier(identifier, flag);
                 }
-            }.visit(m, found);
-            return found.get();
+            }.reduce(m, new AtomicBoolean()).get();
         }
 
         private J.MethodDeclaration removeOrphanedFieldAssignments(J.MethodDeclaration md, Set<String> removedParamNames) {
@@ -270,24 +268,15 @@ public class MigrateJobBuilderFactory extends Recipe {
                 return md;
             }
             return md.withBody(md.getBody().withStatements(ListUtils.map(md.getBody().getStatements(), stmt -> {
-                J.Assignment assign = unwrapAssignment(stmt);
-                if (assign == null) {
-                    return stmt;
-                }
-                Expression rhs = assign.getAssignment();
-                if (rhs instanceof J.Identifier && removedParamNames.contains(((J.Identifier) rhs).getSimpleName())) {
-                    //noinspection DataFlowIssue
-                    return null;
+                if (stmt instanceof J.Assignment) {
+                    Expression rhs = ((J.Assignment) stmt).getAssignment();
+                    if (rhs instanceof J.Identifier && removedParamNames.contains(((J.Identifier) rhs).getSimpleName())) {
+                        //noinspection DataFlowIssue
+                        return null;
+                    }
                 }
                 return stmt;
             })));
-        }
-
-        private J.Assignment unwrapAssignment(Statement stmt) {
-            if (stmt instanceof J.Assignment) {
-                return (J.Assignment) stmt;
-            }
-            return null;
         }
     }
 }

--- a/src/main/java/org/openrewrite/java/spring/batch/MigrateStepBuilderFactory.java
+++ b/src/main/java/org/openrewrite/java/spring/batch/MigrateStepBuilderFactory.java
@@ -22,15 +22,21 @@ import org.openrewrite.internal.ListUtils;
 import org.openrewrite.java.*;
 import org.openrewrite.java.search.FindMethods;
 import org.openrewrite.java.search.UsesMethod;
+import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaType;
 import org.openrewrite.java.tree.Space;
 import org.openrewrite.java.tree.Statement;
 import org.openrewrite.java.tree.TypeUtils;
 
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
+import static java.util.stream.Collectors.toSet;
 
 public class MigrateStepBuilderFactory extends Recipe {
 
@@ -55,18 +61,40 @@ public class MigrateStepBuilderFactory extends Recipe {
         );
     }
 
+    private static final String STEP_BUILDER_FACTORY_FQN =
+            "org.springframework.batch.core.configuration.annotation.StepBuilderFactory";
+
     private static class AddJobRepositoryVisitor extends JavaIsoVisitor<ExecutionContext> {
+
+        // Set true before children are visited when the enclosing class has references to a
+        // StepBuilderFactory field that the visitor will not rewrite (getters/setters, helper
+        // methods). In that case we leave the field, constructor parameters, and constructor
+        // body assignments intact rather than producing broken code.
+        private boolean preserveField;
+
+        private Set<String> stepBuilderFactoryFieldNames = new HashSet<>();
+
+        private @Nullable JavaType scopeType;
+
         @Override
         public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration classDeclaration, ExecutionContext ctx) {
+            boolean classHasGet = !FindMethods.find(classDeclaration, STEP_BUILDER_FACTORY_GET).isEmpty();
+            if (classHasGet) {
+                scopeType = classDeclaration.getType();
+                stepBuilderFactoryFieldNames = collectStepBuilderFactoryFieldNames(classDeclaration);
+                preserveField = !stepBuilderFactoryFieldNames.isEmpty() &&
+                        hasReferencesOutsideRewrittenMethods(classDeclaration, stepBuilderFactoryFieldNames);
+            }
+
             J.ClassDeclaration cd = super.visitClassDeclaration(classDeclaration, ctx);
 
             // Remove StepBuilderFactory field if StepBuilderFactory.get(..) is used further down
-            if (!FindMethods.find(classDeclaration, STEP_BUILDER_FACTORY_GET).isEmpty()) {
+            if (classHasGet && !preserveField) {
                 cd = cd.withBody(cd.getBody().withStatements(ListUtils.map(cd.getBody().getStatements(), statement -> {
                     if (statement instanceof J.VariableDeclarations &&
                             ((J.VariableDeclarations) statement).getTypeExpression() != null) {
                         if (TypeUtils.isOfClassType(((J.VariableDeclarations) statement).getTypeExpression().getType(),
-                                "org.springframework.batch.core.configuration.annotation.StepBuilderFactory")) {
+                                STEP_BUILDER_FACTORY_FQN)) {
                             return null;
                         }
                     }
@@ -79,13 +107,24 @@ public class MigrateStepBuilderFactory extends Recipe {
 
         @Override
         public J.@Nullable MethodDeclaration visitMethodDeclaration(J.MethodDeclaration md, ExecutionContext ctx) {
-            // Add JobRepository parameter to method if StepBuilderFactory.get(..) is used further down
-            if (!FindMethods.find(md, STEP_BUILDER_FACTORY_GET).isEmpty()) {
+            boolean bodyHasGet = !FindMethods.find(md, STEP_BUILDER_FACTORY_GET).isEmpty();
+            boolean isConstructorToRewrite = md.isConstructor() && !preserveField &&
+                    md.getParameters().stream().anyMatch(this::isStepBuilderFactoryParameter);
+
+            // Add JobRepository parameter to method if StepBuilderFactory.get(..) is used further down,
+            // or rewrite a constructor that takes StepBuilderFactory as a parameter (Defect 3).
+            if (bodyHasGet || isConstructorToRewrite) {
+                Set<String> removedParamNames = md.getParameters().stream()
+                        .filter(this::isStepBuilderFactoryParameter)
+                        .map(p -> ((J.VariableDeclarations) p).getVariables().get(0).getSimpleName())
+                        .collect(toSet());
+
                 List<Statement> params = ListUtils.filter(md.getParameters(), j -> !isStepBuilderFactoryParameter(j));
                 if (params.isEmpty() && md.isConstructor()) {
                     return null;
                 }
-                params = ListUtils.mapFirst(params, p -> p.withPrefix(md.getParameters().get(0).getPrefix().withComments(emptyList())));
+                Space firstParamPrefix = md.getParameters().get(0).getPrefix().withComments(emptyList());
+                params = ListUtils.mapFirst(params, p -> p.withPrefix(firstParamPrefix));
 
                 if (md.getParameters().stream().noneMatch(this::isJobRepositoryParameter) && !md.isConstructor()) {
                     maybeAddImport("org.springframework.batch.core.repository.JobRepository");
@@ -98,14 +137,29 @@ public class MigrateStepBuilderFactory extends Recipe {
                             .<J.MethodDeclaration>apply(getCursor(), md.getCoordinates().replaceParameters())
                             .getParameters().get(0).withPrefix(parametersEmpty ? Space.EMPTY : Space.SINGLE_SPACE);
                     if (parametersEmpty) {
-                        return md.withParameters(singletonList(vdd))
+                        md = md.withParameters(singletonList(vdd))
                                 .withMethodType(md.getMethodType()
                                         .withParameterTypes(singletonList(vdd.getType())));
+                    } else {
+                        md = md.withParameters(ListUtils.concat(params, vdd))
+                                .withMethodType(md.getMethodType()
+                                        .withParameterTypes(ListUtils.concat(md.getMethodType().getParameterTypes(), vdd.getType())));
                     }
-                    return md.withParameters(ListUtils.concat(params, vdd))
-                            .withMethodType(md.getMethodType()
-                                    .withParameterTypes(ListUtils.concat(md.getMethodType().getParameterTypes(), vdd.getType())));
+                } else if (md.isConstructor()) {
+                    // For constructors we drop the StepBuilderFactory parameter without adding JobRepository.
+                    md = md.withParameters(params);
+                    if (md.getMethodType() != null) {
+                        List<org.openrewrite.java.tree.JavaType> remainingTypes = md.getParameters().stream()
+                                .filter(p -> p instanceof J.VariableDeclarations)
+                                .map(p -> ((J.VariableDeclarations) p).getType())
+                                .collect(java.util.stream.Collectors.toList());
+                        md = md.withMethodType(md.getMethodType().withParameterTypes(remainingTypes));
+                    }
                 }
+
+                // Remove orphaned `this.<field> = <removedParam>;` body assignments left by parameter removal.
+                md = removeOrphanedFieldAssignments(md, removedParamNames);
+                return md;
             }
 
             return super.visitMethodDeclaration(md, ctx);
@@ -120,7 +174,75 @@ public class MigrateStepBuilderFactory extends Recipe {
         private boolean isStepBuilderFactoryParameter(Statement statement) {
             return statement instanceof J.VariableDeclarations &&
                     TypeUtils.isOfClassType(((J.VariableDeclarations) statement).getType(),
-                            "org.springframework.batch.core.configuration.annotation.StepBuilderFactory");
+                            STEP_BUILDER_FACTORY_FQN);
+        }
+
+        private Set<String> collectStepBuilderFactoryFieldNames(J.ClassDeclaration cd) {
+            Set<String> names = new HashSet<>();
+            for (Statement stmt : cd.getBody().getStatements()) {
+                if (stmt instanceof J.VariableDeclarations) {
+                    J.VariableDeclarations vd = (J.VariableDeclarations) stmt;
+                    if (vd.getTypeExpression() != null &&
+                            TypeUtils.isOfClassType(vd.getTypeExpression().getType(), STEP_BUILDER_FACTORY_FQN)) {
+                        vd.getVariables().forEach(v -> names.add(v.getSimpleName()));
+                    }
+                }
+            }
+            return names;
+        }
+
+        private boolean hasReferencesOutsideRewrittenMethods(J.ClassDeclaration cd, Set<String> fieldNames) {
+            for (Statement stmt : cd.getBody().getStatements()) {
+                if (!(stmt instanceof J.MethodDeclaration)) {
+                    continue;
+                }
+                J.MethodDeclaration m = (J.MethodDeclaration) stmt;
+                if (m.isConstructor()) {
+                    continue;
+                }
+                if (!FindMethods.find(m, STEP_BUILDER_FACTORY_GET).isEmpty()) {
+                    continue;
+                }
+                if (containsFieldReference(m, fieldNames)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        private boolean containsFieldReference(J.MethodDeclaration m, Set<String> fieldNames) {
+            AtomicBoolean found = new AtomicBoolean();
+            JavaType currentScopeType = scopeType;
+            new JavaIsoVisitor<AtomicBoolean>() {
+                @Override
+                public J.Identifier visitIdentifier(J.Identifier identifier, AtomicBoolean flag) {
+                    JavaType.Variable fieldType = identifier.getFieldType();
+                    // getFieldType() is non-null only for field references; local variables
+                    // and parameters that happen to share the field's simple name are skipped.
+                    if (fieldType != null &&
+                            fieldNames.contains(identifier.getSimpleName()) &&
+                            TypeUtils.isOfType(fieldType.getOwner(), currentScopeType)) {
+                        flag.set(true);
+                    }
+                    return super.visitIdentifier(identifier, flag);
+                }
+            }.visit(m, found);
+            return found.get();
+        }
+
+        private J.MethodDeclaration removeOrphanedFieldAssignments(J.MethodDeclaration md, Set<String> removedParamNames) {
+            if (md.getBody() == null || removedParamNames.isEmpty()) {
+                return md;
+            }
+            return md.withBody(md.getBody().withStatements(ListUtils.map(md.getBody().getStatements(), stmt -> {
+                if (stmt instanceof J.Assignment) {
+                    Expression rhs = ((J.Assignment) stmt).getAssignment();
+                    if (rhs instanceof J.Identifier && removedParamNames.contains(((J.Identifier) rhs).getSimpleName())) {
+                        return null;
+                    }
+                }
+                return stmt;
+            })));
         }
     }
 

--- a/src/main/java/org/openrewrite/java/spring/batch/MigrateStepBuilderFactory.java
+++ b/src/main/java/org/openrewrite/java/spring/batch/MigrateStepBuilderFactory.java
@@ -211,9 +211,8 @@ public class MigrateStepBuilderFactory extends Recipe {
         }
 
         private boolean containsFieldReference(J.MethodDeclaration m, Set<String> fieldNames) {
-            AtomicBoolean found = new AtomicBoolean();
             JavaType currentScopeType = scopeType;
-            new JavaIsoVisitor<AtomicBoolean>() {
+            return new JavaIsoVisitor<AtomicBoolean>() {
                 @Override
                 public J.Identifier visitIdentifier(J.Identifier identifier, AtomicBoolean flag) {
                     JavaType.Variable fieldType = identifier.getFieldType();
@@ -226,8 +225,7 @@ public class MigrateStepBuilderFactory extends Recipe {
                     }
                     return super.visitIdentifier(identifier, flag);
                 }
-            }.visit(m, found);
-            return found.get();
+            }.reduce(m, new AtomicBoolean()).get();
         }
 
         private J.MethodDeclaration removeOrphanedFieldAssignments(J.MethodDeclaration md, Set<String> removedParamNames) {

--- a/src/test/java/org/openrewrite/java/spring/batch/MigrateJobBuilderFactoryTest.java
+++ b/src/test/java/org/openrewrite/java/spring/batch/MigrateJobBuilderFactoryTest.java
@@ -163,6 +163,186 @@ class MigrateJobBuilderFactoryTest implements RewriteTest {
     }
 
     @Test
+    void preserveFieldWhenGettersOrSettersReferenceIt() {
+        // language=java
+        rewriteRun(
+          java(
+            """
+              import org.springframework.batch.core.Job;
+              import org.springframework.batch.core.Step;
+              import org.springframework.batch.core.configuration.annotation.JobBuilderFactory;
+              import org.springframework.context.annotation.Bean;
+
+              class MyJobConfig {
+
+                  private JobBuilderFactory jobBuilderFactory;
+
+                  public MyJobConfig(JobBuilderFactory jobBuilderFactory, String other) {
+                      this.jobBuilderFactory = jobBuilderFactory;
+                  }
+
+                  public JobBuilderFactory getJobBuilderFactory() {
+                      return jobBuilderFactory;
+                  }
+
+                  public void setJobBuilderFactory(JobBuilderFactory jobBuilderFactory) {
+                      this.jobBuilderFactory = jobBuilderFactory;
+                  }
+
+                  @Bean
+                  Job myJob(Step step) {
+                      return this.jobBuilderFactory.get("myJob")
+                          .start(step)
+                          .build();
+                  }
+              }
+              """,
+            """
+              import org.springframework.batch.core.Job;
+              import org.springframework.batch.core.Step;
+              import org.springframework.batch.core.configuration.annotation.JobBuilderFactory;
+              import org.springframework.batch.core.job.builder.JobBuilder;
+              import org.springframework.batch.core.repository.JobRepository;
+              import org.springframework.context.annotation.Bean;
+
+              class MyJobConfig {
+
+                  private JobBuilderFactory jobBuilderFactory;
+
+                  public MyJobConfig(JobBuilderFactory jobBuilderFactory, String other) {
+                      this.jobBuilderFactory = jobBuilderFactory;
+                  }
+
+                  public JobBuilderFactory getJobBuilderFactory() {
+                      return jobBuilderFactory;
+                  }
+
+                  public void setJobBuilderFactory(JobBuilderFactory jobBuilderFactory) {
+                      this.jobBuilderFactory = jobBuilderFactory;
+                  }
+
+                  @Bean
+                  Job myJob(Step step, JobRepository jobRepository) {
+                      return new JobBuilder("myJob", jobRepository)
+                          .start(step)
+                          .build();
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void cleanUpConstructorBodyWhenParameterRemoved() {
+        // language=java
+        rewriteRun(
+          java(
+            """
+              import org.springframework.batch.core.Job;
+              import org.springframework.batch.core.Step;
+              import org.springframework.batch.core.configuration.annotation.JobBuilderFactory;
+              import org.springframework.context.annotation.Bean;
+
+              class MyJobConfig {
+
+                  private JobBuilderFactory jobBuilderFactory;
+                  private String other;
+
+                  public MyJobConfig(JobBuilderFactory jobBuilderFactory, String other) {
+                      this.jobBuilderFactory = jobBuilderFactory;
+                      this.other = other;
+                  }
+
+                  @Bean
+                  Job myJob(Step step) {
+                      return this.jobBuilderFactory.get("myJob")
+                          .start(step)
+                          .build();
+                  }
+              }
+              """,
+            """
+              import org.springframework.batch.core.Job;
+              import org.springframework.batch.core.Step;
+              import org.springframework.batch.core.job.builder.JobBuilder;
+              import org.springframework.batch.core.repository.JobRepository;
+              import org.springframework.context.annotation.Bean;
+
+              class MyJobConfig {
+                  private String other;
+
+                  public MyJobConfig(String other) {
+                      this.other = other;
+                  }
+
+                  @Bean
+                  Job myJob(Step step, JobRepository jobRepository) {
+                      return new JobBuilder("myJob", jobRepository)
+                          .start(step)
+                          .build();
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void localVariableShadowingFieldNameDoesNotPreserveField() {
+        // language=java
+        rewriteRun(
+          java(
+            """
+              import org.springframework.batch.core.Job;
+              import org.springframework.batch.core.Step;
+              import org.springframework.batch.core.configuration.annotation.JobBuilderFactory;
+              import org.springframework.context.annotation.Bean;
+
+              class MyJobConfig {
+
+                  private JobBuilderFactory jobBuilderFactory;
+
+                  void unrelatedHelper() {
+                      String jobBuilderFactory = "not the field";
+                      System.out.println(jobBuilderFactory);
+                  }
+
+                  @Bean
+                  Job myJob(Step step) {
+                      return this.jobBuilderFactory.get("myJob")
+                          .start(step)
+                          .build();
+                  }
+              }
+              """,
+            """
+              import org.springframework.batch.core.Job;
+              import org.springframework.batch.core.Step;
+              import org.springframework.batch.core.job.builder.JobBuilder;
+              import org.springframework.batch.core.repository.JobRepository;
+              import org.springframework.context.annotation.Bean;
+
+              class MyJobConfig {
+
+                  void unrelatedHelper() {
+                      String jobBuilderFactory = "not the field";
+                      System.out.println(jobBuilderFactory);
+                  }
+
+                  @Bean
+                  Job myJob(Step step, JobRepository jobRepository) {
+                      return new JobBuilder("myJob", jobRepository)
+                          .start(step)
+                          .build();
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void replaceJobBuilderFactoryInsideConstructor() {
         // language=java
         rewriteRun(

--- a/src/test/java/org/openrewrite/java/spring/batch/MigrateStepBuilderFactoryTest.java
+++ b/src/test/java/org/openrewrite/java/spring/batch/MigrateStepBuilderFactoryTest.java
@@ -127,6 +127,132 @@ class MigrateStepBuilderFactoryTest implements RewriteTest {
     }
 
     @Test
+    void removeStepBuilderFactoryConstructorParameterAndBodyAssignment() {
+        // language=java
+        rewriteRun(
+          java(
+            """
+              import org.springframework.batch.core.Step;
+              import org.springframework.batch.core.configuration.annotation.StepBuilderFactory;
+              import org.springframework.batch.core.step.tasklet.Tasklet;
+              import org.springframework.context.annotation.Bean;
+
+              class MyJobConfig {
+
+                  private StepBuilderFactory stepBuilderFactory;
+                  private String other;
+
+                  public MyJobConfig(StepBuilderFactory stepBuilderFactory, String other) {
+                      this.stepBuilderFactory = stepBuilderFactory;
+                      this.other = other;
+                  }
+
+                  @Bean
+                  Step myStep(Tasklet myTasklet) {
+                      return this.stepBuilderFactory.get("myStep")
+                              .tasklet(myTasklet)
+                              .build();
+                  }
+              }
+              """,
+            """
+              import org.springframework.batch.core.Step;
+              import org.springframework.batch.core.repository.JobRepository;
+              import org.springframework.batch.core.step.builder.StepBuilder;
+              import org.springframework.batch.core.step.tasklet.Tasklet;
+              import org.springframework.context.annotation.Bean;
+
+              class MyJobConfig {
+                  private String other;
+
+                  public MyJobConfig(String other) {
+                      this.other = other;
+                  }
+
+                  @Bean
+                  Step myStep(Tasklet myTasklet, JobRepository jobRepository) {
+                      return new StepBuilder("myStep", jobRepository)
+                              .tasklet(myTasklet)
+                              .build();
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void preserveStepBuilderFactoryFieldWhenGettersOrSettersReferenceIt() {
+        // language=java
+        rewriteRun(
+          java(
+            """
+              import org.springframework.batch.core.Step;
+              import org.springframework.batch.core.configuration.annotation.StepBuilderFactory;
+              import org.springframework.batch.core.step.tasklet.Tasklet;
+              import org.springframework.context.annotation.Bean;
+
+              class MyJobConfig {
+
+                  private StepBuilderFactory stepBuilderFactory;
+
+                  public MyJobConfig(StepBuilderFactory stepBuilderFactory, String other) {
+                      this.stepBuilderFactory = stepBuilderFactory;
+                  }
+
+                  public StepBuilderFactory getStepBuilderFactory() {
+                      return stepBuilderFactory;
+                  }
+
+                  public void setStepBuilderFactory(StepBuilderFactory stepBuilderFactory) {
+                      this.stepBuilderFactory = stepBuilderFactory;
+                  }
+
+                  @Bean
+                  Step myStep(Tasklet myTasklet) {
+                      return this.stepBuilderFactory.get("myStep")
+                              .tasklet(myTasklet)
+                              .build();
+                  }
+              }
+              """,
+            """
+              import org.springframework.batch.core.Step;
+              import org.springframework.batch.core.configuration.annotation.StepBuilderFactory;
+              import org.springframework.batch.core.repository.JobRepository;
+              import org.springframework.batch.core.step.builder.StepBuilder;
+              import org.springframework.batch.core.step.tasklet.Tasklet;
+              import org.springframework.context.annotation.Bean;
+
+              class MyJobConfig {
+
+                  private StepBuilderFactory stepBuilderFactory;
+
+                  public MyJobConfig(StepBuilderFactory stepBuilderFactory, String other) {
+                      this.stepBuilderFactory = stepBuilderFactory;
+                  }
+
+                  public StepBuilderFactory getStepBuilderFactory() {
+                      return stepBuilderFactory;
+                  }
+
+                  public void setStepBuilderFactory(StepBuilderFactory stepBuilderFactory) {
+                      this.stepBuilderFactory = stepBuilderFactory;
+                  }
+
+                  @Bean
+                  Step myStep(Tasklet myTasklet, JobRepository jobRepository) {
+                      return new StepBuilder("myStep", jobRepository)
+                              .tasklet(myTasklet)
+                              .build();
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void replaceStepBuilderFactoryWithChunk() {
         // language=java
         rewriteRun(


### PR DESCRIPTION
## Problem

When a class injects `JobBuilderFactory` or `StepBuilderFactory` via a multi-arg constructor, or exposes the factory through accessor methods, the current recipes produce uncompilable code:

- The field is deleted while getters, setters, and helper methods still reference it.
- `MigrateJobBuilderFactory` already has a constructor carve-out that drops the `JobBuilderFactory` parameter, but the matching `this.<field> = <param>;` body assignment is left behind — orphaning both sides after field deletion.
- `MigrateStepBuilderFactory` has no constructor carve-out, so the `StepBuilderFactory` parameter survives even when the rest of the file has been migrated, leaving a reference to a class that no longer exists in Spring Batch 5.

- This affects classes that follow the standard Spring constructor-injection pattern — exactly the shape called out in #788 and #789.

## Changes

**Field deletion is now usage-aware (both recipes).** Before deleting a `JobBuilderFactory`/`StepBuilderFactory` field, each visitor scans the class for type-aware references to the field outside the methods it will rewrite (constructors and methods containing `.get(...)`). The check uses `J.Identifier.getFieldType()` and confirms the declaring type matches the enclosing class, so local variables and parameters that happen to share the field's simple name are not false positives. If outside references exist (getters, setters, helper methods), the field is preserved **and** constructor parameter removal is skipped — the field, parameter, and body assignment remain wired up for the developer to clean up.

**Constructor body cleanup moves in lockstep with parameter removal (both recipes).** When a `JobBuilderFactory`/`StepBuilderFactory` parameter is dropped from a method declaration, any matching `this.<field> = <removedParam>;` body assignment is removed rather than being left referencing a parameter that no longer exists.

**`MigrateStepBuilderFactory` gets a constructor carve-out.** `AddJobRepositoryVisitor.visitMethodDeclaration` now rewrites constructors that take a `StepBuilderFactory` parameter, mirroring the existing behavior in `MigrateJobBuilderFactory`. Gated by the field-preservation guard above.

## Tests

Five new tests across `MigrateJobBuilderFactoryTest` and `MigrateStepBuilderFactoryTest`:

- Field preserved when getters/setters reference it; the `.get(...)` chain still rewrites.
- Constructor body assignment removed when its parameter is removed (no accessors present).
- `StepBuilderFactory` constructor parameter removed and body assignment cleaned up.
- `StepBuilderFactory` field preserved when accessor methods reference it.
- Local variable shadowing the field's simple name does **not** trigger preservation — the tightened type-aware check ignores it.

- Closes #788
- Closes #789