### PR TITLE
Add ChangePackage for actuate.endpoint.web.servlet to webmvc module

### DIFF
--- a/src/main/resources/META-INF/rewrite/spring-boot-40-modular-starters.yml
+++ b/src/main/resources/META-INF/rewrite/spring-boot-40-modular-starters.yml
@@ -389,6 +389,11 @@ recipeList:
       # module: spring-boot-security
       newPackageName: org.springframework.boot.security.autoconfigure.actuate.web.servlet
       recursive: true
+  # spring-boot-actuator → spring-boot-webmvc
+  - org.openrewrite.java.ChangePackage:
+      oldPackageName: org.springframework.boot.actuate.endpoint.web.servlet
+      newPackageName: org.springframework.boot.webmvc.actuate.endpoint.web
+      recursive: true
   # spring-boot-actuator → spring-boot-health
   # Types that move to health.actuate.endpoint (must be listed before the catch-all ChangePackage)
   - org.openrewrite.java.ChangeType:

--- a/src/test/java/org/openrewrite/java/spring/boot4/MigrateToModularStartersTest.java
+++ b/src/test/java/org/openrewrite/java/spring/boot4/MigrateToModularStartersTest.java
@@ -550,6 +550,42 @@ class MigrateToModularStartersTest implements RewriteTest {
     }
 
     @Nested
+    class MigrateActuateEndpointWebServletPackage implements RewriteTest {
+        @Override
+        public void defaults(RecipeSpec spec) {
+            spec.recipeFromResource(
+              "/META-INF/rewrite/spring-boot-40-modular-starters.yml",
+              "org.openrewrite.java.spring.boot4.MigrateToModularStarters"
+            ).parser(JavaParser.fromJavaVersion()
+              .classpathFromResources(new InMemoryExecutionContext(),
+                "spring-boot-actuator-3"));
+        }
+
+        @Test
+        void migrateWebMvcEndpointHandlerMapping() {
+            rewriteRun(
+              //language=java
+              java(
+                """
+                  import org.springframework.boot.actuate.endpoint.web.servlet.WebMvcEndpointHandlerMapping;
+
+                  class MyConfig {
+                      WebMvcEndpointHandlerMapping handlerMapping;
+                  }
+                  """,
+                """
+                  import org.springframework.boot.webmvc.actuate.endpoint.web.WebMvcEndpointHandlerMapping;
+
+                  class MyConfig {
+                      WebMvcEndpointHandlerMapping handlerMapping;
+                  }
+                  """
+              )
+            );
+        }
+    }
+
+    @Nested
     class MigrateAutoconfigurePackages {
         @Test
         void migrateSecurityPropertiesConstants() {


### PR DESCRIPTION
## Summary

- Add `ChangePackage` rule to migrate `org.springframework.boot.actuate.endpoint.web.servlet` → `org.springframework.boot.webmvc.actuate.endpoint.web` in the Spring Boot 4.0 modular starters recipe
- Spring Boot 4.0 moved `WebMvcEndpointHandlerMapping`, `AbstractWebMvcEndpointHandlerMapping`, `AdditionalHealthEndpointPathsWebMvcHandlerMapping`, and `ControllerEndpointHandlerMapping` into the `spring-boot-webmvc` module, but this package relocation was not previously covered
- Add test for the package migration

## Test plan

- [x] New test `MigrateActuateEndpointWebServletPackage.migrateWebMvcEndpointHandlerMapping` passes
- [ ] Existing `MigrateToModularStartersTest` tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)