### PR TITLE
Skip `@AutoConfigureWebTestClient` when `WebTestClient` is built manually

### DIFF
--- a/src/main/java/org/openrewrite/java/spring/boot4/AddAutoConfigureWebTestClient.java
+++ b/src/main/java/org/openrewrite/java/spring/boot4/AddAutoConfigureWebTestClient.java
@@ -24,11 +24,13 @@ import org.openrewrite.java.AnnotationMatcher;
 import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.java.JavaTemplate;
+import org.openrewrite.java.search.UsesMethod;
 import org.openrewrite.java.search.UsesType;
 import org.openrewrite.java.service.AnnotationService;
 import org.openrewrite.java.tree.J;
 
 import static java.util.Comparator.comparing;
+import static org.openrewrite.Preconditions.*;
 
 public class AddAutoConfigureWebTestClient extends Recipe {
 
@@ -49,7 +51,10 @@ public class AddAutoConfigureWebTestClient extends Recipe {
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
-        return Preconditions.check(new UsesType<>(WEB_TEST_CLIENT, true), new JavaIsoVisitor<ExecutionContext>() {
+        return check(and(new UsesType<>(WEB_TEST_CLIENT, true),
+                        // this assumes either all or no `WebTestClient` is created manually
+                        not(new UsesMethod<>("org.springframework.test.web.reactive.server.WebTestClient.MockServerSpec build()", true))),
+                new JavaIsoVisitor<ExecutionContext>() {
             @Override
             public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration classDecl, ExecutionContext ctx) {
                 J.ClassDeclaration cd = super.visitClassDeclaration(classDecl, ctx);

--- a/src/test/java/org/openrewrite/java/spring/boot4/AddAutoConfigureWebTestClientTest.java
+++ b/src/test/java/org/openrewrite/java/spring/boot4/AddAutoConfigureWebTestClientTest.java
@@ -36,7 +36,14 @@ class AddAutoConfigureWebTestClientTest implements RewriteTest {
             .dependsOn(
               """
                 package org.springframework.test.web.reactive.server;
-                public interface WebTestClient {}
+                public interface WebTestClient {
+                    interface MockServerSpec<B extends MockServerSpec<B>> {
+                        WebTestClient build();
+                    }
+                    static MockServerSpec<?> bindToServer() {
+                        return null;
+                    }
+                }
                 """,
               """
                 package org.springframework.boot.webtestclient.autoconfigure;
@@ -100,6 +107,26 @@ class AddAutoConfigureWebTestClientTest implements RewriteTest {
 
               class ExampleTest {
                   WebTestClient webTestClient;
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void shouldNotAddAnnotationIfConfiguredManual() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import org.springframework.test.web.reactive.server.WebTestClient;
+
+              class ExampleTest {
+                  WebTestClient webTestClient;
+
+                  void setUp() {
+                      webTestClient = WebTestClient.bindToServer().build();
+                  }
               }
               """
           )


### PR DESCRIPTION
## What's changed

`AddAutoConfigureWebTestClient` adds `@AutoConfigureWebTestClient` to `@SpringBootTest` tests that reference `WebTestClient`. However, when a test builds its `WebTestClient` manually — e.g. `WebTestClient.bindToServer().build()` — the bean is not auto-configured, so the annotation is unnecessary. Worse, adding it (and its import) requires the `org.springframework.boot:spring-boot-webtestclient` artifact, which may not be on the classpath, breaking compilation.

This PR guards the recipe with an additional precondition so the annotation is only added when `WebTestClient` is **not** constructed manually:

```java
not(new UsesMethod<>("org.springframework.test.web.reactive.server.WebTestClient.MockServerSpec build()", true))
```

The check assumes a test either creates all of its `WebTestClient` instances manually or none of them.

## Why

Reported while validating `UpgradeSpringBoot_4_0` on a customer multi-module migration: the recipe added `@AutoConfigureWebTestClient` to a manually-configured test, introducing a `org.springframework.boot.webtestclient.autoconfigure` import for a package that wasn't available, which broke compilation of an already-SB4 module.

- This partially addresses the WebTestClient gap (Gap 2) from `moderneinc/customer-requests#2572`. It does not add the `spring-boot-webtestclient` dependency for the cases where the annotation _is_ legitimately added — that remains open.

## Testing

Added `shouldNotAddAnnotationIfConfiguredManual` covering the manual-build case, and extended the `WebTestClient` test stub with `bindToServer()` / `MockServerSpec` so the call chain has proper type attribution. All tests in `AddAutoConfigureWebTestClientTest` pass.


- Partially fixes moderneinc/customer-requests#2572 — addresses Gaps 1 and 2.