### PR TITLE
Remove redundant managed dependency versions during Spring Boot 4 migration

### DIFF
--- a/src/main/resources/META-INF/rewrite/spring-boot-40.yml
+++ b/src/main/resources/META-INF/rewrite/spring-boot-40.yml
@@ -61,6 +61,11 @@ recipeList:
   - org.openrewrite.maven.RemoveRedundantDependencyVersions:
       groupPattern: tools.jackson*
       onlyIfManagedVersionIs: ANY
+  # Drop explicit dependency versions that the Spring Boot 4 BOM now manages at the same or a
+  # newer version, along with any version property left unused. `GTE` keeps overrides that are
+  # newer than the managed version, so intentional forward pins are preserved.
+  - org.openrewrite.maven.RemoveRedundantDependencyVersions:
+      onlyIfManagedVersionIs: GTE
   - org.openrewrite.gradle.plugins.UpgradePluginVersion:
       pluginIdPattern: org.springframework.boot
       newVersion: 4.0.x

--- a/src/test/java/org/openrewrite/java/spring/boot4/UpgradeSpringBoot_4_0Test.java
+++ b/src/test/java/org/openrewrite/java/spring/boot4/UpgradeSpringBoot_4_0Test.java
@@ -328,4 +328,138 @@ class UpgradeSpringBoot_4_0Test implements RewriteTest {
         );
     }
 
+    @Test
+    void removeOverrideOvertakenByBoot4Bom() {
+        rewriteRun(
+          mavenProject("project",
+            //language=xml
+            pomXml(
+              """
+                <project>
+                    <modelVersion>4.0.0</modelVersion>
+                    <parent>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-parent</artifactId>
+                        <version>3.5.14</version>
+                        <relativePath/>
+                    </parent>
+                    <groupId>com.example</groupId>
+                    <artifactId>redundant-version-app</artifactId>
+                    <version>1.0-SNAPSHOT</version>
+                    <properties>
+                        <commons-lang3-override.version>3.18.0</commons-lang3-override.version>
+                    </properties>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.apache.commons</groupId>
+                            <artifactId>commons-lang3</artifactId>
+                            <version>${commons-lang3-override.version}</version>
+                        </dependency>
+                    </dependencies>
+                </project>
+                """,
+              spec -> spec.after(actual -> assertThat(actual)
+                .describedAs("A commons-lang3 override newer than the Boot 3.5 managed version (3.17.0) but " +
+                             "older than the Boot 4 managed version (3.19.0) should be removed once on the Boot 4 BOM")
+                .contains("<artifactId>commons-lang3</artifactId>")
+                .doesNotContain("<version>${commons-lang3-override.version}</version>")
+                .describedAs("The now-unused version property should also be removed")
+                .doesNotContain("commons-lang3-override.version")
+                .actual())
+            )
+          )
+        );
+    }
+
+    @Test
+    void preserveDependencyVersionNewerThanBoot4Bom() {
+        rewriteRun(
+          mavenProject("project",
+            //language=xml
+            pomXml(
+              """
+                <project>
+                    <modelVersion>4.0.0</modelVersion>
+                    <parent>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-parent</artifactId>
+                        <version>3.5.14</version>
+                        <relativePath/>
+                    </parent>
+                    <groupId>com.example</groupId>
+                    <artifactId>newer-override-app</artifactId>
+                    <version>1.0-SNAPSHOT</version>
+                    <dependencies>
+                        <dependency>
+                            <groupId>com.google.code.gson</groupId>
+                            <artifactId>gson</artifactId>
+                            <version>2.14.0</version>
+                        </dependency>
+                    </dependencies>
+                </project>
+                """,
+              spec -> spec.after(actual -> assertThat(actual)
+                .describedAs("A gson override newer than the Spring Boot 4 managed version must be preserved")
+                .contains("<version>2.14.0</version>")
+                .actual())
+            )
+          )
+        );
+    }
+
+    @Test
+    void removeRedundantVersionAlreadyOnBoot4() {
+        rewriteRun(
+          mavenProject("project",
+            //language=xml
+            pomXml(
+              """
+                <project>
+                    <modelVersion>4.0.0</modelVersion>
+                    <parent>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-parent</artifactId>
+                        <version>4.0.7</version>
+                        <relativePath/>
+                    </parent>
+                    <groupId>com.example</groupId>
+                    <artifactId>redundant-version-app</artifactId>
+                    <version>1.0-SNAPSHOT</version>
+                    <properties>
+                        <commons-lang3-override.version>3.18.0</commons-lang3-override.version>
+                    </properties>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.apache.commons</groupId>
+                            <artifactId>commons-lang3</artifactId>
+                            <version>${commons-lang3-override.version}</version>
+                        </dependency>
+                    </dependencies>
+                </project>
+                """,
+              """
+                <project>
+                    <modelVersion>4.0.0</modelVersion>
+                    <parent>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-parent</artifactId>
+                        <version>4.0.7</version>
+                        <relativePath/>
+                    </parent>
+                    <groupId>com.example</groupId>
+                    <artifactId>redundant-version-app</artifactId>
+                    <version>1.0-SNAPSHOT</version>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.apache.commons</groupId>
+                            <artifactId>commons-lang3</artifactId>
+                        </dependency>
+                    </dependencies>
+                </project>
+                """
+            )
+          )
+        );
+    }
+
 }


### PR DESCRIPTION
## Summary

- Add `RemoveRedundantDependencyVersions` with `onlyIfManagedVersionIs: GTE` after the Spring Boot 4 parent/BOM upgrade in `UpgradeSpringBoot_4_0`.
- Strips explicit Maven dependency versions the Boot 4 BOM now manages at the same or a newer version, and removes any version property left unused.
- Overrides newer than the managed version are preserved, so intentional forward pins (e.g. a security bump ahead of Boot) are kept.

## Problem

After migrating to Spring Boot 4, version overrides that the new BOM has overtaken are frequently left behind. They unnecessarily pin dependencies and stop future Boot patch releases from managing them.

The migration did already remove such overrides, but only as an incidental side effect of the version transition: it fires when the managed version rises above an explicit version *during the run*. Running the recipe against a project already on Spring Boot 4 with a redundant override left it in place, so the cleanup was neither deliberate nor idempotent.

## Solution

Add an explicit cleanup step right after the parent/BOM upgrade (next to the existing `tools.jackson*` cleanup), before the modular-starter and fallback `ChangeDependency` steps so it doesn't strip versions those intentionally add:

```yaml
- org.openrewrite.maven.RemoveRedundantDependencyVersions:
    onlyIfManagedVersionIs: GTE
```

`GTE` removes an override when `managed >= explicit` and keeps it otherwise. `RemoveRedundantDependencyVersions` already removes a version property once it is left unused, covering the property-cleanup part of the request. Works for both `spring-boot-starter-parent` inheritance and `spring-boot-dependencies` imports.

## Test plan

Added to `UpgradeSpringBoot_4_0Test`:
- `removeOverrideOvertakenByBoot4Bom` — a 3.5→4.0 migration removes a `commons-lang3` override (`3.18.0`) that is newer than Boot 3.5's managed `3.17.0` but older than Boot 4's `3.19.0`, and removes the now-unused property.
- `preserveDependencyVersionNewerThanBoot4Bom` — a `gson` override (`2.14.0`) newer than the managed `2.13.2` is preserved.
- `removeRedundantVersionAlreadyOnBoot4` — a project already on the 4.0 parent has its redundant override removed (fails without this change, demonstrating the previously non-idempotent behavior).

- [x] Existing tests pass (`UpgradeSpringBoot_4_0Test` and the rest of the `boot4` package)
- [x] New tests added for the change

- Fixes #1074