### PR TITLE
Don't re-migrate already-migrated Spring Cloud Gateway properties

### DIFF
--- a/src/main/resources/META-INF/rewrite/spring-cloud-2025.yml
+++ b/src/main/resources/META-INF/rewrite/spring-cloud-2025.yml
@@ -181,7 +181,7 @@ recipeList:
   - org.openrewrite.java.spring.ChangeSpringPropertyKey:
       oldPropertyKey: spring.cloud.gateway
       newPropertyKey: spring.cloud.gateway.server.webflux
-      except: ["proxy"]
+      except: ["proxy", "mvc", "server"]
   - org.openrewrite.java.spring.ChangeSpringPropertyKey:
       oldPropertyKey: spring.cloud.gateway.mvc
       newPropertyKey: spring.cloud.gateway.server.webmvc

--- a/src/test/java/org/openrewrite/java/spring/boot3/UpgradeSpringCloud2025Test.java
+++ b/src/test/java/org/openrewrite/java/spring/boot3/UpgradeSpringCloud2025Test.java
@@ -70,4 +70,35 @@ class UpgradeSpringCloud2025Test implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void doesNotReMigrateAlreadyMigratedProperties() {
+        rewriteRun(
+          srcMainResources(
+            //language=properties
+            properties(
+              """
+                spring.cloud.gateway.server.webmvc.forwarded-request-headers-filter.enabled=false
+                spring.cloud.gateway.server.webmvc.x-forwarded-request-headers-filter.enabled=false
+                spring.cloud.gateway.server.webflux.routes[0].id=foo
+                """,
+              spec -> spec.path("application.properties")
+            )
+          )
+        );
+    }
+
+    @Test
+    void migratesMvcPropertiesToWebMvc() {
+        rewriteRun(
+          srcMainResources(
+            //language=properties
+            properties(
+              "spring.cloud.gateway.mvc.routes[0].id=foo",
+              "spring.cloud.gateway.server.webmvc.routes[0].id=foo",
+              spec -> spec.path("application.properties")
+            )
+          )
+        );
+    }
 }


### PR DESCRIPTION
- Fixes #1046

### Problem

`SpringCloudGatewayProperties` blindly rewrites every `spring.cloud.gateway.*` key (except `proxy`) to `spring.cloud.gateway.server.webflux.*`. That rule is meant for **pre-2025** gateway properties, but it also matches keys that are *already* in the 2025 layout, producing corrupted, doubled keys:

```properties
# before
spring.cloud.gateway.server.webmvc.forwarded-request-headers-filter.enabled=false
# after (wrong)
spring.cloud.gateway.server.webflux.server.webmvc.forwarded-request-headers-filter.enabled=false
```

The existing file-level guard only protects already-migrated `server.webflux` files, not `server.webmvc` ones, so the recipe was non-idempotent on the WebMVC layout.

### Fix

Add `mvc` and `server` to the `except` list of the broad `spring.cloud.gateway` → `spring.cloud.gateway.server.webflux` rule:

- `server` leaves any key already under `spring.cloud.gateway.server.*` (both `webmvc` and `webflux`) untouched — fixes the reported corruption and makes the recipe idempotent.
- `mvc` prevents `spring.cloud.gateway.mvc.*` from being swept into `…server.webflux.mvc.*` before the dedicated `spring.cloud.gateway.mvc` → `…server.webmvc` rule can run.

Genuine old keys (`routes`, `default-filters`, …) still migrate to `…server.webflux.*` as before.

### Tests

- `doesNotReMigrateAlreadyMigratedProperties` — already-migrated `server.webmvc` / `server.webflux` properties are left unchanged.
- `migratesMvcPropertiesToWebMvc` — `spring.cloud.gateway.mvc.*` migrates to `spring.cloud.gateway.server.webmvc.*`.