### PR TITLE
Introduce Spring Data 4 migration foundation

### DIFF
--- a/src/main/resources/META-INF/rewrite/spring-data-4.yml
+++ b/src/main/resources/META-INF/rewrite/spring-data-4.yml
@@ -1,0 +1,27 @@
+#
+# Copyright 2026 the original author or authors.
+# <p>
+# Licensed under the Moderne Source Available License (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# <p>
+# https://docs.moderne.io/licensing/moderne-source-available-license
+# <p>
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.spring.data.UpgradeSpringData_4_0
+displayName: Migrate to Spring Data 4.0
+description: >-
+  Migrate applications to the Spring Data 2025.1 release train.
+  Datastore-specific migration support is added incrementally.
+preconditions:
+  - org.openrewrite.Singleton
+recipeList:
+  - org.openrewrite.java.spring.data.UpgradeSpringData_3_4

--- a/src/test/java/org/openrewrite/java/spring/data/UpgradeSpringData_4_0Test.java
+++ b/src/test/java/org/openrewrite/java/spring/data/UpgradeSpringData_4_0Test.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.spring.data;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.InMemoryExecutionContext;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+class UpgradeSpringData_4_0Test implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipeFromResources("org.openrewrite.java.spring.data.UpgradeSpringData_4_0")
+          .parser(JavaParser.fromJavaVersion()
+            .classpathFromResources(new InMemoryExecutionContext(), "spring-data-jpa-3.4.7"));
+    }
+
+    @Test
+    void chainsSpringData34Migration() {
+        rewriteRun(
+          java(
+            """
+              import org.springframework.data.jpa.repository.Query;
+
+              interface Repository {
+
+                  @Query(value = "select * from foo", nativeQuery = true)
+                  void customQuery();
+              }
+              """,
+            """
+              import org.springframework.data.jpa.repository.NativeQuery;
+
+              interface Repository {
+
+                  @NativeQuery("select * from foo")
+                  void customQuery();
+              }
+              """
+          )
+        );
+    }
+}


### PR DESCRIPTION
> Superseded by #1087 after renaming the fork branch to `introduce-spring-data-4-foundation`.

## What changed

- Add `spring-data-4.yml`.
- Introduce `org.openrewrite.java.spring.data.UpgradeSpringData_4_0`.
- Chain the existing `UpgradeSpringData_3_4` recipe.
- Document that datastore-specific Spring Data 2025.1 support will be added incrementally.
- Add a focused test proving that the new composite loads and delegates to the existing Spring Data 3.4 migration chain.

## Why

Spring Data migration support spans multiple datastore modules with different major versions and migration requirements. This establishes a datastore-neutral extension point so Commons, JPA, MongoDB, and other module-specific recipes can be contributed independently without coupling them into one large change.

This PR intentionally does not add datastore-specific API changes, dependency alignment, Spring Boot package changes, or Framework/Boot integration.

Part of #1080.

## Validation

The branch diff was reviewed against the existing Spring Data declarative-recipe and test conventions. I could not run the Gradle test suite or regenerate `recipes.csv` in this connector-only environment, so this remains a draft pending local/CI validation and generated metadata update if required.