### PR TITLE
Route TestEntityManager types to spring-boot-jpa-test package in SB 4.0 migration

### DIFF
--- a/src/main/resources/META-INF/rewrite/spring-boot-40-modular-starters.yml
+++ b/src/main/resources/META-INF/rewrite/spring-boot-40-modular-starters.yml
@@ -216,6 +216,16 @@ recipeList:
       oldPackageName: org.springframework.boot.actuate.autoconfigure.metrics.orm.jpa
       newPackageName: org.springframework.boot.hibernate.autoconfigure.metrics
       recursive: true
+  # spring-boot-jpa-test
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureTestEntityManager
+      newFullyQualifiedTypeName: org.springframework.boot.jpa.test.autoconfigure.AutoConfigureTestEntityManager
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager
+      newFullyQualifiedTypeName: org.springframework.boot.jpa.test.autoconfigure.TestEntityManager
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManagerAutoConfiguration
+      newFullyQualifiedTypeName: org.springframework.boot.jpa.test.autoconfigure.TestEntityManagerAutoConfiguration
   # spring-boot-data-jpa-test
   - org.openrewrite.java.ChangePackage:
       oldPackageName: org.springframework.boot.test.autoconfigure.orm.jpa

--- a/src/test/java/org/openrewrite/java/spring/boot4/MigrateToModularStartersTest.java
+++ b/src/test/java/org/openrewrite/java/spring/boot4/MigrateToModularStartersTest.java
@@ -814,7 +814,6 @@ class MigrateToModularStartersTest implements RewriteTest {
     @Test
     void migrateOrmJpaTestPackageSplit() {
         rewriteRun(
-          spec -> spec.typeValidationOptions(TypeValidation.none()),
           //language=java
           java(
             """

--- a/src/test/java/org/openrewrite/java/spring/boot4/MigrateToModularStartersTest.java
+++ b/src/test/java/org/openrewrite/java/spring/boot4/MigrateToModularStartersTest.java
@@ -811,4 +811,40 @@ class MigrateToModularStartersTest implements RewriteTest {
         );
     }
 
+    @Test
+    void migrateOrmJpaTestPackageSplit() {
+        rewriteRun(
+          spec -> spec.typeValidationOptions(TypeValidation.none()),
+          //language=java
+          java(
+            """
+              import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureTestEntityManager;
+              import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+              import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+              import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
+
+              @DataJpaTest
+              @AutoConfigureDataJpa
+              @AutoConfigureTestEntityManager
+              class A {
+                  TestEntityManager entityManager;
+              }
+              """,
+            """
+              import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+              import org.springframework.boot.jpa.test.autoconfigure.AutoConfigureTestEntityManager;
+              import org.springframework.boot.jpa.test.autoconfigure.TestEntityManager;
+              import org.springframework.boot.data.jpa.test.autoconfigure.AutoConfigureDataJpa;
+
+              @DataJpaTest
+              @AutoConfigureDataJpa
+              @AutoConfigureTestEntityManager
+              class A {
+                  TestEntityManager entityManager;
+              }
+              """
+          )
+        );
+    }
+
 }


### PR DESCRIPTION
## Summary

`MigrateToModularStarters` (`spring-boot-40-modular-starters.yml`) currently sends every type in `org.springframework.boot.test.autoconfigure.orm.jpa` to `org.springframework.boot.data.jpa.test.autoconfigure` via a single recursive `ChangePackage`. In SB 4.0 that package was split, and the `TestEntityManager` trio actually moves to `org.springframework.boot.jpa.test.autoconfigure` (no `data.` segment).

| SB 3.5 type | SB 4.0 destination |
| --- | --- |
| `AutoConfigureTestEntityManager` | `org.springframework.boot.jpa.test.autoconfigure` |
| `TestEntityManager` | `org.springframework.boot.jpa.test.autoconfigure` |
| `TestEntityManagerAutoConfiguration` | `org.springframework.boot.jpa.test.autoconfigure` |
| `AutoConfigureDataJpa` | `org.springframework.boot.data.jpa.test.autoconfigure` |
| `DataJpaTest` | `org.springframework.boot.data.jpa.test.autoconfigure` |
| `DataJpaTypeExcludeFilter` (public in SB 3.5, package-private in SB 4.0) | `org.springframework.boot.data.jpa.test.autoconfigure` |

Adds three `ChangeType` entries for the `TestEntityManager` trio ahead of the existing `ChangePackage`, which now stands as the catch-all for the remaining `Data*` types. Ordering matters — the more specific `ChangeType` rewrites must run before the recursive `ChangePackage`, otherwise the latter routes the trio incorrectly.

Refs:
- [SB 3.5 `orm.jpa` package](https://docs.spring.io/spring-boot/3.5/api/java/org/springframework/boot/test/autoconfigure/orm/jpa/package-summary.html)
- [SB 4.0 `jpa.test.autoconfigure`](https://docs.spring.io/spring-boot/4.0/api/java/org/springframework/boot/jpa/test/autoconfigure/package-summary.html)
- [SB 4.0 `data.jpa.test.autoconfigure`](https://docs.spring.io/spring-boot/4.0/api/java/org/springframework/boot/data/jpa/test/autoconfigure/package-summary.html)

## Test plan

- [x] New `MigrateToModularStartersTest.migrateOrmJpaTestPackageSplit` covers all five surviving types in one input and asserts the split destinations
- [x] Full `MigrateToModularStartersTest` class passes locally

