### PR TITLE
Apply `except` as a regex to YAML, and merge relocated sections

### DIFF
--- a/src/main/java/org/openrewrite/java/spring/ChangeSpringPropertyKey.java
+++ b/src/main/java/org/openrewrite/java/spring/ChangeSpringPropertyKey.java
@@ -31,15 +31,22 @@ import org.openrewrite.kotlin.tree.K;
 import org.openrewrite.properties.search.FindProperties;
 import org.openrewrite.properties.tree.Properties;
 import org.openrewrite.yaml.ChangePropertyKey;
+import org.openrewrite.yaml.MergeYamlVisitor;
 import org.openrewrite.yaml.UnfoldProperties;
 import org.openrewrite.yaml.YamlIsoVisitor;
 import org.openrewrite.yaml.tree.Yaml;
 
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static java.util.regex.Pattern.quote;
 
@@ -81,8 +88,6 @@ public class ChangeSpringPropertyKey extends Recipe {
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
-        ChangePropertyKey yamlChangePropertyKey =
-                new ChangePropertyKey(oldPropertyKey, newPropertyKey, true, except, null);
         org.openrewrite.properties.ChangePropertyKey propertiesChangePropertyKey =
                 new org.openrewrite.properties.ChangePropertyKey(oldPropertyKey, newPropertyKey, true, false);
         org.openrewrite.properties.ChangePropertyKey subpropertiesChangePropertyKey =
@@ -99,10 +104,15 @@ public class ChangeSpringPropertyKey extends Recipe {
             @Override
             public @Nullable Tree visit(@Nullable Tree tree, ExecutionContext ctx) {
                 if (tree instanceof Yaml.Documents) {
-                    boolean nested = isWrittenAsNestedMappings((Yaml.Documents) tree);
-                    Tree newTree = yamlChangePropertyKey.getVisitor().visit(tree, ctx);
-                    if (newTree != tree && nested) {
-                        newTree = unfoldNewPropertyKey.getVisitor().visit(newTree, ctx);
+                    Yaml.Documents documents = (Yaml.Documents) tree;
+                    boolean nested = isWrittenAsNestedMappings(documents);
+                    Tree newTree = new ChangePropertyKey(oldPropertyKey, newPropertyKey, true, excludedSubkeys(documents), null)
+                            .getVisitor().visit(tree, ctx);
+                    if (newTree != tree) {
+                        if (nested) {
+                            newTree = unfoldNewPropertyKey.getVisitor().visit(newTree, ctx);
+                        }
+                        newTree = new MergeRelocatedSectionsVisitor().visit(newTree, ctx);
                     }
                     tree = newTree;
                 } else if (tree instanceof Properties.File) {
@@ -132,22 +142,79 @@ public class ChangeSpringPropertyKey extends Recipe {
             @Override
             public Yaml.Mapping.Entry visitMappingEntry(Yaml.Mapping.Entry entry, AtomicBoolean found) {
                 if (!found.get() && !entry.getKey().getValue().contains(".") &&
-                        NameCaseConvention.matchesGlobRelaxedBinding(propertyPath(entry), oldPropertyKey)) {
+                        NameCaseConvention.matchesGlobRelaxedBinding(propertyPath(entry, getCursor()), oldPropertyKey)) {
                     found.set(true);
                 }
                 return super.visitMappingEntry(entry, found);
             }
+        }.reduce(documents, new AtomicBoolean()).get();
+    }
 
-            private String propertyPath(Yaml.Mapping.Entry entry) {
-                StringBuilder path = new StringBuilder(entry.getKey().getValue());
-                for (Cursor c = getCursor().getParent(); c != null; c = c.getParent()) {
-                    if (c.getValue() instanceof Yaml.Mapping.Entry) {
-                        path.insert(0, ((Yaml.Mapping.Entry) c.getValue()).getKey().getValue() + '.');
+    /**
+     * `except` is documented as a regex, and applied as such to properties files, but
+     * `org.openrewrite.yaml.ChangePropertyKey` matches it as a glob. Resolve the regex against the subkeys actually
+     * present under `oldPropertyKey` here, so both formats exclude the same subproperties.
+     */
+    private @Nullable List<String> excludedSubkeys(Yaml.Documents documents) {
+        if (except == null || except.isEmpty()) {
+            return except;
+        }
+        Pattern exceptedSubkey = Pattern.compile("(?:" + String.join("|", except) + ")\\b.*", Pattern.DOTALL);
+        Set<String> subkeys = new YamlIsoVisitor<Set<String>>() {
+            @Override
+            public Yaml.Mapping.Entry visitMappingEntry(Yaml.Mapping.Entry entry, Set<String> subkeys) {
+                if (entry.getValue() instanceof Yaml.Mapping &&
+                        NameCaseConvention.matchesGlobRelaxedBinding(propertyPath(entry, getCursor()), oldPropertyKey)) {
+                    for (Yaml.Mapping.Entry child : ((Yaml.Mapping) entry.getValue()).getEntries()) {
+                        String subkey = child.getKey().getValue();
+                        if (exceptedSubkey.matcher(subkey).matches()) {
+                            subkeys.add(subkey);
+                        }
                     }
                 }
-                return path.toString();
+                return super.visitMappingEntry(entry, subkeys);
             }
-        }.reduce(documents, new AtomicBoolean()).get();
+        }.reduce(documents, new LinkedHashSet<>());
+        return new ArrayList<>(subkeys);
+    }
+
+    /**
+     * Relocating a property into a section that already exists leaves two mapping entries with the same key; merge
+     * those back together, limited to the segments of `newPropertyKey` so unrelated duplicates are left alone.
+     */
+    private class MergeRelocatedSectionsVisitor extends YamlIsoVisitor<ExecutionContext> {
+        private final List<String> newKeySegments = asList(newPropertyKey.split("\\."));
+
+        @Override
+        public Yaml.Mapping visitMapping(Yaml.Mapping mapping, ExecutionContext ctx) {
+            Yaml.Mapping m = super.visitMapping(mapping, ctx);
+            Map<String, Yaml.Mapping.Entry> merged = new LinkedHashMap<>();
+            boolean changed = false;
+            for (Yaml.Mapping.Entry entry : m.getEntries()) {
+                String key = entry.getKey().getValue();
+                Yaml.Mapping.Entry existing = merged.get(key);
+                if (existing == null || !newKeySegments.contains(key) ||
+                        entry.getPrefix().contains("#") || existing.getPrefix().contains("#")) {
+                    merged.put(key, entry);
+                    continue;
+                }
+                Yaml value = new MergeYamlVisitor<>(existing.getValue(), entry.getValue(), false, null, null, null)
+                        .visitNonNull(existing.getValue(), ctx, getCursor());
+                merged.put(key, existing.withValue((Yaml.Block) value));
+                changed = true;
+            }
+            return changed ? m.withEntries(new ArrayList<>(merged.values())) : m;
+        }
+    }
+
+    private static String propertyPath(Yaml.Mapping.Entry entry, Cursor cursor) {
+        StringBuilder path = new StringBuilder(entry.getKey().getValue());
+        for (Cursor c = cursor.getParent(); c != null; c = c.getParent()) {
+            if (c.getValue() instanceof Yaml.Mapping.Entry) {
+                path.insert(0, ((Yaml.Mapping.Entry) c.getValue()).getKey().getValue() + '.');
+            }
+        }
+        return path.toString();
     }
 
     private String exceptRegex() {

--- a/src/main/java/org/openrewrite/java/spring/ChangeSpringPropertyKey.java
+++ b/src/main/java/org/openrewrite/java/spring/ChangeSpringPropertyKey.java
@@ -37,10 +37,8 @@ import org.openrewrite.yaml.YamlIsoVisitor;
 import org.openrewrite.yaml.tree.Yaml;
 
 import java.util.ArrayList;
-import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.regex.Matcher;
@@ -188,22 +186,30 @@ public class ChangeSpringPropertyKey extends Recipe {
         @Override
         public Yaml.Mapping visitMapping(Yaml.Mapping mapping, ExecutionContext ctx) {
             Yaml.Mapping m = super.visitMapping(mapping, ctx);
-            Map<String, Yaml.Mapping.Entry> merged = new LinkedHashMap<>();
-            boolean changed = false;
-            for (Yaml.Mapping.Entry entry : m.getEntries()) {
-                String key = entry.getKey().getValue();
-                Yaml.Mapping.Entry existing = merged.get(key);
-                if (existing == null || !newKeySegments.contains(key) ||
-                        entry.getPrefix().contains("#") || existing.getPrefix().contains("#")) {
-                    merged.put(key, entry);
-                    continue;
+            List<Yaml.Mapping.Entry> entries = m.getEntries();
+            return m.withEntries(ListUtils.map(entries, (i, entry) -> {
+                if (!isMergeable(entry)) {
+                    return entry;
                 }
-                Yaml value = new MergeYamlVisitor<>(existing.getValue(), entry.getValue(), false, null, null, null)
-                        .visitNonNull(existing.getValue(), ctx, getCursor());
-                merged.put(key, existing.withValue((Yaml.Block) value));
-                changed = true;
-            }
-            return changed ? m.withEntries(new ArrayList<>(merged.values())) : m;
+                Yaml.Block value = entry.getValue();
+                for (int j = 0; j < entries.size(); j++) {
+                    Yaml.Mapping.Entry other = entries.get(j);
+                    if (i == j || !isMergeable(other) ||
+                            !entry.getKey().getValue().equals(other.getKey().getValue())) {
+                        continue;
+                    }
+                    if (j < i) {
+                        return null; // already merged into the first entry with this key
+                    }
+                    value = (Yaml.Block) new MergeYamlVisitor<>(value, other.getValue(), false, null, null, null)
+                            .visitNonNull(value, ctx, getCursor());
+                }
+                return entry.withValue(value);
+            }));
+        }
+
+        private boolean isMergeable(Yaml.Mapping.Entry entry) {
+            return newKeySegments.contains(entry.getKey().getValue()) && !entry.getPrefix().contains("#");
         }
     }
 

--- a/src/test/java/org/openrewrite/java/spring/ChangeSpringPropertyKeyTest.java
+++ b/src/test/java/org/openrewrite/java/spring/ChangeSpringPropertyKeyTest.java
@@ -15,7 +15,6 @@
  */
 package org.openrewrite.java.spring;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.InMemoryExecutionContext;
@@ -331,6 +330,80 @@ class ChangeSpringPropertyKeyTest implements RewriteTest {
         );
     }
 
+    @Issue("https://github.com/openrewrite/rewrite-spring/issues/436")
+    @Test
+    void exceptAppliesAsRegexToYamlAsWellAsProperties() {
+        rewriteRun(
+          spec -> spec.recipe(new ChangeSpringPropertyKey("logging.file", "logging.file.name", List.of(".+"))),
+          mavenProject("project",
+            srcMainResources(
+              //language=properties
+              properties(
+                """
+                  logging.file.max-size = 10MB
+                  """
+              ),
+              //language=yaml
+              yaml(
+                """
+                  logging:
+                    file:
+                      max-size: 10MB
+                  """
+              ),
+              //language=properties
+              properties(
+                """
+                  logging.file = foo.txt
+                  """,
+                """
+                  logging.file.name = foo.txt
+                  """
+              ),
+              //language=yaml
+              yaml(
+                """
+                  logging:
+                    file: foo.txt
+                  """,
+                """
+                  logging:
+                    file:
+                      name: foo.txt
+                  """
+              )
+            )
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite-spring/issues/436")
+    @Test
+    void relocatedPropertyMergesIntoExistingSection() {
+        rewriteRun(
+          spec -> spec.recipe(new ChangeSpringPropertyKey("logging.path", "logging.file.path", null)),
+          mavenProject("project",
+            srcMainResources(
+              //language=yaml
+              yaml(
+                """
+                  logging:
+                    file:
+                      max-size: 10MB
+                    path: ${user.home}/some-folder
+                  """,
+                """
+                  logging:
+                    file:
+                      max-size: 10MB
+                      path: ${user.home}/some-folder
+                  """
+              )
+            )
+          )
+        );
+    }
+
     @Issue("https://github.com/openrewrite/rewrite-spring/issues/432")
     @Test
     void loggingFileSubproperties() {
@@ -429,7 +502,6 @@ class ChangeSpringPropertyKeyTest implements RewriteTest {
         );
     }
 
-    @Disabled
     @Issue("https://github.com/openrewrite/rewrite-spring/issues/436")
     @Test
     void loggingFileSubpropertiesYaml() {


### PR DESCRIPTION
## What's changed?

- Fixes #436.

Two separate defects kept `logging.file` from surviving `UpgradeSpringBoot_2_2` in YAML, and left the recipe non-idempotent:

- **1. `except` was a regex for properties but a glob for YAML.** The option is documented as "Regex", and `ChangeSpringPropertyKey` builds a real regex for the properties path, but it hands the same list straight to `org.openrewrite.yaml.ChangePropertyKey`, which matches it as a glob. So `except: [ .+ ]` — the way `spring-boot-22-properties.yml` says "only rename `logging.file` when it is a leaf" — excluded nothing at all in YAML, and a `logging.file` mapping got buried under `logging.file.name`. The regex is now resolved against the subkeys actually present under the old key, and those literal subkeys are passed on to the YAML recipe, so both formats exclude the same subproperties. This is the mismatch @nmck257 [called out on #581](https://github.com/openrewrite/rewrite-spring/issues/581#issuecomment-2312150334).

**2. Relocating a property into a section that already exists produced a duplicate key.** `logging.path` → `logging.file.path` appended a second `file:` entry next to the existing one, and the next cycle then renamed the property again — so the recipe never converged. Duplicate entries are now merged back together, limited to the segments of the new key so unrelated duplicates elsewhere in the file are left alone.

```yaml
# before
logging:
  file:
    max-history: 10
    max-size: 10MB
  level:
    org: INFO
  path: ${user.home}/some-folder

# after (before this PR, and still changing on the next cycle)
logging:
  file:
    name:
      max-history: 10
      max-size: 10MB
  level:
    org: INFO
  file:
    name:
      path: ${user.home}/some-folder

# after (this PR)
logging:
  file:
    max-history: 10
    max-size: 10MB
    path: ${user.home}/some-folder
  level:
    org: INFO
```

`ChangeSpringPropertyKeyTest#loggingFileSubpropertiesYaml` — replicated in feb28d5 back in 2023 and `@Disabled` ever since — is enabled and passes. Two smaller tests pin each half of the fix on its own.

## Anything in particular you'd like reviewers to focus on?

`MergeRelocatedSectionsVisitor` deliberately does not reuse `org.openrewrite.yaml.MergeDuplicateSectionsVisitor`: that one treats any non-newline entry prefix as a comment and bails, so it never merges anything indented, which is every case here. This visitor skips entries whose prefix actually contains a `#` instead.

`excludedSubkeys` only inspects direct children of a mapping spelled out under the old key, matching how the `except` option is documented. A file that writes the old key in flattened form (`logging.file.max-size: 10MB`) is unchanged in behaviour by this PR.

### Related issues this does *not* close

- #353 — the comment half. `org.openrewrite.yaml.ChangePropertyKey` copies `scope.getPrefix()` onto the relocated entry ([`InsertSubpropertyVisitor`, line 265](https://github.com/openrewrite/rewrite/blob/main/rewrite-yaml/src/main/java/org/openrewrite/yaml/ChangePropertyKey.java#L265)); in a multi-document file that prefix carries the document's leading comment, so it gets emitted twice. That needs fixing upstream in `openrewrite/rewrite`, where it affects every consumer.