### PR TITLE
JacksonAutoConfiguration migration

### DIFF
--- a/src/main/resources/META-INF/rewrite/spring-boot-40-modular-starters.yml
+++ b/src/main/resources/META-INF/rewrite/spring-boot-40-modular-starters.yml
@@ -470,6 +470,10 @@ recipeList:
       newMethodName: health
       matchOverrides: true
       ignoreDefinition: false
+  # spring-boot-jackson
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.springframework.boot.autoconfigure.jackson.JacksonAutoConfiguration
+      newFullyQualifiedTypeName: org.springframework.boot.jackson.autoconfigure.JacksonAutoConfiguration
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.spring.boot4.AddSpringBootStarterFlyway


### PR DESCRIPTION

## What's changed?
Added `JacksonAutoConfiguration` migration to Spring Boot 4.0 modular starters recipe

## What's your motivation?
In Spring Boot 4, `JacksonAutoConfiguration`  has been moved to separate module, `spring-boot-jackson`, and package changed from `org.springframework.boot.autoconfigure.jackson` to `org.springframework.boot.jackson.autoconfigure`.


## Have you considered any alternatives or workarounds?
Alternative is to declare the same declarative recipe on my own, but adding it here to be used by community. 


### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
