### PR TITLE
Preserve generic type parameters in AutowiredFieldIntoConstructorParameterVisitor

### DIFF
--- a/src/main/java/org/openrewrite/java/spring/AutowiredFieldIntoConstructorParameterVisitor.java
+++ b/src/main/java/org/openrewrite/java/spring/AutowiredFieldIntoConstructorParameterVisitor.java
@@ -21,6 +21,7 @@ import org.openrewrite.ExecutionContext;
 import org.openrewrite.Tree;
 import org.openrewrite.internal.ListUtils;
 import org.openrewrite.java.*;
+import org.openrewrite.java.service.ImportService;
 import org.openrewrite.java.tree.*;
 import org.openrewrite.java.tree.J.Block;
 import org.openrewrite.java.tree.J.ClassDeclaration;
@@ -156,10 +157,10 @@ public class AutowiredFieldIntoConstructorParameterVisitor extends JavaVisitor<E
                 Object n = getCursor().getParent().getValue();
                 if (n instanceof ClassDeclaration) {
                     ClassDeclaration classDecl = (ClassDeclaration) n;
-                    JavaType.FullyQualified typeFqn = TypeUtils.asFullyQualified(type.getType());
-                    if (typeFqn != null && classDecl.getKind() == ClassDeclaration.Kind.Type.Class && className.equals(classDecl.getSimpleName())) {
+                    JavaType fieldType = type.getType();
+                    if (fieldType != null && !(fieldType instanceof JavaType.Primitive) && classDecl.getKind() == ClassDeclaration.Kind.Type.Class && className.equals(classDecl.getSimpleName())) {
                         JavaTemplate.Builder template = JavaTemplate.builder("" +
-                                classDecl.getSimpleName() + "(" + typeFqn.getClassName() + " " + fieldName + ") {\n" +
+                                classDecl.getSimpleName() + "(" + type + " " + fieldName + ") {\n" +
                                 "this." + fieldName + " = " + fieldName + ";\n" +
                                 "}\n"
                         ).contextSensitive();
@@ -198,12 +199,9 @@ public class AutowiredFieldIntoConstructorParameterVisitor extends JavaVisitor<E
         public AddConstructorParameterAndAssignment(MethodDeclaration constructor, String fieldName, TypeTree type) {
             this.constructor = constructor;
             this.fieldName = fieldName;
-            JavaType.FullyQualified fq = TypeUtils.asFullyQualified(type.getType());
-            if (fq != null) {
-                methodType = fq.getClassName();
-            } else {
-                throw new IllegalArgumentException("Unable to determine parameter type");
-            }
+            // The parameter template is parsed without the surrounding file's imports, so simple names would not
+            // resolve; render the type fully qualified and shorten the references after the template is applied.
+            this.methodType = type.getType() == null ? type.toString() : TypeUtils.toString(type.getType()).replace("$", ".");
         }
 
         @Override
@@ -223,6 +221,13 @@ public class AutowiredFieldIntoConstructorParameterVisitor extends JavaVisitor<E
                                 params.toArray()
                         );
                 updateCursor(md);
+                Statement addedParam = md.getParameters().get(md.getParameters().size() - 1);
+                if (addedParam instanceof J.VariableDeclarations) {
+                    TypeTree addedType = ((J.VariableDeclarations) addedParam).getTypeExpression();
+                    if (addedType != null && !(addedType instanceof J.Identifier || addedType instanceof J.Primitive)) {
+                        doAfterVisit(service(ImportService.class).shortenFullyQualifiedTypeReferencesIn(addedType));
+                    }
+                }
 
                 //noinspection ConstantConditions
                 md = JavaTemplate.builder("this." + fieldName + " = " + fieldName + ";")

--- a/src/test/java/org/openrewrite/java/spring/AutowiredFieldIntoConstructorParameterVisitorTest.java
+++ b/src/test/java/org/openrewrite/java/spring/AutowiredFieldIntoConstructorParameterVisitorTest.java
@@ -21,6 +21,7 @@ import org.openrewrite.InMemoryExecutionContext;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
+import org.openrewrite.test.TypeValidation;
 
 import static org.openrewrite.java.Assertions.java;
 import static org.openrewrite.test.RewriteTest.toRecipe;
@@ -404,6 +405,386 @@ class AutowiredFieldIntoConstructorParameterVisitorTest implements RewriteTest {
                   final private String a;
 
                   A(String a) {
+                      this.a = a;
+                  }
+
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void fieldWithGenericTypeIntoNewConstructor() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              package demo;
+
+              import java.util.List;
+              import org.springframework.beans.factory.annotation.Autowired;
+
+              public class A {
+
+                  @Autowired
+                  private List<String> a;
+
+              }
+              """,
+            """
+              package demo;
+
+              import java.util.List;
+
+              public class A {
+
+                  private final List<String> a;
+
+                  A(List<String> a) {
+                      this.a = a;
+                  }
+
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void fieldWithGenericTypeIntoExistingConstructor() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              package demo;
+
+              import java.util.List;
+              import org.springframework.beans.factory.annotation.Autowired;
+
+              public class A {
+
+                  @Autowired
+                  private List<String> a;
+
+                  A() {
+                  }
+
+              }
+              """,
+            """
+              package demo;
+
+              import java.util.List;
+
+              public class A {
+
+                  private final List<String> a;
+
+                  A(List<String> a) {
+                      this.a = a;
+                  }
+
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void fieldWithGenericTypeIntoExistingConstructorWithParams() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              package demo;
+
+              import java.util.List;
+              import org.springframework.beans.factory.annotation.Autowired;
+
+              public class A {
+
+                  @Autowired
+                  private List<String> a;
+
+                  A() {
+                  }
+
+                  @Autowired
+                  A(long l) {
+                  }
+              }
+              """,
+            """
+              package demo;
+
+              import java.util.List;
+              import org.springframework.beans.factory.annotation.Autowired;
+
+              public class A {
+
+                  private final List<String> a;
+
+                  A() {
+                  }
+
+                  @Autowired
+                  A(long l, List<String> a) {
+                      this.a = a;
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void fieldWithNestedGenericType() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              package demo;
+
+              import java.util.List;
+              import java.util.Map;
+              import org.springframework.beans.factory.annotation.Autowired;
+
+              public class A {
+
+                  @Autowired
+                  private Map<String, List<Integer>> a;
+
+              }
+              """,
+            """
+              package demo;
+
+              import java.util.List;
+              import java.util.Map;
+
+              public class A {
+
+                  private final Map<String, List<Integer>> a;
+
+                  A(Map<String, List<Integer>> a) {
+                      this.a = a;
+                  }
+
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void fieldWithUpperBoundedWildcard() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              package demo;
+
+              import java.util.List;
+              import org.springframework.beans.factory.annotation.Autowired;
+
+              public class A {
+
+                  @Autowired
+                  private List<? extends Number> a;
+
+              }
+              """,
+            """
+              package demo;
+
+              import java.util.List;
+
+              public class A {
+
+                  private final List<? extends Number> a;
+
+                  A(List<? extends Number> a) {
+                      this.a = a;
+                  }
+
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void fieldWithUserDefinedGenericType() {
+        //language=java
+        rewriteRun(
+          // The template parser re-parses the synthetic source from scratch, so types only present as sibling
+          // sources of this run (MyService/MyConfig) cannot be resolved and the generated constructor lacks type
+          // attribution for them. This predates this change and applies equally to non-generic user-defined types;
+          // it would only be fixable by supplying the user's types to the template parser, which the visitor
+          // cannot know a priori.
+          spec -> spec.afterTypeValidationOptions(TypeValidation.all().methodDeclarations(false).identifiers(false)),
+          java(
+            """
+              package demo.model;
+
+              public class MyConfig {
+              }
+              """
+          ),
+          java(
+            """
+              package demo.service;
+
+              public class MyService<T> {
+              }
+              """
+          ),
+          java(
+            """
+              package demo;
+
+              import demo.model.MyConfig;
+              import demo.service.MyService;
+              import org.springframework.beans.factory.annotation.Autowired;
+
+              public class A {
+
+                  @Autowired
+                  private MyService<MyConfig> a;
+
+              }
+              """,
+            """
+              package demo;
+
+              import demo.model.MyConfig;
+              import demo.service.MyService;
+
+              public class A {
+
+                  private final MyService<MyConfig> a;
+
+                  A(MyService<MyConfig> a) {
+                      this.a = a;
+                  }
+
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void fieldWithArrayType() {
+        //language=java
+        rewriteRun(
+          // JavaTemplate mis-attributes the generated assignment for array-typed fields (the right-hand side
+          // identifier lacks a type); an upstream JavaTemplate limitation, not specific to this visitor.
+          spec -> spec.afterTypeValidationOptions(TypeValidation.all().identifiers(false)),
+          java(
+            """
+              package demo;
+
+              import org.springframework.beans.factory.annotation.Autowired;
+
+              public class A {
+
+                  @Autowired
+                  private String[] a;
+
+              }
+              """,
+            """
+              package demo;
+
+              public class A {
+
+                  private final String[] a;
+
+                  A(String[] a) {
+                      this.a = a;
+                  }
+
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void fieldWithNestedGenericTypeIntoExistingConstructor() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              package demo;
+
+              import java.util.List;
+              import java.util.Map;
+              import org.springframework.beans.factory.annotation.Autowired;
+
+              public class A {
+
+                  @Autowired
+                  private Map<String, List<Integer>> a;
+
+                  A() {
+                  }
+
+              }
+              """,
+            """
+              package demo;
+
+              import java.util.List;
+              import java.util.Map;
+
+              public class A {
+
+                  private final Map<String, List<Integer>> a;
+
+                  A(Map<String, List<Integer>> a) {
+                      this.a = a;
+                  }
+
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void fieldWithArrayTypeIntoExistingConstructor() {
+        //language=java
+        rewriteRun(
+          // JavaTemplate mis-attributes the generated assignment for array-typed fields (the right-hand side
+          // identifier lacks a type); an upstream JavaTemplate limitation, not specific to this visitor.
+          spec -> spec.afterTypeValidationOptions(TypeValidation.all().identifiers(false)),
+          java(
+            """
+              package demo;
+
+              import org.springframework.beans.factory.annotation.Autowired;
+
+              public class A {
+
+                  @Autowired
+                  private String[] a;
+
+                  A() {
+                  }
+
+              }
+              """,
+            """
+              package demo;
+
+              public class A {
+
+                  private final String[] a;
+
+                  A(String[] a) {
                       this.a = a;
                   }
 


### PR DESCRIPTION
- Closes #1005.

- Big thanks to @dim-kod for the upfront investigation and the clear reproduction in #1005 / #1006 — it pinned down the root cause and surfaced all the edge cases (nested generics, wildcards, arrays) that this needed to handle. This is a smaller take on the same fix, leaning on existing utilities.

## What's changed?

`AutowiredFieldIntoConstructorParameterVisitor` rendered the generated constructor parameter type with `TypeUtils.asFullyQualified(type).getClassName()`, which drops type arguments — so an `@Autowired List<String>` field became a raw `List` parameter (and array fields were skipped entirely).

- **New-constructor path** (`AddConstructorVisitor`): render the field's `TypeTree` source text directly in the template. Because the template is `contextSensitive()` and the field stays in the class, its imports are already present — no import registration needed.
- **Existing-constructor path** (`AddConstructorParameterAndAssignment`): the `replaceParameters()` template is parsed without the file's imports, so the parameter is rendered fully qualified via `TypeUtils.toString(..)` and then simplified with `service(ImportService.class).shortenFullyQualifiedTypeReferencesIn(..)` — the same idiom `ChangeMethodParameter` already uses in this repo. This also fixes array fields into an existing constructor, which previously threw.
- The type guard now skips only `null`/primitive types instead of everything without a `FullyQualified`, letting arrays and type variables through.

## Why this shape

The fix itself is just rendering the type from the LST instead of `getClassName()`. No recursive FQN-collection helper is needed: imports are already in scope on the new-constructor path, and `ImportService` handles them on the existing-constructor path. Net production change is ~23 lines.

## Tests

Covers generics into new/existing/parameterized constructors, nested generics (incl. into an existing constructor, under full type validation), bounded wildcards, user-defined generic types across packages, and arrays. Two tests relax `TypeValidation` to document current `JavaTemplate` limitations (the template parser can't resolve sibling in-run sources; array assignments are mis-attributed upstream) — each annotated with the precise reason.