### PR TITLE
Update SeparateApplicationYamlByProfile expected output for MergeYaml blank-line fix

### DIFF
--- a/src/test/java/org/openrewrite/java/spring/SeparateApplicationYamlByProfileTest.java
+++ b/src/test/java/org/openrewrite/java/spring/SeparateApplicationYamlByProfileTest.java
@@ -142,12 +142,10 @@ class SeparateApplicationYamlByProfileTest implements RewriteTest {
                     password: devpassword
                     url: jdbc:mysql://devserver
                     driver-class-name: com.mysql.jdbc.Driver
-
                   jpa:
                     hibernate:
                       ddl-auto: update
                     show-sql: true
-
                 logging:
                   level:
                     root: DEBUG
@@ -183,7 +181,6 @@ class SeparateApplicationYamlByProfileTest implements RewriteTest {
                 """,
               """
                 existing: property
-
                 name: dev
                 """,
               spec -> spec.path("application-dev.yml").noTrim()


### PR DESCRIPTION
## What's changed?

- [openrewrite/rewrite#8232](https://github.com/openrewrite/rewrite/pull/8232) fixed `MergeYaml` inserting a new entry *after* blank lines surrounding a mapping — the merged entry now lands directly next to its sibling instead of being pushed past the trailing blank line(s).

`SeparateApplicationYamlByProfile` uses `MergeYaml`, so its output changed accordingly. This updates the expected output of two tests to match:

- `mergeIntoExistingProfileFile` — the blank line before `name: dev` is no longer emitted.
- `mergeIntoExistingProfileFilePreservesFormat` — the two blank lines before `jpa:` and `logging:` are no longer emitted.

## Why?

- Scheduled CI went red on 2026-07-20 (green through 07-19): [run #29771990866](https://github.com/openrewrite/rewrite-spring/actions/runs/29771990866) — `2 tests failed`. Reproduced locally against the current snapshot; both pass with the updated expectations.