### PR TITLE
Include Jackson PropertyNamingStrategy migration in Spring Boot 2.5 upgrade

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -105,6 +105,7 @@ recipeDependencies {
     parserClasspath("jakarta.ws.rs:jakarta.ws.rs-api:4.0.0")
 
     testParserClasspath("com.fasterxml.jackson.core:jackson-core:2.20.+")
+    testParserClasspath("com.fasterxml.jackson.core:jackson-databind:2.19.+")
     testParserClasspath("com.nimbusds:nimbus-jose-jwt:9.13")
     testParserClasspath("io.projectreactor:reactor-core:3.6.3")
     testParserClasspath("io.springfox:springfox-core:3.+")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -105,6 +105,7 @@ recipeDependencies {
     parserClasspath("jakarta.ws.rs:jakarta.ws.rs-api:4.0.0")
 
     testParserClasspath("com.fasterxml.jackson.core:jackson-core:2.20.+")
+    // 2.19 is the last release with the deprecated `PropertyNamingStrategy` inner classes we migrate away from
     testParserClasspath("com.fasterxml.jackson.core:jackson-databind:2.19.+")
     testParserClasspath("com.nimbusds:nimbus-jose-jwt:9.13")
     testParserClasspath("io.projectreactor:reactor-core:3.6.3")

--- a/src/main/resources/META-INF/rewrite/spring-boot-25.yml
+++ b/src/main/resources/META-INF/rewrite/spring-boot-25.yml
@@ -73,6 +73,8 @@ recipeList:
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: org.springframework.boot.autoconfigure.web.ResourceProperties
       newFullyQualifiedTypeName: org.springframework.boot.autoconfigure.web.WebProperties$Resources
+  # Jackson 2.12 shipped with Spring Boot 2.5 relocated PropertyNamingStrategy inner classes and constants to PropertyNamingStrategies
+  - org.openrewrite.java.jackson.ReplacePropertyNamingStrategyConstants
 
   # Update properties
   - org.openrewrite.java.spring.boot2.SpringBootProperties_2_5

--- a/src/test/java/org/openrewrite/java/spring/boot2/MigrateJacksonPropertyNamingStrategyTest.java
+++ b/src/test/java/org/openrewrite/java/spring/boot2/MigrateJacksonPropertyNamingStrategyTest.java
@@ -17,7 +17,6 @@ package org.openrewrite.java.spring.boot2;
 
 import org.junit.jupiter.api.Test;
 import org.openrewrite.InMemoryExecutionContext;
-import org.openrewrite.config.Environment;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
@@ -28,12 +27,9 @@ class MigrateJacksonPropertyNamingStrategyTest implements RewriteTest {
 
     @Override
     public void defaults(RecipeSpec spec) {
-        spec.recipe(Environment.builder()
-            .scanRuntimeClasspath()
-            .build()
-            .activateRecipes("org.openrewrite.java.spring.boot2.UpgradeSpringBoot_2_5"))
+        spec.recipeFromResources("org.openrewrite.java.spring.boot2.UpgradeSpringBoot_2_5")
           .parser(JavaParser.fromJavaVersion().classpathFromResources(
-            new InMemoryExecutionContext(), "jackson-databind"));
+            new InMemoryExecutionContext(), "jackson-databind-2.19"));
     }
 
     @Test

--- a/src/test/java/org/openrewrite/java/spring/boot2/MigrateJacksonPropertyNamingStrategyTest.java
+++ b/src/test/java/org/openrewrite/java/spring/boot2/MigrateJacksonPropertyNamingStrategyTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.spring.boot2;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.InMemoryExecutionContext;
+import org.openrewrite.config.Environment;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+class MigrateJacksonPropertyNamingStrategyTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(Environment.builder()
+            .scanRuntimeClasspath()
+            .build()
+            .activateRecipes("org.openrewrite.java.spring.boot2.UpgradeSpringBoot_2_5"))
+          .parser(JavaParser.fromJavaVersion().classpathFromResources(
+            new InMemoryExecutionContext(), "jackson-databind"));
+    }
+
+    @Test
+    void replaceSnakeCaseStrategyInJsonNamingAnnotation() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+              import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+              @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+              class Test {
+              }
+              """,
+            """
+              import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+              import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+              @JsonNaming(SnakeCaseStrategy.class)
+              class Test {
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void replaceSnakeCaseConstant() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+
+              class Test {
+                  PropertyNamingStrategy strategy = PropertyNamingStrategy.SNAKE_CASE;
+              }
+              """,
+            """
+              import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+              import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+
+              class Test {
+                  PropertyNamingStrategy strategy = PropertyNamingStrategies.SNAKE_CASE;
+              }
+              """
+          )
+        );
+    }
+}

--- a/src/test/java/org/openrewrite/java/spring/boot2/SpringProfilesGroupPropertyTest.java
+++ b/src/test/java/org/openrewrite/java/spring/boot2/SpringProfilesGroupPropertyTest.java
@@ -16,7 +16,6 @@
 package org.openrewrite.java.spring.boot2;
 
 import org.junit.jupiter.api.Test;
-import org.openrewrite.config.Environment;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
@@ -27,10 +26,7 @@ class SpringProfilesGroupPropertyTest implements RewriteTest {
 
     @Override
     public void defaults(RecipeSpec spec) {
-        spec.recipe(Environment.builder()
-          .scanRuntimeClasspath("org.openrewrite.java.spring")
-          .build()
-          .activateRecipes("org.openrewrite.java.spring.boot2.SpringBootProperties_2_4"));
+        spec.recipeFromResources("org.openrewrite.java.spring.boot2.SpringBootProperties_2_4");
     }
 
     @Test

--- a/src/test/java/org/openrewrite/java/spring/boot2/UpdateMysqlDriverArtifactIdTest.java
+++ b/src/test/java/org/openrewrite/java/spring/boot2/UpdateMysqlDriverArtifactIdTest.java
@@ -19,7 +19,6 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.Issue;
-import org.openrewrite.config.Environment;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
@@ -35,10 +34,7 @@ import static org.openrewrite.maven.Assertions.pomXml;
 class UpdateMysqlDriverArtifactIdTest implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
-        spec.recipe(Environment.builder()
-          .scanRuntimeClasspath("org.openrewrite.java.spring")
-          .build()
-          .activateRecipes("org.openrewrite.java.spring.boot2.UpgradeSpringBoot_2_5"));
+        spec.recipeFromResources("org.openrewrite.java.spring.boot2.UpgradeSpringBoot_2_5");
     }
 
     @Nested

--- a/src/test/java/org/openrewrite/java/spring/boot2/UpgradeDependenciesTest.java
+++ b/src/test/java/org/openrewrite/java/spring/boot2/UpgradeDependenciesTest.java
@@ -17,7 +17,6 @@ package org.openrewrite.java.spring.boot2;
 
 import org.junit.jupiter.api.Test;
 import org.openrewrite.Issue;
-import org.openrewrite.config.Environment;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
@@ -26,10 +25,7 @@ import static org.openrewrite.maven.Assertions.pomXml;
 class UpgradeDependenciesTest implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
-        spec.recipe(Environment.builder()
-          .scanRuntimeClasspath("org.openrewrite.java.spring")
-          .build()
-          .activateRecipes("org.openrewrite.java.spring.boot2.UpgradeSpringBoot_2_4"));
+        spec.recipeFromResources("org.openrewrite.java.spring.boot2.UpgradeSpringBoot_2_4");
     }
 
     @Issue("https://github.com/openrewrite/rewrite-spring/issues/92")

--- a/src/test/java/org/openrewrite/java/spring/security5/ReplaceGlobalMethodSecurityWithMethodSecurityTest.java
+++ b/src/test/java/org/openrewrite/java/spring/security5/ReplaceGlobalMethodSecurityWithMethodSecurityTest.java
@@ -18,7 +18,6 @@ package org.openrewrite.java.spring.security5;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.InMemoryExecutionContext;
-import org.openrewrite.config.Environment;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
@@ -106,12 +105,7 @@ class ReplaceGlobalMethodSecurityWithMethodSecurityTest implements RewriteTest {
     @Test
     void removeUseAuthorizationManagerAttribute() {
         rewriteRun(
-          spec -> spec.recipe(
-            Environment.builder()
-              .scanRuntimeClasspath("org.openrewrite.java.spring")
-              .build()
-              .activateRecipes("org.openrewrite.java.spring.security5.ReplaceGlobalMethodSecurityWithMethodSecurityXml")
-          ),
+          spec -> spec.recipeFromResources("org.openrewrite.java.spring.security5.ReplaceGlobalMethodSecurityWithMethodSecurityXml"),
           //language=xml
           xml(
             """


### PR DESCRIPTION
## Summary

Spring Boot 2.5 ships with Jackson 2.12, which deprecated `com.fasterxml.jackson.databind.PropertyNamingStrategy`'s inner classes (`SnakeCaseStrategy`, `KebabCaseStrategy`, `UpperCamelCaseStrategy`, `LowerCamelCaseStrategy`, `LowerCaseStrategy`, `LowerDotCaseStrategy`) and companion constants (`SNAKE_CASE`, `KEBAB_CASE`, ...) in favor of the new `PropertyNamingStrategies` class. Later 2.x releases have removed the deprecated inner classes outright, so code using the old form compiles against 2.12 but fails against current 2.x.

`org.openrewrite.java.jackson.ReplacePropertyNamingStrategyConstants` already handles this rewrite (via `ChangeType` for the inner classes and `ReplaceConstantWithAnotherConstant` for the constants), but it wasn't reachable from any Spring Boot composite. This PR wires it into `UpgradeSpringBoot_2_5` so applications getting bumped to SB 2.5 receive the Jackson deprecation fix as part of the same upgrade path.

## Changes

- `spring-boot-25.yml` — add the recipe to `UpgradeSpringBoot_2_5`'s `recipeList` alongside the existing `ChangeType`-based deprecated-API replacements.
- `MigrateJacksonPropertyNamingStrategyTest` — new end-to-end test that activates `UpgradeSpringBoot_2_5` and asserts the rename fires for both the `@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)` annotation form and the `PropertyNamingStrategy.SNAKE_CASE` constant form.
- `build.gradle.kts` — pin `jackson-databind` to `2.19.+` on the test parser classpath (the newest 2.x that still contains the deprecated inner classes, so the parser can resolve the pre-migration form the test asserts on). Matches what `rewrite-jackson`'s own tests use.
- `classpath.tsv.gz` — regenerated by `./gradlew createTestTypeTable`.

## Test plan

- [x] `./gradlew test --tests "org.openrewrite.java.spring.boot2.MigrateJacksonPropertyNamingStrategyTest"` — both tests pass end-to-end through `UpgradeSpringBoot_2_5`.