### PR TITLE
Upgrade JobRunr to 8.x when migrating to Spring Boot 4

### DIFF
--- a/src/main/resources/META-INF/rewrite/spring-boot-40.yml
+++ b/src/main/resources/META-INF/rewrite/spring-boot-40.yml
@@ -137,6 +137,20 @@ recipeList:
       artifactId: error-handling-spring-boot-starter
       newVersion: 5.0.x
       overrideManagedVersion: true
+  # JobRunr 8.x ships a dedicated Spring Boot 4 starter; the Spring Boot 3 starter
+  # is not compatible with Spring Boot 4. Rename to the new starter, then bump every
+  # JobRunr artifact (core library and starter) to the latest 8.x release.
+  # https://www.jobrunr.io/en/documentation/configuration/spring/
+  - org.openrewrite.java.dependencies.ChangeDependency:
+      oldGroupId: org.jobrunr
+      oldArtifactId: jobrunr-spring-boot-3-starter
+      newArtifactId: jobrunr-spring-boot-4-starter
+      newVersion: 8.x
+  - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
+      groupId: org.jobrunr
+      artifactId: "*"
+      newVersion: 8.x
+      overrideManagedVersion: true
 
   - org.openrewrite.java.spring.boot4.AddAutoConfigureTestRestTemplate
   - org.openrewrite.java.spring.boot4.AddAutoConfigureWebTestClient

--- a/src/test/java/org/openrewrite/java/spring/boot4/UpgradeSpringBoot_4_0Test.java
+++ b/src/test/java/org/openrewrite/java/spring/boot4/UpgradeSpringBoot_4_0Test.java
@@ -20,6 +20,7 @@ import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.openrewrite.gradle.Assertions.buildGradle;
 import static org.openrewrite.gradle.Assertions.buildGradleKts;
 import static org.openrewrite.gradle.toolingapi.Assertions.withToolingApi;
 import static org.openrewrite.java.Assertions.mavenProject;
@@ -101,6 +102,111 @@ class UpgradeSpringBoot_4_0Test implements RewriteTest {
                     .describedAs("kotlin.version property should be bumped to 2.2.x")
                     .containsPattern("<kotlin\\.version>2\\.2\\.\\d+</kotlin\\.version>").actual();
               })
+            )
+          )
+        );
+    }
+
+    @Test
+    void upgradeJobRunrStarterToSpringBoot4Starter() {
+        rewriteRun(
+          mavenProject("project",
+            //language=xml
+            pomXml(
+              """
+                <project>
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>com.example</groupId>
+                    <artifactId>jobrunr-app</artifactId>
+                    <version>1.0-SNAPSHOT</version>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.springframework.boot</groupId>
+                            <artifactId>spring-boot-starter</artifactId>
+                            <version>3.5.7</version>
+                        </dependency>
+                        <dependency>
+                            <groupId>org.jobrunr</groupId>
+                            <artifactId>jobrunr-spring-boot-3-starter</artifactId>
+                            <version>7.5.0</version>
+                        </dependency>
+                    </dependencies>
+                </project>
+                """,
+              spec -> spec.after(actual ->
+                assertThat(actual)
+                  .describedAs("JobRunr Spring Boot 3 starter should be renamed to the Spring Boot 4 starter at 8.x")
+                  .contains("jobrunr-spring-boot-4-starter")
+                  .doesNotContain("jobrunr-spring-boot-3-starter")
+                  .containsPattern("<artifactId>jobrunr-spring-boot-4-starter</artifactId>\\s*<version>8\\.\\d+(\\.\\d+)?</version>")
+                  .actual())
+            )
+          )
+        );
+    }
+
+    @Test
+    void upgradeJobRunrCoreDependency() {
+        rewriteRun(
+          mavenProject("project",
+            //language=xml
+            pomXml(
+              """
+                <project>
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>com.example</groupId>
+                    <artifactId>jobrunr-app</artifactId>
+                    <version>1.0-SNAPSHOT</version>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.springframework.boot</groupId>
+                            <artifactId>spring-boot-starter</artifactId>
+                            <version>3.5.7</version>
+                        </dependency>
+                        <dependency>
+                            <groupId>org.jobrunr</groupId>
+                            <artifactId>jobrunr</artifactId>
+                            <version>7.5.0</version>
+                        </dependency>
+                    </dependencies>
+                </project>
+                """,
+              spec -> spec.after(actual ->
+                assertThat(actual)
+                  .describedAs("JobRunr core library should be upgraded to 8.x")
+                  .containsPattern("<artifactId>jobrunr</artifactId>\\s*<version>8\\.\\d+(\\.\\d+)?</version>")
+                  .actual())
+            )
+          )
+        );
+    }
+
+    @Test
+    void upgradeJobRunrStarterInGradle() {
+        rewriteRun(
+          mavenProject("project",
+            //language=groovy
+            buildGradle(
+              """
+                plugins {
+                    id 'java'
+                    id 'org.springframework.boot' version '3.5.7'
+                    id 'io.spring.dependency-management' version '1.1.7'
+                }
+                repositories {
+                    mavenCentral()
+                }
+                dependencies {
+                    implementation 'org.jobrunr:jobrunr-spring-boot-3-starter:7.5.0'
+                }
+                """,
+              spec -> spec.after(actual ->
+                assertThat(actual)
+                  .describedAs("JobRunr Spring Boot 3 starter should be renamed to the Spring Boot 4 starter at 8.x")
+                  .contains("jobrunr-spring-boot-4-starter")
+                  .doesNotContain("jobrunr-spring-boot-3-starter")
+                  .containsPattern("org\\.jobrunr:jobrunr-spring-boot-4-starter:8\\.\\d+(\\.\\d+)?")
+                  .actual())
             )
           )
         );


### PR DESCRIPTION
JobRunr 8.x ships a dedicated `jobrunr-spring-boot-4-starter` artifact, and the Spring Boot 3 starter is not compatible with Spring Boot 4. This adds the migration to the `UpgradeSpringBoot_4_0` recipe: it renames `org.jobrunr:jobrunr-spring-boot-3-starter` to `jobrunr-spring-boot-4-starter` and bumps every `org.jobrunr` artifact (core library and starter) to the latest 8.x release. Tests cover the starter rename and version bump for both Maven and Gradle, plus the core `jobrunr` library upgrade.

This handles the dependency migration only; JobRunr 8 API breaking changes are out of scope for this PR.