### PR TITLE
Trigger spring-boot-starter-jdbc and spring-boot-hibernate on SB3 autoconfigure packages

### DIFF
--- a/src/main/resources/META-INF/rewrite/spring-boot-40-modular-starters.yml
+++ b/src/main/resources/META-INF/rewrite/spring-boot-40-modular-starters.yml
@@ -121,6 +121,18 @@ recipeList:
       version: 4.0.x
       scope: test
       onlyIfUsing: org.springframework.boot.test.web.client.*
+  - org.openrewrite.java.dependencies.AddDependency:
+      groupId: org.springframework.boot
+      artifactId: spring-boot-starter-jdbc
+      acceptTransitive: true
+      version: 4.0.x
+      onlyIfUsing: org.springframework.boot.autoconfigure.jdbc.*
+  - org.openrewrite.java.dependencies.AddDependency:
+      groupId: org.springframework.boot
+      artifactId: spring-boot-hibernate
+      acceptTransitive: true
+      version: 4.0.x
+      onlyIfUsing: org.springframework.boot.autoconfigure.orm.jpa.*
 
   # Update packages to match the new modular starter structure
   - org.openrewrite.java.spring.boot4.MigrateAutoconfigurePackages

--- a/src/test/java/org/openrewrite/java/spring/boot4/MigrateToModularStartersTest.java
+++ b/src/test/java/org/openrewrite/java/spring/boot4/MigrateToModularStartersTest.java
@@ -812,6 +812,104 @@ class MigrateToModularStartersTest implements RewriteTest {
     }
 
     @Test
+    void addJdbcStarterWhenSb3JdbcAutoconfigurePackageIsUsed() {
+        rewriteRun(
+          mavenProject("app",
+            //language=xml
+            pomXml(
+              """
+                <project>
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>org.example</groupId>
+                    <artifactId>example</artifactId>
+                    <version>1.0-SNAPSHOT</version>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.springframework.boot</groupId>
+                            <artifactId>spring-boot-autoconfigure</artifactId>
+                            <version>3.3.0</version>
+                        </dependency>
+                    </dependencies>
+                </project>
+                """,
+              spec -> spec.after(pom -> assertThat(pom)
+                .contains("<artifactId>spring-boot-starter-jdbc</artifactId>")
+                .containsPattern("<version>4\\.0\\.\\d+</version>")
+                .actual())
+            ),
+            srcMainJava(
+              //language=java
+              java(
+                """
+                  import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
+
+                  class Config {
+                      Class<?> cfg = DataSourceAutoConfiguration.class;
+                  }
+                  """,
+                """
+                  import org.springframework.boot.jdbc.autoconfigure.DataSourceAutoConfiguration;
+
+                  class Config {
+                      Class<?> cfg = DataSourceAutoConfiguration.class;
+                  }
+                  """
+              )
+            )
+          )
+        );
+    }
+
+    @Test
+    void addHibernateModuleWhenSb3OrmJpaAutoconfigurePackageIsUsed() {
+        rewriteRun(
+          mavenProject("app",
+            //language=xml
+            pomXml(
+              """
+                <project>
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>org.example</groupId>
+                    <artifactId>example</artifactId>
+                    <version>1.0-SNAPSHOT</version>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.springframework.boot</groupId>
+                            <artifactId>spring-boot-autoconfigure</artifactId>
+                            <version>3.3.0</version>
+                        </dependency>
+                    </dependencies>
+                </project>
+                """,
+              spec -> spec.after(pom -> assertThat(pom)
+                .contains("<artifactId>spring-boot-hibernate</artifactId>")
+                .containsPattern("<version>4\\.0\\.\\d+</version>")
+                .actual())
+            ),
+            srcMainJava(
+              //language=java
+              java(
+                """
+                  import org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration;
+
+                  class Config {
+                      Class<?> cfg = HibernateJpaAutoConfiguration.class;
+                  }
+                  """,
+                """
+                  import org.springframework.boot.hibernate.autoconfigure.HibernateJpaAutoConfiguration;
+
+                  class Config {
+                      Class<?> cfg = HibernateJpaAutoConfiguration.class;
+                  }
+                  """
+              )
+            )
+          )
+        );
+    }
+
+    @Test
     void migrateOrmJpaTestPackageSplit() {
         rewriteRun(
           //language=java


### PR DESCRIPTION
## What

Add two `AddDependency` entries to `MigrateToModularStarters`, gated on the SB3 pre-rename autoconfigure namespaces:

| artifact | `onlyIfUsing` |
| --- | --- |
| `spring-boot-starter-jdbc` | `org.springframework.boot.autoconfigure.jdbc.*` |
| `spring-boot-hibernate` | `org.springframework.boot.autoconfigure.orm.jpa.*` |

Placed alongside the existing SB3-gated entries (`spring-boot-starter-data-jpa-test` on `boot.test.autoconfigure.orm.jpa.*`, `spring-boot-starter-jdbc-test` on `boot.test.autoconfigure.jdbc.*`), with `MigrateAutoconfigurePackages` continuing to run last in the same list.

## Why

Source that references SB3 autoconfigure types like `org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration` or `org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration` gets its imports rewritten by `MigrateAutoconfigurePackages` into the SB4 modular namespaces (`org.springframework.boot.hibernate.autoconfigure.*` / `org.springframework.boot.jdbc.autoconfigure.*`), but until now no `AddDependency` entry fired for the artifact that owns those new namespaces. The rewritten source then fails to compile because the referenced class isn't on the classpath.

The pattern in the file already handles this correctly for the test-scope variants — this PR extends it to the production-scope JDBC starter and to the `spring-boot-hibernate` module (which has no `spring-boot-starter-hibernate` equivalent per the Spring Boot 4.0 migration guide).

Gating on the SB3 namespace mirrors the convention used by every other entry in `MigrateToModularStarters`: the `onlyIfUsing` check fires before `MigrateAutoconfigurePackages` runs, so the customer's original SB3 code is what's matched.

## Test plan

- [x] `MigrateToModularStartersTest.addJdbcStarterWhenSb3JdbcAutoconfigurePackageIsUsed` — SB3 source referencing `DataSourceAutoConfiguration` triggers `spring-boot-starter-jdbc` and gets its import rewritten to the SB4 namespace.
- [x] `MigrateToModularStartersTest.addHibernateModuleWhenSb3OrmJpaAutoconfigurePackageIsUsed` — SB3 source referencing `HibernateJpaAutoConfiguration` triggers `spring-boot-hibernate` and gets its import rewritten to the SB4 namespace.
- [x] All existing `MigrateToModularStartersTest` tests continue to pass.