### PR TITLE
Fix AddSpringProperty duplicating flattened YAML keys

### DIFF
--- a/src/main/java/org/openrewrite/java/spring/AddSpringProperty.java
+++ b/src/main/java/org/openrewrite/java/spring/AddSpringProperty.java
@@ -23,11 +23,10 @@ import org.openrewrite.internal.StringUtils;
 import org.openrewrite.properties.AddProperty;
 import org.openrewrite.properties.tree.Properties;
 import org.openrewrite.yaml.MergeYaml;
+import org.openrewrite.yaml.search.FindProperty;
 import org.openrewrite.yaml.tree.Yaml;
 
 import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -84,7 +83,10 @@ public class AddSpringProperty extends Recipe {
             @Override
             public @Nullable Tree visit(@Nullable Tree t, ExecutionContext ctx) {
                 if (t instanceof Yaml.Documents && sourcePathMatches(((SourceFile) t).getSourcePath(), ctx)) {
-                    if (yamlPropertyExists((Yaml.Documents) t)) {
+                    // Spring treats a flattened key (e.g. `some.property: true`) as equivalent to its nested form, but
+                    // MergeYaml only recognizes the nested form. Skip the merge if the property already exists in either
+                    // form to avoid duplicating a flattened key.
+                    if (!FindProperty.find((Yaml.Documents) t, property, true).isEmpty()) {
                         return t;
                     }
                     t = createMergeYamlVisitor().getVisitor().visit(t, ctx);
@@ -111,35 +113,6 @@ public class AddSpringProperty extends Recipe {
             }
         }
 
-        return false;
-    }
-
-    /**
-     * Determines whether the property already exists in the YAML document, taking into account that Spring treats a
-     * flattened key (e.g. {@code some.property: true}) as equivalent to its nested form. {@link MergeYaml} only
-     * recognizes the nested form, so without this check a flattened key would be duplicated.
-     */
-    private boolean yamlPropertyExists(Yaml.Documents documents) {
-        List<String> target = Arrays.asList(property.split("\\."));
-        for (Yaml.Document document : documents.getDocuments()) {
-            if (mappingContainsProperty(document.getBlock(), new ArrayList<>(), target)) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    private static boolean mappingContainsProperty(Yaml.Block block, List<String> prefix, List<String> target) {
-        if (!(block instanceof Yaml.Mapping)) {
-            return false;
-        }
-        for (Yaml.Mapping.Entry entry : ((Yaml.Mapping) block).getEntries()) {
-            List<String> path = new ArrayList<>(prefix);
-            path.addAll(Arrays.asList(entry.getKey().getValue().split("\\.")));
-            if (path.equals(target) || mappingContainsProperty(entry.getValue(), path, target)) {
-                return true;
-            }
-        }
         return false;
     }
 

--- a/src/main/java/org/openrewrite/java/spring/AddSpringProperty.java
+++ b/src/main/java/org/openrewrite/java/spring/AddSpringProperty.java
@@ -26,6 +26,8 @@ import org.openrewrite.yaml.MergeYaml;
 import org.openrewrite.yaml.tree.Yaml;
 
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -82,6 +84,9 @@ public class AddSpringProperty extends Recipe {
             @Override
             public @Nullable Tree visit(@Nullable Tree t, ExecutionContext ctx) {
                 if (t instanceof Yaml.Documents && sourcePathMatches(((SourceFile) t).getSourcePath(), ctx)) {
+                    if (yamlPropertyExists((Yaml.Documents) t)) {
+                        return t;
+                    }
                     t = createMergeYamlVisitor().getVisitor().visit(t, ctx);
                 } else if (t instanceof Properties.File && sourcePathMatches(((SourceFile) t).getSourcePath(), ctx)) {
                     t = new AddProperty(property, value, comment, null, null, null, null).getVisitor().visit(t, ctx);
@@ -106,6 +111,35 @@ public class AddSpringProperty extends Recipe {
             }
         }
 
+        return false;
+    }
+
+    /**
+     * Determines whether the property already exists in the YAML document, taking into account that Spring treats a
+     * flattened key (e.g. {@code some.property: true}) as equivalent to its nested form. {@link MergeYaml} only
+     * recognizes the nested form, so without this check a flattened key would be duplicated.
+     */
+    private boolean yamlPropertyExists(Yaml.Documents documents) {
+        List<String> target = Arrays.asList(property.split("\\."));
+        for (Yaml.Document document : documents.getDocuments()) {
+            if (mappingContainsProperty(document.getBlock(), new ArrayList<>(), target)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean mappingContainsProperty(Yaml.Block block, List<String> prefix, List<String> target) {
+        if (!(block instanceof Yaml.Mapping)) {
+            return false;
+        }
+        for (Yaml.Mapping.Entry entry : ((Yaml.Mapping) block).getEntries()) {
+            List<String> path = new ArrayList<>(prefix);
+            path.addAll(Arrays.asList(entry.getKey().getValue().split("\\.")));
+            if (path.equals(target) || mappingContainsProperty(entry.getValue(), path, target)) {
+                return true;
+            }
+        }
         return false;
     }
 

--- a/src/test/java/org/openrewrite/java/spring/AddSpringPropertyTest.java
+++ b/src/test/java/org/openrewrite/java/spring/AddSpringPropertyTest.java
@@ -110,6 +110,33 @@ class AddSpringPropertyTest implements RewriteTest {
     }
 
     @Test
+    void propertyAlreadyExistsAsFlattenedYamlKey() {
+        rewriteRun(
+          spec -> spec.recipe(new AddSpringProperty("some.property", "true", null, List.of("*"))),
+          //language=yaml
+          yaml(
+            """
+              some.property: true
+              """
+          )
+        );
+    }
+
+    @Test
+    void propertyAlreadyExistsAsPartiallyFlattenedYamlKey() {
+        rewriteRun(
+          spec -> spec.recipe(new AddSpringProperty("some.nested.property", "true", null, List.of("*"))),
+          //language=yaml
+          yaml(
+            """
+              some:
+                nested.property: true
+              """
+          )
+        );
+    }
+
+    @Test
     void addPropertyWithComment() {
         rewriteRun(
           spec -> spec.recipe(new AddSpringProperty("server.servlet.path", "/tmp/my-server-path", "This property was added", List.of("*"))),


### PR DESCRIPTION
- Fixes #1043

`AddSpringProperty` relied on `MergeYaml` to detect whether a property already existed, but `MergeYaml` only recognizes the nested mapping form. When a property was already present as a flattened dotted key (e.g. `some.property: true`), the recipe failed to detect it and re-added the property in nested form, producing a duplicate.

This adds an existence check before merging that splits dotted keys, so both the flattened (`some.property: true`) and nested forms — and any mix of the two — are recognized as the same property.

Added tests covering a fully flattened key and a partially flattened key.