### PR TITLE
Add option to keep the property in `CommentOutSpringPropertyKey`

### DIFF
--- a/src/main/java/org/openrewrite/java/spring/CommentOutSpringPropertyKey.java
+++ b/src/main/java/org/openrewrite/java/spring/CommentOutSpringPropertyKey.java
@@ -29,7 +29,7 @@ public class CommentOutSpringPropertyKey extends Recipe {
 
     String displayName = "Comment out Spring properties";
 
-    String description = "Add comment to specified Spring properties, and comment out the property.";
+    String description = "Add comment to specified Spring properties, and optionally comment out the property.";
 
     @Option(displayName = "Property key",
             description = "The name of the property key to comment out.",
@@ -41,10 +41,17 @@ public class CommentOutSpringPropertyKey extends Recipe {
             example = "This property is deprecated and no longer applicable starting from Spring Boot 3.0.x")
     String comment;
 
+    @Option(displayName = "Comment out property",
+            description = "If `false` the property is kept and only the comment is added. Defaults to `true`.",
+            required = false)
+    @Nullable
+    Boolean commentOutProperty;
+
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
-        Recipe changeProperties = new org.openrewrite.properties.AddPropertyComment(propertyKey, comment, true);
-        Recipe changeYaml = new org.openrewrite.yaml.CommentOutProperty(propertyKey, comment, true);
+        boolean commentOut = !Boolean.FALSE.equals(commentOutProperty);
+        Recipe changeProperties = new org.openrewrite.properties.AddPropertyComment(propertyKey, comment, commentOut);
+        Recipe changeYaml = new org.openrewrite.yaml.CommentOutProperty(propertyKey, comment, commentOut);
         return Preconditions.check(new IsPossibleSpringConfigFile(), new TreeVisitor<Tree, ExecutionContext>() {
             @Override
             public @Nullable Tree preVisit(@NonNull Tree tree, ExecutionContext ctx) {

--- a/src/test/java/org/openrewrite/java/spring/CommentOutSpringPropertyKeyTest.java
+++ b/src/test/java/org/openrewrite/java/spring/CommentOutSpringPropertyKeyTest.java
@@ -33,7 +33,7 @@ class CommentOutSpringPropertyKeyTest implements RewriteTest {
     @Test
     void yamlComment() {
         rewriteRun(
-          spec -> spec.recipe(new CommentOutSpringPropertyKey("server.port", "This property has been removed.")),
+          spec -> spec.recipe(new CommentOutSpringPropertyKey("server.port", "This property has been removed.", null)),
           mavenProject("project",
             srcMainResources(
               //language=yaml
@@ -52,8 +52,8 @@ class CommentOutSpringPropertyKeyTest implements RewriteTest {
     void multipleYamlComments() {
         rewriteRun(
           spec -> spec.recipes(
-            new CommentOutSpringPropertyKey("test.propertyKey1", "my comment 1"),
-            new CommentOutSpringPropertyKey("test.propertyKey2", "my comment 2")
+            new CommentOutSpringPropertyKey("test.propertyKey1", "my comment 1", null),
+            new CommentOutSpringPropertyKey("test.propertyKey2", "my comment 2", null)
           ),
           mavenProject("project",
             srcMainResources(
@@ -102,8 +102,8 @@ class CommentOutSpringPropertyKeyTest implements RewriteTest {
     void multiplePropertiesComments() {
         rewriteRun(
           spec -> spec.recipes(
-            new CommentOutSpringPropertyKey("test.propertyKey1", "my comment 1"),
-            new CommentOutSpringPropertyKey("test.propertyKey2", "my comment 2")
+            new CommentOutSpringPropertyKey("test.propertyKey1", "my comment 1", null),
+            new CommentOutSpringPropertyKey("test.propertyKey2", "my comment 2", null)
           ),
           mavenProject("project",
             srcMainResources(
@@ -125,6 +125,48 @@ class CommentOutSpringPropertyKeyTest implements RewriteTest {
                   .afterRecipe(file ->
                     assertThat(((Properties.Comment) file.getContent().get(3)).getMessage())
                       .isEqualTo(" test.propertyKey2=yyy"))
+              )
+            )
+          )
+        );
+    }
+
+    @Test
+    void yamlCommentWithoutCommentingOut() {
+        rewriteRun(
+          spec -> spec.recipe(new CommentOutSpringPropertyKey("server.port", "This property is deprecated.", false)),
+          mavenProject("project",
+            srcMainResources(
+              //language=yaml
+              yaml(
+                "server.port: 8080",
+                """
+                  # This property is deprecated.
+                  server.port: 8080
+                  """)
+            )
+          )
+        );
+    }
+
+    @Test
+    void propertiesCommentWithoutCommentingOut() {
+        rewriteRun(
+          spec -> spec.recipe(new CommentOutSpringPropertyKey("test.propertyKey1", "my comment 1", false)),
+          mavenProject("project",
+            srcMainResources(
+              //language=properties
+              properties(
+                """
+                  test.propertyKey1=xxx
+                  test.propertyKey2=yyy
+                  """,
+                """
+                  # my comment 1
+                  test.propertyKey1=xxx
+                  test.propertyKey2=yyy
+                  """,
+                spec -> spec.path("application.properties")
               )
             )
           )


### PR DESCRIPTION
- Resolves #1055.

Adds an optional `commentOutProperty` option to `CommentOutSpringPropertyKey`; when set to `false` the recipe adds the comment above the property key without commenting out the property itself. The option is optional and defaults to `true`, so existing behavior (including the declarative `spring-boot-*-properties.yml` recipes) is unchanged. The flag is threaded through to the underlying `AddPropertyComment` and `CommentOutProperty` recipes, and new tests cover the `false` case for both `.properties` and YAML.