### PR TITLE
Set resolvable 3.1.x version when migrating thymeleaf dependencies to Spring Boot 3

### DIFF
--- a/src/main/resources/META-INF/rewrite/spring-boot-30.yml
+++ b/src/main/resources/META-INF/rewrite/spring-boot-30.yml
@@ -149,10 +149,12 @@ recipeList:
       oldGroupId: org.thymeleaf
       oldArtifactId: thymeleaf-spring5
       newArtifactId: thymeleaf-spring6
+      newVersion: 3.1.x
   - org.openrewrite.java.dependencies.ChangeDependency:
       oldGroupId: org.thymeleaf.extras
       oldArtifactId: thymeleaf-extras-springsecurity5
       newArtifactId: thymeleaf-extras-springsecurity6
+      newVersion: 3.1.x
 
 ---
 type: specs.openrewrite.org/v1beta/recipe

--- a/src/test/java/org/openrewrite/java/spring/boot3/MigrateThymeleafDependenciesTest.java
+++ b/src/test/java/org/openrewrite/java/spring/boot3/MigrateThymeleafDependenciesTest.java
@@ -21,9 +21,6 @@ import org.openrewrite.Issue;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.openrewrite.maven.Assertions.pomXml;
 
@@ -56,26 +53,10 @@ class MigrateThymeleafDependenciesTest implements RewriteTest {
                 </dependencies>
               </project>
               """,
-            spec -> spec.after(pom -> {
-                Matcher version = Pattern.compile("3\\.1\\.\\d+\\.RELEASE").matcher(pom);
-                assertThat(version.find()).describedAs("Expected a resolvable 3.1.x version in %s", pom).isTrue();
-                //language=xml
-                return """
-                  <project>
-                    <modelVersion>4.0.0</modelVersion>
-                    <groupId>com.example</groupId>
-                    <artifactId>demo</artifactId>
-                    <version>0.0.1-SNAPSHOT</version>
-                    <dependencies>
-                      <dependency>
-                        <groupId>org.thymeleaf</groupId>
-                        <artifactId>thymeleaf-spring6</artifactId>
-                        <version>%s</version>
-                      </dependency>
-                    </dependencies>
-                  </project>
-                  """.formatted(version.group());
-            })
+            spec -> spec.after(pom -> assertThat(pom)
+              .contains("<artifactId>thymeleaf-spring6</artifactId>")
+              .containsPattern("<version>3\\.1\\.\\d+\\.RELEASE</version>")
+              .actual())
           )
         );
     }
@@ -101,26 +82,10 @@ class MigrateThymeleafDependenciesTest implements RewriteTest {
                 </dependencies>
               </project>
               """,
-            spec -> spec.after(pom -> {
-                Matcher version = Pattern.compile("3\\.1\\.\\d+\\.RELEASE").matcher(pom);
-                assertThat(version.find()).describedAs("Expected a resolvable 3.1.x version in %s", pom).isTrue();
-                //language=xml
-                return """
-                  <project>
-                    <modelVersion>4.0.0</modelVersion>
-                    <groupId>com.example</groupId>
-                    <artifactId>demo</artifactId>
-                    <version>0.0.1-SNAPSHOT</version>
-                    <dependencies>
-                      <dependency>
-                        <groupId>org.thymeleaf.extras</groupId>
-                        <artifactId>thymeleaf-extras-springsecurity6</artifactId>
-                        <version>%s</version>
-                      </dependency>
-                    </dependencies>
-                  </project>
-                  """.formatted(version.group());
-            })
+            spec -> spec.after(pom -> assertThat(pom)
+              .contains("<artifactId>thymeleaf-extras-springsecurity6</artifactId>")
+              .containsPattern("<version>3\\.1\\.\\d+\\.RELEASE</version>")
+              .actual())
           )
         );
     }

--- a/src/test/java/org/openrewrite/java/spring/boot3/MigrateThymeleafDependenciesTest.java
+++ b/src/test/java/org/openrewrite/java/spring/boot3/MigrateThymeleafDependenciesTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.spring.boot3;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.Issue;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.openrewrite.maven.Assertions.pomXml;
+
+class MigrateThymeleafDependenciesTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipeFromResources("org.openrewrite.java.spring.boot3.MigrateThymeleafDependencies");
+    }
+
+    @DocumentExample
+    @Issue("https://github.com/moderneinc/customer-requests/issues/2588")
+    @Test
+    void migrateThymeleafSpring5ToSpring6WithResolvableVersion() {
+        rewriteRun(
+          //language=xml
+          pomXml(
+            """
+              <project>
+                <modelVersion>4.0.0</modelVersion>
+                <groupId>com.example</groupId>
+                <artifactId>demo</artifactId>
+                <version>0.0.1-SNAPSHOT</version>
+                <dependencies>
+                  <dependency>
+                    <groupId>org.thymeleaf</groupId>
+                    <artifactId>thymeleaf-spring5</artifactId>
+                    <version>3.0.15.RELEASE</version>
+                  </dependency>
+                </dependencies>
+              </project>
+              """,
+            spec -> spec.after(pom -> {
+                Matcher version = Pattern.compile("3\\.1\\.\\d+\\.RELEASE").matcher(pom);
+                assertThat(version.find()).describedAs("Expected a resolvable 3.1.x version in %s", pom).isTrue();
+                //language=xml
+                return """
+                  <project>
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>com.example</groupId>
+                    <artifactId>demo</artifactId>
+                    <version>0.0.1-SNAPSHOT</version>
+                    <dependencies>
+                      <dependency>
+                        <groupId>org.thymeleaf</groupId>
+                        <artifactId>thymeleaf-spring6</artifactId>
+                        <version>%s</version>
+                      </dependency>
+                    </dependencies>
+                  </project>
+                  """.formatted(version.group());
+            })
+          )
+        );
+    }
+
+    @Issue("https://github.com/moderneinc/customer-requests/issues/2588")
+    @Test
+    void migrateThymeleafExtrasSpringSecurity5ToSpring6WithResolvableVersion() {
+        rewriteRun(
+          //language=xml
+          pomXml(
+            """
+              <project>
+                <modelVersion>4.0.0</modelVersion>
+                <groupId>com.example</groupId>
+                <artifactId>demo</artifactId>
+                <version>0.0.1-SNAPSHOT</version>
+                <dependencies>
+                  <dependency>
+                    <groupId>org.thymeleaf.extras</groupId>
+                    <artifactId>thymeleaf-extras-springsecurity5</artifactId>
+                    <version>3.0.5.RELEASE</version>
+                  </dependency>
+                </dependencies>
+              </project>
+              """,
+            spec -> spec.after(pom -> {
+                Matcher version = Pattern.compile("3\\.1\\.\\d+\\.RELEASE").matcher(pom);
+                assertThat(version.find()).describedAs("Expected a resolvable 3.1.x version in %s", pom).isTrue();
+                //language=xml
+                return """
+                  <project>
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>com.example</groupId>
+                    <artifactId>demo</artifactId>
+                    <version>0.0.1-SNAPSHOT</version>
+                    <dependencies>
+                      <dependency>
+                        <groupId>org.thymeleaf.extras</groupId>
+                        <artifactId>thymeleaf-extras-springsecurity6</artifactId>
+                        <version>%s</version>
+                      </dependency>
+                    </dependencies>
+                  </project>
+                  """.formatted(version.group());
+            })
+          )
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Add `newVersion: 3.1.x` to the two `ChangeDependency` steps in `MigrateThymeleafDependencies` so the dependency version is updated alongside the artifactId.

## Problem

`org.openrewrite.java.spring.boot3.MigrateThymeleafDependencies` renamed `thymeleaf-spring5` → `thymeleaf-spring6` (and `thymeleaf-extras-springsecurity5` → `6`) but kept the original `3.0.x` version. The `-spring6`/`-springsecurity6` artifacts only publish `3.1.x` and later, so migrated projects ended up with an unresolvable version:

```xml
<dependency>
    <groupId>org.thymeleaf</groupId>
    <artifactId>thymeleaf-spring6</artifactId>
    <version>3.0.13.RELEASE</version>   <!-- Unable to download POM -->
</dependency>
```

## Solution

Set `newVersion: 3.1.x` on both `ChangeDependency` steps, which resolves to the latest available `3.1.x` release that exists for the Spring Boot 3 artifacts.

## Test plan

- [x] New `MigrateThymeleafDependenciesTest` covering both `thymeleaf-spring6` and `thymeleaf-extras-springsecurity6`; asserts a resolvable `3.1.x` version. Confirmed the tests fail on `main` (reproducing the "Unable to download POM" error) and pass with this change.

- Fixes moderneinc/customer-requests#2588