### PR TITLE
Migrate `CompositeHealth`/`HealthComponent` to Spring Boot 4 descriptor types

### DIFF
--- a/src/main/resources/META-INF/rewrite/spring-boot-40-modular-starters.yml
+++ b/src/main/resources/META-INF/rewrite/spring-boot-40-modular-starters.yml
@@ -395,6 +395,12 @@ recipeList:
       oldFullyQualifiedTypeName: org.springframework.boot.actuate.health.AdditionalHealthEndpointPath
       newFullyQualifiedTypeName: org.springframework.boot.health.actuate.endpoint.AdditionalHealthEndpointPath
   - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.springframework.boot.actuate.health.CompositeHealth
+      newFullyQualifiedTypeName: org.springframework.boot.health.actuate.endpoint.CompositeHealthDescriptor
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.springframework.boot.actuate.health.HealthComponent
+      newFullyQualifiedTypeName: org.springframework.boot.health.actuate.endpoint.HealthDescriptor
+  - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: org.springframework.boot.actuate.health.HealthEndpoint
       newFullyQualifiedTypeName: org.springframework.boot.health.actuate.endpoint.HealthEndpoint
   - org.openrewrite.java.ChangeType:

--- a/src/test/java/org/openrewrite/java/spring/boot4/MigrateToModularStartersTest.java
+++ b/src/test/java/org/openrewrite/java/spring/boot4/MigrateToModularStartersTest.java
@@ -437,6 +437,58 @@ class MigrateToModularStartersTest implements RewriteTest {
         }
 
         @Test
+        void migrateCompositeHealthAndHealthComponentToDescriptors() {
+            rewriteRun(
+              spec -> spec.typeValidationOptions(TypeValidation.none()),
+              //language=java
+              java(
+                """
+                  import org.springframework.boot.actuate.health.CompositeHealth;
+                  import org.springframework.boot.actuate.health.HealthComponent;
+                  import org.springframework.boot.actuate.health.HealthEndpoint;
+
+                  import java.util.HashMap;
+                  import java.util.Map;
+
+                  class HealthController {
+                      HealthEndpoint endpoint;
+
+                      Map<String, Object> health() {
+                          HealthComponent health = endpoint.health();
+                          Map<String, Object> body = new HashMap<>();
+                          if (health instanceof CompositeHealth composite) {
+                              body.put("components", composite.getComponents());
+                          }
+                          return body;
+                      }
+                  }
+                  """,
+                """
+                  import org.springframework.boot.health.actuate.endpoint.CompositeHealthDescriptor;
+                  import org.springframework.boot.health.actuate.endpoint.HealthDescriptor;
+                  import org.springframework.boot.health.actuate.endpoint.HealthEndpoint;
+
+                  import java.util.HashMap;
+                  import java.util.Map;
+
+                  class HealthController {
+                      HealthEndpoint endpoint;
+
+                      Map<String, Object> health() {
+                          HealthDescriptor health = endpoint.health();
+                          Map<String, Object> body = new HashMap<>();
+                          if (health instanceof CompositeHealthDescriptor composite) {
+                              body.put("components", composite.getComponents());
+                          }
+                          return body;
+                      }
+                  }
+                  """
+              )
+            );
+        }
+
+        @Test
         void migrateEndpointRequest() {
             rewriteRun(
               spec -> spec.typeValidationOptions(TypeValidation.none()),


### PR DESCRIPTION
## What's missing

In Spring Boot 4 the actuator health response API was reorganised:

| Spring Boot 3 | Spring Boot 4 |
| --- | --- |
| `org.springframework.boot.actuate.health.HealthComponent` (abstract) | `org.springframework.boot.health.actuate.endpoint.HealthDescriptor` (abstract) |
| `org.springframework.boot.actuate.health.CompositeHealth` | `org.springframework.boot.health.actuate.endpoint.CompositeHealthDescriptor` |
| `HealthEndpoint.health()` returns `HealthComponent` | `HealthEndpoint.health()` returns `HealthDescriptor` |

`MigrateToModularStarters` already handles every other `org.springframework.boot.actuate.health.*` type explicitly and then falls through to a catch-all `ChangePackage` that maps the remainder to `org.springframework.boot.health.contributor`. That catch-all sent `CompositeHealth` and `HealthComponent` to the wrong package and didn't rename the classes, so callers like the one below still failed to compile under SB4:

```java
HealthComponent health = healthEndpoint.health();
if (health instanceof CompositeHealth composite) {
    body.put("components", composite.getComponents());
}
```

## Change

Add two `ChangeType` entries before the catch-all `ChangePackage`, alongside the other types that move to `health.actuate.endpoint`:

- `org.springframework.boot.actuate.health.CompositeHealth` → `org.springframework.boot.health.actuate.endpoint.CompositeHealthDescriptor`
- `org.springframework.boot.actuate.health.HealthComponent` → `org.springframework.boot.health.actuate.endpoint.HealthDescriptor`

`getComponents()` exists on `CompositeHealthDescriptor` with the same signature shape (returning `Map<String, HealthDescriptor>`), so the rest of the call site doesn't need touching.

`org.springframework.boot.actuate.health.Health` is unchanged — it still ends up at `org.springframework.boot.health.contributor.Health` via the catch-all (it's the indicator output type, not a `HealthDescriptor`).

## Test plan

- [x] New test `MigrateActuateHealthPackage#migrateCompositeHealthAndHealthComponentToDescriptors` exercises the `instanceof` + `getComponents()` pattern from a real controller
- [x] All tests in `MigrateToModularStartersTest` pass locally