### PR TITLE
Keep renamed Spring properties as nested YAML mappings

### DIFF
--- a/src/main/java/org/openrewrite/java/spring/ChangeSpringPropertyKey.java
+++ b/src/main/java/org/openrewrite/java/spring/ChangeSpringPropertyKey.java
@@ -20,6 +20,7 @@ import lombok.Value;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.*;
 import org.openrewrite.internal.ListUtils;
+import org.openrewrite.internal.NameCaseConvention;
 import org.openrewrite.internal.StringUtils;
 import org.openrewrite.java.AnnotationMatcher;
 import org.openrewrite.java.JavaIsoVisitor;
@@ -30,12 +31,16 @@ import org.openrewrite.kotlin.tree.K;
 import org.openrewrite.properties.search.FindProperties;
 import org.openrewrite.properties.tree.Properties;
 import org.openrewrite.yaml.ChangePropertyKey;
+import org.openrewrite.yaml.UnfoldProperties;
+import org.openrewrite.yaml.YamlIsoVisitor;
 import org.openrewrite.yaml.tree.Yaml;
 
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import static java.util.Collections.singletonList;
 import static java.util.regex.Pattern.quote;
 
 /**
@@ -82,6 +87,8 @@ public class ChangeSpringPropertyKey extends Recipe {
                 new org.openrewrite.properties.ChangePropertyKey(oldPropertyKey, newPropertyKey, true, false);
         org.openrewrite.properties.ChangePropertyKey subpropertiesChangePropertyKey =
                 new org.openrewrite.properties.ChangePropertyKey(quote(oldPropertyKey) + exceptRegex() + "(.+)", newPropertyKey + "$1", true, true);
+        UnfoldProperties unfoldNewPropertyKey =
+                new UnfoldProperties(null, singletonList("$." + newPropertyKey));
 
         return Preconditions.check(Preconditions.or(
                 new IsPossibleSpringConfigFile(),
@@ -92,7 +99,12 @@ public class ChangeSpringPropertyKey extends Recipe {
             @Override
             public @Nullable Tree visit(@Nullable Tree tree, ExecutionContext ctx) {
                 if (tree instanceof Yaml.Documents) {
-                    tree = yamlChangePropertyKey.getVisitor().visit(tree, ctx);
+                    boolean nested = isWrittenAsNestedMappings((Yaml.Documents) tree);
+                    Tree newTree = yamlChangePropertyKey.getVisitor().visit(tree, ctx);
+                    if (newTree != tree && nested) {
+                        newTree = unfoldNewPropertyKey.getVisitor().visit(newTree, ctx);
+                    }
+                    tree = newTree;
                 } else if (tree instanceof Properties.File) {
                     if (FindProperties.find((Properties.File) tree, newPropertyKey, true).isEmpty()) {
                         Tree newTree = propertiesChangePropertyKey.getVisitor().visit(tree, ctx);
@@ -108,6 +120,36 @@ public class ChangeSpringPropertyKey extends Recipe {
                 return tree;
             }
         });
+    }
+
+    /**
+     * Spring configuration accepts both `a: {b: {c: value}}` and `a.b.c: value`; only unfold the renamed key back into
+     * nested mappings when the original file spelled the old key out as one mapping entry per segment, such that we do
+     * not convert a deliberately flattened file to nested mappings.
+     */
+    private boolean isWrittenAsNestedMappings(Yaml.Documents documents) {
+        AtomicBoolean nested = new AtomicBoolean();
+        new YamlIsoVisitor<AtomicBoolean>() {
+            @Override
+            public Yaml.Mapping.Entry visitMappingEntry(Yaml.Mapping.Entry entry, AtomicBoolean found) {
+                if (!found.get() && !entry.getKey().getValue().contains(".") &&
+                        NameCaseConvention.matchesGlobRelaxedBinding(propertyPath(entry), oldPropertyKey)) {
+                    found.set(true);
+                }
+                return super.visitMappingEntry(entry, found);
+            }
+
+            private String propertyPath(Yaml.Mapping.Entry entry) {
+                StringBuilder path = new StringBuilder(entry.getKey().getValue());
+                for (Cursor c = getCursor().getParent(); c != null; c = c.getParent()) {
+                    if (c.getValue() instanceof Yaml.Mapping.Entry) {
+                        path.insert(0, ((Yaml.Mapping.Entry) c.getValue()).getKey().getValue() + '.');
+                    }
+                }
+                return path.toString();
+            }
+        }.visit(documents, nested);
+        return nested.get();
     }
 
     private String exceptRegex() {

--- a/src/main/java/org/openrewrite/java/spring/ChangeSpringPropertyKey.java
+++ b/src/main/java/org/openrewrite/java/spring/ChangeSpringPropertyKey.java
@@ -128,8 +128,7 @@ public class ChangeSpringPropertyKey extends Recipe {
      * not convert a deliberately flattened file to nested mappings.
      */
     private boolean isWrittenAsNestedMappings(Yaml.Documents documents) {
-        AtomicBoolean nested = new AtomicBoolean();
-        new YamlIsoVisitor<AtomicBoolean>() {
+        return new YamlIsoVisitor<AtomicBoolean>() {
             @Override
             public Yaml.Mapping.Entry visitMappingEntry(Yaml.Mapping.Entry entry, AtomicBoolean found) {
                 if (!found.get() && !entry.getKey().getValue().contains(".") &&
@@ -148,8 +147,7 @@ public class ChangeSpringPropertyKey extends Recipe {
                 }
                 return path.toString();
             }
-        }.visit(documents, nested);
-        return nested.get();
+        }.reduce(documents, new AtomicBoolean()).get();
     }
 
     private String exceptRegex() {

--- a/src/test/java/org/openrewrite/java/spring/ChangeSpringPropertyKeyTest.java
+++ b/src/test/java/org/openrewrite/java/spring/ChangeSpringPropertyKeyTest.java
@@ -208,6 +208,46 @@ class ChangeSpringPropertyKeyTest implements RewriteTest {
         );
     }
 
+    @Issue("https://github.com/openrewrite/rewrite-spring/issues/581")
+    @Test
+    void keepFlattenedYamlFlat() {
+        rewriteRun(
+          spec -> spec.recipe(new ChangeSpringPropertyKey("spring.resources", "spring.web.resources", null)),
+          mavenProject("project",
+            srcMainResources(
+              //language=yaml
+              yaml(
+                """
+                  spring.resources.chain.strategy.content.enabled: true
+                  spring.resources.chain.strategy.content.paths:
+                    - /foo/**
+                    - /bar/**
+                  """,
+                """
+                  spring.web.resources.chain.strategy.content.enabled: true
+                  spring.web.resources.chain.strategy.content.paths:
+                    - /foo/**
+                    - /bar/**
+                  """,
+                spec -> spec.path("application.yml")
+              ),
+              //language=yaml
+              yaml(
+                """
+                  spring:
+                    resources.chain.strategy.content.enabled: true
+                  """,
+                """
+                  spring:
+                    web.resources.chain.strategy.content.enabled: true
+                  """,
+                spec -> spec.path("application-dev.yml")
+              )
+            )
+          )
+        );
+    }
+
     @Test
     void except() {
         rewriteRun(

--- a/src/test/java/org/openrewrite/java/spring/ChangeSpringPropertyKeyTest.java
+++ b/src/test/java/org/openrewrite/java/spring/ChangeSpringPropertyKeyTest.java
@@ -56,7 +56,8 @@ class ChangeSpringPropertyKeyTest implements RewriteTest {
                   """,
                 """
                   server:
-                    servlet.path: /tmp/my-server-path
+                    servlet:
+                      path: /tmp/my-server-path
                   """
               ))
           )
@@ -91,7 +92,10 @@ class ChangeSpringPropertyKeyTest implements RewriteTest {
                 """
                   server:
                     port: 8888
-                  servlet.session.cookie.path: /tmp/my-server-path
+                  servlet:
+                    session:
+                      cookie:
+                        path: /tmp/my-server-path
                   """
               )
             )));
@@ -130,17 +134,78 @@ class ChangeSpringPropertyKeyTest implements RewriteTest {
                   """,
                 """
                   spring:
-                    web.resources:
-                      chain:
-                        strategy:
-                          content:
-                            enabled: true
-                            paths:
-                              - /foo/**
-                              - /bar/**
+                    web:
+                      resources:
+                        chain:
+                          strategy:
+                            content:
+                              enabled: true
+                              paths:
+                                - /foo/**
+                                - /bar/**
                   """
               )
             )));
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite-spring/issues/353")
+    @Test
+    void nestYamlMappings() {
+        rewriteRun(
+          spec -> spec.recipe(new ChangeSpringPropertyKey("org.test.property", "org.test2.property", null)),
+          mavenProject("project",
+            srcMainResources(
+              //language=yaml
+              yaml(
+                """
+                  org:
+                    test:
+                      property: false
+                  """,
+                """
+                  org:
+                    test2:
+                      property: false
+                  """,
+                spec -> spec.path("application.yml")
+              )
+            )
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite-spring/issues/353")
+    @Test
+    void nestYamlMappingsWithMultipleSubproperties() {
+        rewriteRun(
+          spec -> spec.recipe(new ChangeSpringPropertyKey("ezpaas.oauth2.client.cps", "ezpaas.oauth2.restclient.cps", null)),
+          mavenProject("project",
+            srcMainResources(
+              //language=yaml
+              yaml(
+                """
+                  ezpaas:
+                    oauth2:
+                      client:
+                        cps:
+                          token-relay: false
+                          token-uri: https://localhost.com/v1
+                          client-secret: my-secret-key
+                  """,
+                """
+                  ezpaas:
+                    oauth2:
+                      restclient:
+                        cps:
+                          token-relay: false
+                          token-uri: https://localhost.com/v1
+                          client-secret: my-secret-key
+                  """,
+                spec -> spec.path("application.yml")
+              )
+            )
+          )
+        );
     }
 
     @Test
@@ -197,7 +262,8 @@ class ChangeSpringPropertyKeyTest implements RewriteTest {
                   """,
                 """
                   logging:
-                    file.name: foo.txt
+                    file:
+                      name: foo.txt
                   """
               ),
               yaml(
@@ -311,9 +377,11 @@ class ChangeSpringPropertyKeyTest implements RewriteTest {
                   spring:
                     data:
                       redis:
-                        ssl.enabled: true
+                        ssl:
+                          enabled: true
                     cassandra:
-                      ssl.enabled: true
+                      ssl:
+                        enabled: true
                   """
               )
             )

--- a/src/test/java/org/openrewrite/java/spring/ChangeSpringPropertyKeyTest.java
+++ b/src/test/java/org/openrewrite/java/spring/ChangeSpringPropertyKeyTest.java
@@ -148,7 +148,7 @@ class ChangeSpringPropertyKeyTest implements RewriteTest {
             )));
     }
 
-    @Issue("https://github.com/openrewrite/rewrite-spring/issues/353")
+    @Issue("https://github.com/openrewrite/rewrite-spring/issues/1107")
     @Test
     void nestYamlMappings() {
         rewriteRun(
@@ -174,7 +174,7 @@ class ChangeSpringPropertyKeyTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite-spring/issues/353")
+    @Issue("https://github.com/openrewrite/rewrite-spring/issues/1107")
     @Test
     void nestYamlMappingsWithMultipleSubproperties() {
         rewriteRun(

--- a/src/test/java/org/openrewrite/java/spring/boot2/UpgradeSpringBoot2ConfigurationTest.java
+++ b/src/test/java/org/openrewrite/java/spring/boot2/UpgradeSpringBoot2ConfigurationTest.java
@@ -67,7 +67,9 @@ class UpgradeSpringBoot2ConfigurationTest implements RewriteTest {
                       active: dev
                   ---
                   spring:
-                    config.activate.on-profile: prod
+                    config:
+                      activate:
+                        on-profile: prod
                   """
               )
             )

--- a/src/test/java/org/openrewrite/java/spring/boot3/MigrateEndpointAccessValueSpring34Test.java
+++ b/src/test/java/org/openrewrite/java/spring/boot3/MigrateEndpointAccessValueSpring34Test.java
@@ -66,7 +66,8 @@ class MigrateEndpointAccessValueSpring34Test implements RewriteTest {
                 """
                   management:
                     endpoints:
-                      access.default: read-only
+                      access:
+                        default: read-only
                   """,
                 sourceSpecs -> sourceSpecs.markers(JavaSourceSet.build("test", List.of()))
               )
@@ -98,7 +99,8 @@ class MigrateEndpointAccessValueSpring34Test implements RewriteTest {
                 """
                   management:
                     endpoints:
-                      access.default: none
+                      access:
+                        default: none
                   """,
                 sourceSpecs -> sourceSpecs.markers(JavaSourceSet.build("test", List.of()))
               )

--- a/src/test/java/org/openrewrite/java/spring/boot4/SpringBoot41PropertiesTest.java
+++ b/src/test/java/org/openrewrite/java/spring/boot4/SpringBoot41PropertiesTest.java
@@ -71,11 +71,13 @@ class SpringBoot41PropertiesTest implements RewriteTest {
                 """,
               """
                 logging:
-                  logback.rollingpolicy.clean-history-on-start: true
-                  logback.rollingpolicy.max-history: 7
-                  logback.rollingpolicy.max-file-size: 10MB
-                  logback.rollingpolicy.total-size-cap: 1GB
-                  logback.rollingpolicy.file-name-pattern: app-%d.log
+                  logback:
+                    rollingpolicy:
+                      clean-history-on-start: true
+                      max-history: 7
+                      max-file-size: 10MB
+                      total-size-cap: 1GB
+                      file-name-pattern: app-%d.log
                 """
             )
           )

--- a/src/test/java/org/openrewrite/java/spring/boot4/UpgradeSpringBoot40ConfigurationTest.java
+++ b/src/test/java/org/openrewrite/java/spring/boot4/UpgradeSpringBoot40ConfigurationTest.java
@@ -100,8 +100,10 @@ class UpgradeSpringBoot40ConfigurationTest implements RewriteTest {
                 """
                   spring:
                     jackson:
-                        datatype.datetime.write-dates-as-timestamps: true
-                        datatype.datetime.adjust-dates-to-context-time-zone: false
+                      datatype:
+                        datetime:
+                          write-dates-as-timestamps: true
+                          adjust-dates-to-context-time-zone: false
                   """
               )
             )

--- a/src/test/java/org/openrewrite/java/spring/cloud2022/MigrateProjectTest.java
+++ b/src/test/java/org/openrewrite/java/spring/cloud2022/MigrateProjectTest.java
@@ -64,7 +64,11 @@ class MigrateProjectTest implements RewriteTest {
                               correlation-enabled: true
                   """,
                 """
-                  management.tracing.baggage.correlation.enabled: true
+                  management:
+                    tracing:
+                      baggage:
+                        correlation:
+                          enabled: true
                   """,
                 s -> s.path("src/main/resources/application.yml")
               )


### PR DESCRIPTION
## What's changed?

- Fixes #1107.

`ChangeSpringPropertyKey` delegates YAML to `org.openrewrite.yaml.ChangePropertyKey`, which inserts the relocated key as one dot-separated mapping entry. On a file written as nested mappings the nesting is lost:

```yaml
# before
org:
  test:
    property: false

# after (current)
org:
  test2.property: false

# after (this PR)
org:
  test2:
    property: false
```

Both spellings bind to the same Spring property, so this was never wrong output, but it does not round-trip the file's own style and reads badly in review.

The renamed key is now unfolded back into mappings via `UnfoldProperties`, scoped with `applyTo` so nothing else in the file is touched. That only happens when the *old* key was itself spelled out as one mapping entry per segment — a file that deliberately writes `logging.file: foo.txt` keeps its dotted style, which `avoidRegenerativeChangesInYaml` covers.

The existing YAML expectations that asserted the flattened output are updated across `UpgradeSpringBoot2ConfigurationTest`, `MigrateEndpointAccessValueSpring34Test`, `SpringBoot41PropertiesTest`, `UpgradeSpringBoot40ConfigurationTest` and `MigrateProjectTest`.

## Anything in particular you'd like reviewers to focus on?

**Depends on openrewrite/rewrite#8348.** Two tests here (`nestYamlMappingsWithMultipleSubproperties` and `migrateJacksonDateTimeProperties`) fail until that snapshot lands — a separate `IndentsVisitor` bug over-indents the relocated key when the rename happens three or more levels deep, which is exactly where nesting is most visible. Everything else passes against the current snapshot.

Worth a look at `isWrittenAsNestedMappings`: the rule is "unfold only if the old key existed as a dot-free mapping entry", which preserves style for flattened files but does mean a mixed-style file follows whichever style the old key used.

### Related issues this does *not* close

- #353 — the format half is fixed here, but its other complaint, top-level comments being duplicated onto the relocated property in multi-document YAML, still reproduces.
- #436 — still fails for an unrelated reason (duplicate `file:` keys, recipe is not idempotent).
- #581 — coalesced/dotted keys still aren't matched; this PR preserves that style rather than changing what gets matched.