### PR TITLE
Remove Springfox 3.x `@EnableOpenApi` annotation when migrating to SpringDoc

### DIFF
--- a/src/main/resources/META-INF/rewrite/springdoc.yml
+++ b/src/main/resources/META-INF/rewrite/springdoc.yml
@@ -57,6 +57,8 @@ recipeList:
   - org.openrewrite.java.spring.doc.RemoveBeanValidatorPluginsConfiguration
   - org.openrewrite.java.RemoveAnnotation:
       annotationPattern: '@springfox.documentation.swagger2.annotations.EnableSwagger2'
+  - org.openrewrite.java.RemoveAnnotation:
+      annotationPattern: '@springfox.documentation.oas.annotations.EnableOpenApi'
   - org.openrewrite.java.spring.doc.MigrateDocketBeanToGroupedOpenApiBean
 
 ---


### PR DESCRIPTION
Extend `SwaggerToSpringDoc` to also strip `@springfox.documentation.oas.annotations.EnableOpenApi`, the Springfox 3.x OAS-flavored counterpart to `@EnableSwagger2`.

SpringDoc auto-configures via classpath presence of `springdoc-openapi-ui` / `springdoc-openapi-starter-webmvc-ui`; there is no SpringDoc equivalent annotation, so the correct migration is to remove it (mirroring the existing `@EnableSwagger2` treatment). See https://springdoc.org/#migrating-from-springfox.