### PR TITLE
pin ambiguous classpathFromResources() artifact versions in tests

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -187,7 +187,6 @@ recipeDependencies {
     testParserClasspath("org.springframework.security:spring-security-web:6.2.+")
 
     testParserClasspath("org.springframework:spring-context:6.0.+")
-    testParserClasspath("org.springframework:spring-context:6.2.+")
     testParserClasspath("org.springframework:spring-orm:5.3.+")
     testParserClasspath("org.springframework:spring-test:5.3.+")
     testParserClasspath("org.springframework:spring-tx:4.1.+")

--- a/src/main/java/org/openrewrite/java/spring/batch/AddTransactionManagerToTaskletAndChunk.java
+++ b/src/main/java/org/openrewrite/java/spring/batch/AddTransactionManagerToTaskletAndChunk.java
@@ -173,7 +173,10 @@ public class AddTransactionManagerToTaskletAndChunk extends Recipe {
                 return JavaTemplate.builder("#{any(org.springframework.batch.repeat.CompletionPolicy)}, " + tmName)
                         .contextSensitive()
                         .javaParser(JavaParser.fromJavaVersion()
-                                .classpathFromResources(ctx, "spring-batch-core-5.1.+", "spring-batch-infrastructure-5.1.+", "spring-tx-5.+"))
+                                .classpathFromResources(ctx,
+                                        "spring-batch-core-5.1.+",
+                                        "spring-batch-infrastructure-5.1.+",
+                                        "spring-tx-5.+"))
                         .build()
                         .apply(getCursor(), mi.getCoordinates().replaceArguments(), mi.getArguments().get(0));
             }

--- a/src/main/java/org/openrewrite/java/spring/boot2/GetErrorAttributes.java
+++ b/src/main/java/org/openrewrite/java/spring/boot2/GetErrorAttributes.java
@@ -71,7 +71,10 @@ public class GetErrorAttributes extends Recipe {
                             .contextSensitive()
                             .imports(parserImports)
                             .javaParser(JavaParser.fromJavaVersion()
-                                    .classpathFromResources(ctx, "spring-boot-2.*", "spring-boot-autoconfigure-2.*", "spring-web-5.*"))
+                                    .classpathFromResources(ctx,
+                                            "spring-boot-2.*",
+                                            "spring-boot-autoconfigure-2.*",
+                                            "spring-web-5.*"))
                             .build().apply(
                                     getCursor(),
                                     mi.getCoordinates().replaceArguments(),
@@ -83,7 +86,10 @@ public class GetErrorAttributes extends Recipe {
                             .contextSensitive()
                             .imports(parserImports)
                             .javaParser(JavaParser.fromJavaVersion()
-                                    .classpathFromResources(ctx, "spring-boot-2.*", "spring-boot-autoconfigure-2.*", "spring-web-5.*"))
+                                    .classpathFromResources(ctx,
+                                            "spring-boot-2.*",
+                                            "spring-boot-autoconfigure-2.*",
+                                            "spring-web-5.*"))
                             .build()
                             .apply(
                                     getCursor(),
@@ -96,7 +102,10 @@ public class GetErrorAttributes extends Recipe {
                             .contextSensitive()
                             .imports(parserImports)
                             .javaParser(JavaParser.fromJavaVersion()
-                                    .classpathFromResources(ctx, "spring-boot-2.*", "spring-boot-autoconfigure-2.*", "spring-web-5.*"))
+                                    .classpathFromResources(ctx,
+                                            "spring-boot-2.*",
+                                            "spring-boot-autoconfigure-2.*",
+                                            "spring-web-5.*"))
                             .build()
                             .apply(
                                     getCursor(),

--- a/src/main/java/org/openrewrite/java/spring/boot2/MigrateActuatorMediaTypeToApiVersion.java
+++ b/src/main/java/org/openrewrite/java/spring/boot2/MigrateActuatorMediaTypeToApiVersion.java
@@ -61,7 +61,9 @@ public class MigrateActuatorMediaTypeToApiVersion extends Recipe {
                                 maybeAddImport("org.springframework.http.MediaType");
                                 mi = JavaTemplate.builder("MediaType.asMediaType(ApiVersion.#{}.getProducedMimeType())")
                                         .javaParser(JavaParser.fromJavaVersion()
-                                                .classpathFromResources(ctx, "spring-web-5.*", "spring-boot-actuator-2",
+                                                .classpathFromResources(ctx,
+                                                        "spring-web-5.*",
+                                                        "spring-boot-actuator-2",
                                                         "spring-core-5.*"))
                                         .imports("org.springframework.http.MediaType",
                                                 "org.springframework.boot.actuate.endpoint.ApiVersion")

--- a/src/main/java/org/openrewrite/java/spring/boot3/AddSetUseTrailingSlashMatch.java
+++ b/src/main/java/org/openrewrite/java/spring/boot3/AddSetUseTrailingSlashMatch.java
@@ -107,7 +107,10 @@ public class AddSetUseTrailingSlashMatch extends Recipe {
                                         ".setUseTrailingSlashMatch(true); }")
                         .contextSensitive()
                         .javaParser(JavaParser.fromJavaVersion()
-                                .classpathFromResources(ctx, "spring-webmvc-5", "spring-context-5", "spring-web-5"))
+                                .classpathFromResources(ctx,
+                                        "spring-webmvc-5",
+                                        "spring-context-5",
+                                        "spring-web-5"))
                         .imports(WEB_MVC_PATH_MATCH_CONFIGURER,
                                 "org.springframework.web.servlet.config.annotation.WebMvcConfigurer",
                                 "org.springframework.context.annotation.Configuration")
@@ -119,7 +122,10 @@ public class AddSetUseTrailingSlashMatch extends Recipe {
                                                 ".setUseTrailingSlashMatch(true); }")
                                 .contextSensitive()
                                 .javaParser(JavaParser.fromJavaVersion()
-                                        .classpathFromResources(ctx, "spring-webflux-5", "spring-context-5", "spring-web-5"))
+                                        .classpathFromResources(ctx,
+                                                "spring-webflux-5",
+                                                "spring-context-5",
+                                                "spring-web-5"))
                                 .imports(WEB_FLUX_PATH_MATCH_CONFIGURER,
                                         "org.springframework.web.reactive.config.WebFluxConfigurer",
                                         "org.springframework.context.annotation.Configuration")
@@ -148,7 +154,10 @@ public class AddSetUseTrailingSlashMatch extends Recipe {
                     JavaTemplate webMvcTemplate = JavaTemplate.builder("#{any()}.setUseTrailingSlashMatch(true);")
                             .contextSensitive()
                             .javaParser(JavaParser.fromJavaVersion()
-                                    .classpathFromResources(ctx, "spring-webmvc-5", "spring-context-5", "spring-web-5"))
+                                    .classpathFromResources(ctx,
+                                            "spring-webmvc-5",
+                                            "spring-context-5",
+                                            "spring-web-5"))
                             .imports(WEB_MVC_PATH_MATCH_CONFIGURER,
                                     "org.springframework.web.servlet.config.annotation.WebMvcConfigurer",
                                     "org.springframework.context.annotation.Configuration")
@@ -157,7 +166,10 @@ public class AddSetUseTrailingSlashMatch extends Recipe {
                     JavaTemplate webFluxTemplate = JavaTemplate.builder("#{any()}.setUseTrailingSlashMatch(true);")
                             .contextSensitive()
                             .javaParser(JavaParser.fromJavaVersion()
-                                    .classpathFromResources(ctx, "spring-webflux-5", "spring-context-5", "spring-web-5"))
+                                    .classpathFromResources(ctx,
+                                            "spring-webflux-5",
+                                            "spring-context-5",
+                                            "spring-web-5"))
                             .imports(WEB_MVC_PATH_MATCH_CONFIGURER,
                                     "org.springframework.web.reactive.config.WebFluxConfigurer",
                                     "org.springframework.context.annotation.Configuration")

--- a/src/main/java/org/openrewrite/java/spring/boot3/MigrateWebMvcTagsToObservationConvention.java
+++ b/src/main/java/org/openrewrite/java/spring/boot3/MigrateWebMvcTagsToObservationConvention.java
@@ -107,7 +107,10 @@ public class MigrateWebMvcTagsToObservationConvention extends Recipe {
                                 "}";
                         J.ClassDeclaration newClassDeclaration = JavaTemplate.builder(tmpl)
                                 .contextSensitive()
-                                .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "micrometer-commons-1.11.+", "spring-web-6.+", "jakarta.servlet-api"))
+                                .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx,
+                                        "micrometer-commons-1.11.+",
+                                        "spring-web-6.+",
+                                        "jakarta.servlet-api"))
                                 .imports(DEFAULTSERVERREQUESTOBSERVATIONCONVENTION_FQ, KEYVALUES_FQ, HTTPSERVLETREQUEST_FQ, HTTPSERVLETRESPONSE_FQ, SERVERREQUESTOBSERVATIONCONVENTION_FQ)
                                 .build()
                                 .apply(getCursor(), classDecl.getCoordinates().replace());
@@ -154,14 +157,20 @@ public class MigrateWebMvcTagsToObservationConvention extends Recipe {
                             if (Boolean.TRUE.equals(addHttpServletResponse) && m.getBody() != null) {
                                 m = JavaTemplate.builder("HttpServletResponse response = #{any()}.getResponse();")
                                         .imports(HTTPSERVLETRESPONSE_FQ)
-                                        .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "jakarta.servlet-api", "spring-web-6.+", "micrometer-observation-1.11.+"))
+                                        .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx,
+                                                "jakarta.servlet-api",
+                                                "spring-web-6.+",
+                                                "micrometer-observation-1.11.+"))
                                         .build()
                                         .apply(updateCursor(m), m.getBody().getCoordinates().firstStatement(), methodParamIdentifier);
                             }
                             if (Boolean.TRUE.equals(addHttpServletRequest) && m.getBody() != null) {
                                 m = JavaTemplate.builder("HttpServletRequest request = #{any()}.getCarrier();")
                                         .imports(HTTPSERVLETREQUEST_FQ)
-                                        .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "jakarta.servlet-api", "spring-web-6.+", "micrometer-observation-1.11.+"))
+                                        .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx,
+                                                "jakarta.servlet-api",
+                                                "spring-web-6.+",
+                                                "micrometer-observation-1.11.+"))
                                         .build()
                                         .apply(updateCursor(m), m.getBody().getCoordinates().firstStatement(), methodParamIdentifier);
                             }

--- a/src/main/java/org/openrewrite/java/spring/data/MigrateJpaSort.java
+++ b/src/main/java/org/openrewrite/java/spring/data/MigrateJpaSort.java
@@ -68,8 +68,10 @@ public class MigrateJpaSort extends Recipe {
                     return JavaTemplate.builder(template)
                             .contextSensitive()
                             .javaParser(JavaParser.fromJavaVersion()
-                                    .classpathFromResources(ctx, "spring-data-commons-2.*",
-                                            "spring-data-jpa-2.3.*", "javax.persistence-api-2.*"))
+                                    .classpathFromResources(ctx,
+                                            "spring-data-commons-2.*",
+                                            "spring-data-jpa-2.3.*",
+                                            "javax.persistence-api-2.*"))
                             .imports("org.springframework.data.jpa.domain.JpaSort")
                             .build()
                             .apply(

--- a/src/main/java/org/openrewrite/java/spring/framework/MigrateResponseStatusExceptionGetRawStatusCodeMethod.java
+++ b/src/main/java/org/openrewrite/java/spring/framework/MigrateResponseStatusExceptionGetRawStatusCodeMethod.java
@@ -46,7 +46,10 @@ public class MigrateResponseStatusExceptionGetRawStatusCodeMethod extends Recipe
                 J.MethodInvocation m = (J.MethodInvocation) super.visitMethodInvocation(method, ctx);
                 if (RESPONSE_STATUS_EXCEPTION_MATCHER.matches(m) || REST_CLIENT_RESPONSE_EXCEPTION_MATCHER.matches(m)) {
                     return JavaTemplate.builder("#{any()}.getStatusCode().value()")
-                            .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "spring-core-6", "spring-beans-6", "spring-web-6"))
+                            .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx,
+                                    "spring-core-6",
+                                    "spring-beans-6",
+                                    "spring-web-6"))
                             .build()
                             .apply(updateCursor(m), m.getCoordinates().replace(), m.getSelect());
                 }

--- a/src/main/java/org/openrewrite/java/spring/framework/MigrateResponseStatusExceptionGetStatusCodeMethod.java
+++ b/src/main/java/org/openrewrite/java/spring/framework/MigrateResponseStatusExceptionGetStatusCodeMethod.java
@@ -53,7 +53,10 @@ public class MigrateResponseStatusExceptionGetStatusCodeMethod extends Recipe {
                 J.MethodInvocation mi = super.visitMethodInvocation(method, ctx);
                 if (GET_STATUS_METHOD_MATCHER.matches(mi)) {
                     return JavaTemplate.builder("#{any()}.getStatusCode()")
-                            .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "spring-core-6", "spring-beans-6", "spring-web-6"))
+                            .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx,
+                                    "spring-core-6",
+                                    "spring-beans-6",
+                                    "spring-web-6"))
                             .build()
                             .apply(getCursor(), mi.getCoordinates().replace(), mi.getSelect());
                 }

--- a/src/test/java/org/openrewrite/java/spring/AutowiredFieldIntoConstructorParameterVisitorTest.java
+++ b/src/test/java/org/openrewrite/java/spring/AutowiredFieldIntoConstructorParameterVisitorTest.java
@@ -859,7 +859,11 @@ class AutowiredFieldIntoConstructorParameterVisitorTest implements RewriteTest {
         rewriteRun(
           recipeSpec -> recipeSpec.recipe(toRecipe(() -> new AutowiredFieldIntoConstructorParameterVisitor("SecurityConfiguration", "authConverter")))
             .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(),
-              "spring-beans-6.+", "spring-context-6.2", "spring-core-6.+", "spring-security-core-6.0.+", "spring-security-oauth2-jose-6.0.+")),
+              "spring-beans-6.+",
+              "spring-context-6.2",
+              "spring-core-6.+",
+              "spring-security-core-6.0.+",
+              "spring-security-oauth2-jose-6.0.+")),
           java(
             """
               import org.springframework.beans.factory.annotation.Autowired;

--- a/src/test/java/org/openrewrite/java/spring/AutowiredFieldIntoConstructorParameterVisitorTest.java
+++ b/src/test/java/org/openrewrite/java/spring/AutowiredFieldIntoConstructorParameterVisitorTest.java
@@ -859,7 +859,7 @@ class AutowiredFieldIntoConstructorParameterVisitorTest implements RewriteTest {
         rewriteRun(
           recipeSpec -> recipeSpec.recipe(toRecipe(() -> new AutowiredFieldIntoConstructorParameterVisitor("SecurityConfiguration", "authConverter")))
             .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(),
-              "spring-beans-6.+", "spring-context-6.+", "spring-core-6.+", "spring-security-core-6.0.+", "spring-security-oauth2-jose-6.0.+")),
+              "spring-beans-6.+", "spring-context-6.2", "spring-core-6.+", "spring-security-core-6.0.+", "spring-security-oauth2-jose-6.0.+")),
           java(
             """
               import org.springframework.beans.factory.annotation.Autowired;

--- a/src/test/java/org/openrewrite/java/spring/ChangeSpringPropertyKeyTest.java
+++ b/src/test/java/org/openrewrite/java/spring/ChangeSpringPropertyKeyTest.java
@@ -506,7 +506,7 @@ class ChangeSpringPropertyKeyTest implements RewriteTest {
     void changeConditionalOnPropertyAnnotation() {
         rewriteRun(
           spec -> spec.recipe(new ChangeSpringPropertyKey("foo", "bar", List.of("baz")))
-            .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(), "spring-boot-autoconfigure-2")),
+            .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(), "spring-boot-autoconfigure-2.7")),
           java(
             """
               import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -666,7 +666,7 @@ class ChangeSpringPropertyKeyTest implements RewriteTest {
           spec -> spec
             .recipe(
               new ChangeSpringPropertyKey("spring.data.redis.ssl", "spring.data.redis.ssl.enabled", List.of()))
-            .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(), "spring-beans-5", "spring-boot-test-3.2", "spring-boot-autoconfigure-2")),
+            .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(), "spring-beans-5", "spring-boot-test-3.2", "spring-boot-autoconfigure-2.7")),
           java(
             """
               import org.springframework.beans.factory.annotation.Value;
@@ -690,7 +690,7 @@ class ChangeSpringPropertyKeyTest implements RewriteTest {
           spec -> spec
             .recipe(
               new ChangeSpringPropertyKey("spring.data.redis.ssl.enabled", "some.other.key.enabled", List.of()))
-            .parser(KotlinParser.builder().classpathFromResources(new InMemoryExecutionContext(), "spring-beans-5", "spring-boot-test-3.2", "spring-boot-autoconfigure-2")),
+            .parser(KotlinParser.builder().classpathFromResources(new InMemoryExecutionContext(), "spring-beans-5", "spring-boot-test-3.2", "spring-boot-autoconfigure-2.7")),
           kotlin(
             """
               import org.springframework.beans.factory.annotation.Value

--- a/src/test/java/org/openrewrite/java/spring/ChangeSpringPropertyKeyTest.java
+++ b/src/test/java/org/openrewrite/java/spring/ChangeSpringPropertyKeyTest.java
@@ -666,7 +666,10 @@ class ChangeSpringPropertyKeyTest implements RewriteTest {
           spec -> spec
             .recipe(
               new ChangeSpringPropertyKey("spring.data.redis.ssl", "spring.data.redis.ssl.enabled", List.of()))
-            .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(), "spring-beans-5", "spring-boot-test-3.2", "spring-boot-autoconfigure-2.7")),
+            .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(),
+              "spring-beans-5",
+              "spring-boot-test-3.2",
+              "spring-boot-autoconfigure-2.7")),
           java(
             """
               import org.springframework.beans.factory.annotation.Value;

--- a/src/test/java/org/openrewrite/java/spring/ChangeSpringPropertyValueTest.java
+++ b/src/test/java/org/openrewrite/java/spring/ChangeSpringPropertyValueTest.java
@@ -278,7 +278,7 @@ class ChangeSpringPropertyValueTest implements RewriteTest {
         void conditionalOnPropertyHavingValue() {
             rewriteRun(
               spec -> spec.recipe(new ChangeSpringPropertyValue("feature.enabled", "true", "false", null, null))
-                .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(), "spring-boot-autoconfigure-2")),
+                .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(), "spring-boot-autoconfigure-2.7")),
               java(
                 """
                   import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -300,7 +300,7 @@ class ChangeSpringPropertyValueTest implements RewriteTest {
         void conditionalOnPropertyDifferentKey() {
             rewriteRun(
               spec -> spec.recipe(new ChangeSpringPropertyValue("feature.enabled", "true", "false", null, null))
-                .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(), "spring-boot-autoconfigure-2")),
+                .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(), "spring-boot-autoconfigure-2.7")),
               java(
                 """
                   import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;

--- a/src/test/java/org/openrewrite/java/spring/ImplicitWebAnnotationNamesTest.java
+++ b/src/test/java/org/openrewrite/java/spring/ImplicitWebAnnotationNamesTest.java
@@ -36,8 +36,8 @@ class ImplicitWebAnnotationNamesTest implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
         spec.recipe(new ImplicitWebAnnotationNames())
-          .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(), "spring-web-5.+"))
-          .parser(KotlinParser.builder().classpathFromResources(new InMemoryExecutionContext(), "spring-web-5"));
+          .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(), "spring-web-5.3"))
+          .parser(KotlinParser.builder().classpathFromResources(new InMemoryExecutionContext(), "spring-web-5.3"));
     }
 
     @DocumentExample

--- a/src/test/java/org/openrewrite/java/spring/NoAutowiredOnConstructorTest.java
+++ b/src/test/java/org/openrewrite/java/spring/NoAutowiredOnConstructorTest.java
@@ -33,7 +33,11 @@ class NoAutowiredOnConstructorTest implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
         spec.recipe(new NoAutowiredOnConstructor())
-          .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(), "spring-beans-5.+", "spring-boot-1.5.+", "spring-context-5.+", "spring-core-5.+"))
+          .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(),
+            "spring-beans-5.+",
+            "spring-boot-1.5.+",
+            "spring-context-5.+",
+            "spring-core-5.+"))
           .parser(KotlinParser.builder().classpathFromResources(new InMemoryExecutionContext(), "spring-beans-5", "spring-boot-1.5", "spring-context-5", "spring-core-5"));
     }
 

--- a/src/test/java/org/openrewrite/java/spring/NoHttpExchangeAnnotationTest.java
+++ b/src/test/java/org/openrewrite/java/spring/NoHttpExchangeAnnotationTest.java
@@ -30,7 +30,7 @@ class NoHttpExchangeAnnotationTest implements RewriteTest {
     public void defaults(RecipeSpec spec) {
         spec.recipe(new NoHttpExchangeAnnotation())
           .parser(JavaParser.fromJavaVersion()
-            .classpathFromResources(new InMemoryExecutionContext(), "spring-web-6.+"));
+            .classpathFromResources(new InMemoryExecutionContext(), "spring-web-6.2"));
     }
 
     @DocumentExample

--- a/src/test/java/org/openrewrite/java/spring/NoRepoAnnotationOnRepoInterfaceTest.java
+++ b/src/test/java/org/openrewrite/java/spring/NoRepoAnnotationOnRepoInterfaceTest.java
@@ -29,7 +29,10 @@ class NoRepoAnnotationOnRepoInterfaceTest implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
         spec.recipe(new NoRepoAnnotationOnRepoInterface())
-          .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(), "spring-context-5.+", "spring-beans-5.+", "spring-data-commons-2.7.+"));
+          .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(),
+            "spring-context-5.+",
+            "spring-beans-5.+",
+            "spring-data-commons-2.7.+"));
     }
 
     @DocumentExample

--- a/src/test/java/org/openrewrite/java/spring/NoRequestMappingAnnotationTest.java
+++ b/src/test/java/org/openrewrite/java/spring/NoRequestMappingAnnotationTest.java
@@ -32,7 +32,7 @@ class NoRequestMappingAnnotationTest implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
         spec.recipe(new NoRequestMappingAnnotation())
-          .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(), "spring-web-5.+"));
+          .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(), "spring-web-5.3"));
     }
 
     @DocumentExample

--- a/src/test/java/org/openrewrite/java/spring/RenameBeanTest.java
+++ b/src/test/java/org/openrewrite/java/spring/RenameBeanTest.java
@@ -44,7 +44,7 @@ class RenameBeanTest implements RewriteTest {
                 }
                 """
             )
-            .classpathFromResources(new InMemoryExecutionContext(), "spring-context-6.+", "spring-beans-6.+")
+            .classpathFromResources(new InMemoryExecutionContext(), "spring-context-6.2", "spring-beans-6.+")
           );
     }
 

--- a/src/test/java/org/openrewrite/java/spring/UpdateApiManifestTest.java
+++ b/src/test/java/org/openrewrite/java/spring/UpdateApiManifestTest.java
@@ -29,7 +29,7 @@ class UpdateApiManifestTest implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
         spec.recipe(new UpdateApiManifest())
-          .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(), "spring-web-5.+"));
+          .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(), "spring-web-5.3"));
     }
 
     @Test

--- a/src/test/java/org/openrewrite/java/spring/batch/ConvertReceiveTypeWhenCallStepExecutionMethodTest.java
+++ b/src/test/java/org/openrewrite/java/spring/batch/ConvertReceiveTypeWhenCallStepExecutionMethodTest.java
@@ -30,7 +30,7 @@ class ConvertReceiveTypeWhenCallStepExecutionMethodTest implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
         spec.parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(),
-            "spring-batch-core-4", "spring-batch-infrastructure", "spring-beans", "mockito-core-5.+"))
+            "spring-batch-core-4", "spring-batch-infrastructure-4", "spring-beans-5", "mockito-core-5.+"))
           .recipe(new ConvertReceiveTypeWhenCallStepExecutionMethod());
     }
 

--- a/src/test/java/org/openrewrite/java/spring/batch/ConvertReceiveTypeWhenCallStepExecutionMethodTest.java
+++ b/src/test/java/org/openrewrite/java/spring/batch/ConvertReceiveTypeWhenCallStepExecutionMethodTest.java
@@ -30,7 +30,10 @@ class ConvertReceiveTypeWhenCallStepExecutionMethodTest implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
         spec.parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(),
-            "spring-batch-core-4", "spring-batch-infrastructure-4", "spring-beans-5", "mockito-core-5.+"))
+            "spring-batch-core-4",
+            "spring-batch-infrastructure-4",
+            "spring-beans-5",
+            "mockito-core-5.+"))
           .recipe(new ConvertReceiveTypeWhenCallStepExecutionMethod());
     }
 

--- a/src/test/java/org/openrewrite/java/spring/batch/JobParameterToStringTest.java
+++ b/src/test/java/org/openrewrite/java/spring/batch/JobParameterToStringTest.java
@@ -29,7 +29,9 @@ class JobParameterToStringTest implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
         spec.parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(),
-            "spring-batch-core-4.3.+", "spring-batch-infrastructure-4.3.10", "spring-beans-4.3.+"))
+            "spring-batch-core-4.3.+",
+            "spring-batch-infrastructure-4.3.10",
+            "spring-beans-4.3.+"))
           .recipe(new JobParameterToString());
     }
 

--- a/src/test/java/org/openrewrite/java/spring/batch/MigrateItemWriterWriteTest.java
+++ b/src/test/java/org/openrewrite/java/spring/batch/MigrateItemWriterWriteTest.java
@@ -33,7 +33,9 @@ class MigrateItemWriterWriteTest implements RewriteTest {
         spec.recipe(new MigrateItemWriterWrite())
           .parser(JavaParser.fromJavaVersion()
             .classpathFromResources(new InMemoryExecutionContext(),
-              "spring-batch-core-4.3.+", "spring-batch-infrastructure-4.3.10", "spring-beans-4.3.30.RELEASE"));
+              "spring-batch-core-4.3.+",
+              "spring-batch-infrastructure-4.3.10",
+              "spring-beans-4.3.30.RELEASE"));
     }
 
     @DocumentExample

--- a/src/test/java/org/openrewrite/java/spring/batch/MigrateJobBuilderFactoryTest.java
+++ b/src/test/java/org/openrewrite/java/spring/batch/MigrateJobBuilderFactoryTest.java
@@ -92,8 +92,8 @@ class MigrateJobBuilderFactoryTest implements RewriteTest {
           // This test's source is already the migrated (Spring Batch 5) API, so it must be
           // parsed against Spring Batch 5 rather than the class default of Spring Batch 4.
           spec -> spec.parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(),
-            "spring-batch-core-5.+",
-            "spring-batch-infrastructure-5.+",
+            "spring-batch-core-5.2",
+            "spring-batch-infrastructure-5.2",
             "spring-beans-5.+",
             "spring-core-5.+",
             "spring-context-5.+")),

--- a/src/test/java/org/openrewrite/java/spring/batch/MigrateMethodAnnotatedByBatchAPITest.java
+++ b/src/test/java/org/openrewrite/java/spring/batch/MigrateMethodAnnotatedByBatchAPITest.java
@@ -28,7 +28,10 @@ class MigrateMethodAnnotatedByBatchAPITest implements RewriteTest {
 
     @Override
     public void defaults(RecipeSpec spec) {
-        spec.parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(), "spring-batch-core-4.3.+", "spring-batch-infrastructure-4.3.10", "spring-beans-4.3.+"))
+        spec.parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(),
+                "spring-batch-core-4.3.+",
+                "spring-batch-infrastructure-4.3.10",
+                "spring-beans-4.3.+"))
           .recipe(new MigrateMethodAnnotatedByBatchAPI());
     }
 

--- a/src/test/java/org/openrewrite/java/spring/batch/MigrateToChunkOrientedStepBuilderTest.java
+++ b/src/test/java/org/openrewrite/java/spring/batch/MigrateToChunkOrientedStepBuilderTest.java
@@ -31,8 +31,8 @@ class MigrateToChunkOrientedStepBuilderTest implements RewriteTest {
     public void defaults(RecipeSpec spec) {
         spec.recipe(new MigrateToChunkOrientedStepBuilder())
           .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(),
-            "spring-batch-core-5.+",
-            "spring-batch-infrastructure-5.+",
+            "spring-batch-core-5.2",
+            "spring-batch-infrastructure-5.2",
             "spring-beans-5.+",
             "spring-core-5.+",
             "spring-retry-2.+",

--- a/src/test/java/org/openrewrite/java/spring/batch/ReplaceSupportClassWithItsInterfaceTest.java
+++ b/src/test/java/org/openrewrite/java/spring/batch/ReplaceSupportClassWithItsInterfaceTest.java
@@ -32,7 +32,7 @@ class ReplaceSupportClassWithItsInterfaceTest implements RewriteTest {
           .recipeFromResource("/META-INF/rewrite/spring-batch-5.0.yml", "org.openrewrite.java.spring.batch.ListenerSupportClassToInterface")
           .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(),
             "spring-batch-core-4", "spring-batch-infrastructure-4",
-            "spring-boot-2.+", "spring-beans-5.+", "spring-core-5.+", "spring-context-5.+"));
+            "spring-boot-2.7", "spring-beans-5.+", "spring-core-5.+", "spring-context-5.+"));
     }
 
     @DocumentExample

--- a/src/test/java/org/openrewrite/java/spring/batch/ReplaceSupportClassWithItsInterfaceTest.java
+++ b/src/test/java/org/openrewrite/java/spring/batch/ReplaceSupportClassWithItsInterfaceTest.java
@@ -31,8 +31,12 @@ class ReplaceSupportClassWithItsInterfaceTest implements RewriteTest {
         spec
           .recipeFromResource("/META-INF/rewrite/spring-batch-5.0.yml", "org.openrewrite.java.spring.batch.ListenerSupportClassToInterface")
           .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(),
-            "spring-batch-core-4", "spring-batch-infrastructure-4",
-            "spring-boot-2.7", "spring-beans-5.+", "spring-core-5.+", "spring-context-5.+"));
+            "spring-batch-core-4",
+            "spring-batch-infrastructure-4",
+            "spring-boot-2.7",
+            "spring-beans-5.+",
+            "spring-core-5.+",
+            "spring-context-5.+"));
     }
 
     @DocumentExample

--- a/src/test/java/org/openrewrite/java/spring/batch/UpgradeSkipPolicyParameterTypeTest.java
+++ b/src/test/java/org/openrewrite/java/spring/batch/UpgradeSkipPolicyParameterTypeTest.java
@@ -32,11 +32,9 @@ class UpgradeSkipPolicyParameterTypeTest implements RewriteTest {
           .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(),
             "spring-batch-core-4.3.+",
             "spring-batch-infrastructure-4.3.10",
-            "spring-beans-4.3.30.RELEASE",
-            "spring-batch",
-            "spring-boot-1",
-            "spring-core-4",
-            "spring-context-4"
+            "spring-beans-5",
+            "spring-core-5",
+            "spring-context-5"
           ));
     }
 

--- a/src/test/java/org/openrewrite/java/spring/batch/UpgradeSkipPolicyParameterTypeTest.java
+++ b/src/test/java/org/openrewrite/java/spring/batch/UpgradeSkipPolicyParameterTypeTest.java
@@ -34,9 +34,9 @@ class UpgradeSkipPolicyParameterTypeTest implements RewriteTest {
             "spring-batch-infrastructure-4.3.10",
             "spring-beans-4.3.30.RELEASE",
             "spring-batch",
-            "spring-boot",
-            "spring-core",
-            "spring-context"
+            "spring-boot-1",
+            "spring-core-4",
+            "spring-context-4"
           ));
     }
 

--- a/src/test/java/org/openrewrite/java/spring/boot2/AddRouteTrailingSlashTest.java
+++ b/src/test/java/org/openrewrite/java/spring/boot2/AddRouteTrailingSlashTest.java
@@ -29,7 +29,7 @@ class AddRouteTrailingSlashTest implements RewriteTest {
 
     @Override
     public void defaults(RecipeSpec spec) {
-        spec.parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(), "spring-beans-5", "spring-context-5", "spring-boot-2", "spring-security", "spring-web-5", "spring-core-5"))
+        spec.parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(), "spring-beans-5", "spring-context-5", "spring-boot-2.7", "spring-security-config-5.8", "spring-security-core-5.8", "spring-security-web-5.8", "spring-web-5.3", "spring-core-5"))
           .recipe(new AddRouteTrailingSlash());
     }
 

--- a/src/test/java/org/openrewrite/java/spring/boot2/AddRouteTrailingSlashTest.java
+++ b/src/test/java/org/openrewrite/java/spring/boot2/AddRouteTrailingSlashTest.java
@@ -29,7 +29,15 @@ class AddRouteTrailingSlashTest implements RewriteTest {
 
     @Override
     public void defaults(RecipeSpec spec) {
-        spec.parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(), "spring-beans-5", "spring-context-5", "spring-boot-2.7", "spring-security-config-5.8", "spring-security-core-5.8", "spring-security-web-5.8", "spring-web-5.3", "spring-core-5"))
+        spec.parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(),
+                "spring-beans-5",
+                "spring-context-5",
+                "spring-boot-2.7",
+                "spring-security-config-5.8",
+                "spring-security-core-5.8",
+                "spring-security-web-5.8",
+                "spring-web-5.3",
+                "spring-core-5"))
           .recipe(new AddRouteTrailingSlash());
     }
 

--- a/src/test/java/org/openrewrite/java/spring/boot2/AddSetUseTrailingSlashMatchTest.java
+++ b/src/test/java/org/openrewrite/java/spring/boot2/AddSetUseTrailingSlashMatchTest.java
@@ -29,7 +29,7 @@ class AddSetUseTrailingSlashMatchTest implements RewriteTest {
 
     @Override
     public void defaults(RecipeSpec spec) {
-        spec.parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(), "spring-webmvc", "spring-webflux-5", "spring-web-5", "spring-context-5"))
+        spec.parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(), "spring-webmvc", "spring-webflux-5", "spring-web-5.3", "spring-context-5"))
           .recipe(new AddSetUseTrailingSlashMatch());
     }
 

--- a/src/test/java/org/openrewrite/java/spring/boot2/AddSetUseTrailingSlashMatchTest.java
+++ b/src/test/java/org/openrewrite/java/spring/boot2/AddSetUseTrailingSlashMatchTest.java
@@ -29,7 +29,11 @@ class AddSetUseTrailingSlashMatchTest implements RewriteTest {
 
     @Override
     public void defaults(RecipeSpec spec) {
-        spec.parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(), "spring-webmvc", "spring-webflux-5", "spring-web-5.3", "spring-context-5"))
+        spec.parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(),
+                "spring-webmvc",
+                "spring-webflux-5",
+                "spring-web-5.3",
+                "spring-context-5"))
           .recipe(new AddSetUseTrailingSlashMatch());
     }
 

--- a/src/test/java/org/openrewrite/java/spring/boot2/AddSetUseTrailingSlashMatchTest.java
+++ b/src/test/java/org/openrewrite/java/spring/boot2/AddSetUseTrailingSlashMatchTest.java
@@ -29,7 +29,7 @@ class AddSetUseTrailingSlashMatchTest implements RewriteTest {
 
     @Override
     public void defaults(RecipeSpec spec) {
-        spec.parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(), "spring-webmvc", "spring-webflux", "spring-web-5", "spring-context-5"))
+        spec.parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(), "spring-webmvc", "spring-webflux-5", "spring-web-5", "spring-context-5"))
           .recipe(new AddSetUseTrailingSlashMatch());
     }
 

--- a/src/test/java/org/openrewrite/java/spring/boot2/Boot3UpgradeTest.java
+++ b/src/test/java/org/openrewrite/java/spring/boot2/Boot3UpgradeTest.java
@@ -35,9 +35,9 @@ class Boot3UpgradeTest implements RewriteTest {
           .parser(JavaParser.fromJavaVersion()
             .classpathFromResources(new InMemoryExecutionContext(),
               "spring-context-5",
-              "spring-data-jpa-2",
-              "spring-web-5",
-              "spring-boot-2",
+              "spring-data-jpa-2.7",
+              "spring-web-5.3",
+              "spring-boot-2.7",
               "spring-core-5",
               "javax.persistence-api-2",
               "validation-api-2",

--- a/src/test/java/org/openrewrite/java/spring/boot2/ConditionalOnBeanAnyNestedConditionTest.java
+++ b/src/test/java/org/openrewrite/java/spring/boot2/ConditionalOnBeanAnyNestedConditionTest.java
@@ -350,7 +350,7 @@ class ConditionalOnBeanAnyNestedConditionTest implements RewriteTest {
               spec -> spec
                 .typeValidationOptions(TypeValidation.none())
                 .parser(JavaParser.fromJavaVersion()
-                  .classpathFromResources(new InMemoryExecutionContext(), "spring-boot-autoconfigure-2.+", "spring-context-5.+")),
+                  .classpathFromResources(new InMemoryExecutionContext(), "spring-boot-autoconfigure-2.7", "spring-context-5.+")),
               mavenProject("project",
                 pomXml(POM_BOOT_2),
                 //language=java

--- a/src/test/java/org/openrewrite/java/spring/boot2/ConfigurationOverEnableSecurityTest.java
+++ b/src/test/java/org/openrewrite/java/spring/boot2/ConfigurationOverEnableSecurityTest.java
@@ -34,9 +34,9 @@ class ConfigurationOverEnableSecurityTest implements RewriteTest {
             .classpathFromResources(new InMemoryExecutionContext(),
               "spring-beans-5",
               "spring-context-5",
-              "spring-boot-2",
+              "spring-boot-2.7",
               "spring-security-config-5.8",
-              "spring-web-5",
+              "spring-web-5.3",
               "spring-core-5"));
     }
 

--- a/src/test/java/org/openrewrite/java/spring/boot2/DatabaseComponentAndBeanInitializationOrderingTest.java
+++ b/src/test/java/org/openrewrite/java/spring/boot2/DatabaseComponentAndBeanInitializationOrderingTest.java
@@ -48,8 +48,13 @@ class DatabaseComponentAndBeanInitializationOrderingTest implements RewriteTest 
       """;
     private final JavaParser.Builder<? extends JavaParser, ?> JAVA_PARSER = JavaParser.fromJavaVersion()
       .classpathFromResources(new InMemoryExecutionContext(),
-        "spring-beans-5.+", "spring-context-5.+", "spring-boot-2.4", "spring-jdbc-4.1.+", "spring-orm-5.3.+",
-        "jooq-3.14.15", "jakarta.persistence-api-2.2.3");
+        "spring-beans-5.+",
+        "spring-context-5.+",
+        "spring-boot-2.4",
+        "spring-jdbc-4.1.+",
+        "spring-orm-5.3.+",
+        "jooq-3.14.15",
+        "jakarta.persistence-api-2.2.3");
     private final KotlinParser.Builder KOTLIN_PARSER = KotlinParser.builder()
       .classpathFromResources(new InMemoryExecutionContext(),
         "spring-beans-5", "spring-context-5", "spring-boot-2.4", "spring-jdbc-4.1", "spring-orm-5.3",

--- a/src/test/java/org/openrewrite/java/spring/boot2/GetErrorAttributesTest.java
+++ b/src/test/java/org/openrewrite/java/spring/boot2/GetErrorAttributesTest.java
@@ -30,7 +30,7 @@ class GetErrorAttributesTest implements RewriteTest {
     public void defaults(RecipeSpec spec) {
         spec
           .recipe(new GetErrorAttributes())
-          .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(), "spring-boot-2", "spring-web-5"));
+          .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(), "spring-boot-2.2", "spring-web-5.3"));
     }
 
     @DocumentExample

--- a/src/test/java/org/openrewrite/java/spring/boot2/HeadersConfigurerLambdaDslTest.java
+++ b/src/test/java/org/openrewrite/java/spring/boot2/HeadersConfigurerLambdaDslTest.java
@@ -32,10 +32,10 @@ class HeadersConfigurerLambdaDslTest implements RewriteTest {
             .classpathFromResources(new InMemoryExecutionContext(),
               "spring-beans-5",
               "spring-context-5",
-              "spring-boot-2",
+              "spring-boot-2.7",
               "spring-security-config-5.8.+",
               "spring-security-web-5.8.+",
-              "spring-web-5",
+              "spring-web-5.3",
               "tomcat-embed",
               "spring-core-5"
             ));

--- a/src/test/java/org/openrewrite/java/spring/boot2/HttpSecurityLambdaDslTest.java
+++ b/src/test/java/org/openrewrite/java/spring/boot2/HttpSecurityLambdaDslTest.java
@@ -31,8 +31,14 @@ class HttpSecurityLambdaDslTest implements RewriteTest {
         spec.recipe(new HttpSecurityLambdaDsl())
           .parser(JavaParser.fromJavaVersion()
             .classpathFromResources(new InMemoryExecutionContext(),
-              "spring-beans-5", "spring-context-5", "spring-core-5", "spring-boot-2.7", "spring-web-5.3",
-              "spring-security-core-5.8", "spring-security-config-5.8", "spring-security-web-5.8",
+              "spring-beans-5",
+              "spring-context-5",
+              "spring-core-5",
+              "spring-boot-2.7",
+              "spring-web-5.3",
+              "spring-security-core-5.8",
+              "spring-security-config-5.8",
+              "spring-security-web-5.8",
               "tomcat-embed-core-9"));
     }
 

--- a/src/test/java/org/openrewrite/java/spring/boot2/HttpSecurityLambdaDslTest.java
+++ b/src/test/java/org/openrewrite/java/spring/boot2/HttpSecurityLambdaDslTest.java
@@ -31,8 +31,8 @@ class HttpSecurityLambdaDslTest implements RewriteTest {
         spec.recipe(new HttpSecurityLambdaDsl())
           .parser(JavaParser.fromJavaVersion()
             .classpathFromResources(new InMemoryExecutionContext(),
-              "spring-beans-5", "spring-context-5", "spring-core-5", "spring-boot-2", "spring-web-5",
-              "spring-security-core-5", "spring-security-config-5", "spring-security-web-5",
+              "spring-beans-5", "spring-context-5", "spring-core-5", "spring-boot-2.7", "spring-web-5.3",
+              "spring-security-core-5.8", "spring-security-config-5.8", "spring-security-web-5.8",
               "tomcat-embed-core-9"));
     }
 

--- a/src/test/java/org/openrewrite/java/spring/boot2/LegacyHttpSecurityTest.java
+++ b/src/test/java/org/openrewrite/java/spring/boot2/LegacyHttpSecurityTest.java
@@ -29,7 +29,15 @@ class LegacyHttpSecurityTest implements RewriteTest {
     public void defaults(RecipeSpec spec) {
         spec.recipe(new HttpSecurityLambdaDsl())
           .parser(JavaParser.fromJavaVersion()
-            .classpathFromResources(new InMemoryExecutionContext(), "spring-beans-5", "spring-context-5", "spring-boot-2.7", "spring-security-config-5.8", "spring-security-core-5.8", "spring-security-web-5.8", "spring-web-5.3", "spring-core-5"));
+            .classpathFromResources(new InMemoryExecutionContext(),
+              "spring-beans-5",
+              "spring-context-5",
+              "spring-boot-2.7",
+              "spring-security-config-5.8",
+              "spring-security-core-5.8",
+              "spring-security-web-5.8",
+              "spring-web-5.3",
+              "spring-core-5"));
     }
 
     @Test

--- a/src/test/java/org/openrewrite/java/spring/boot2/LegacyHttpSecurityTest.java
+++ b/src/test/java/org/openrewrite/java/spring/boot2/LegacyHttpSecurityTest.java
@@ -29,7 +29,7 @@ class LegacyHttpSecurityTest implements RewriteTest {
     public void defaults(RecipeSpec spec) {
         spec.recipe(new HttpSecurityLambdaDsl())
           .parser(JavaParser.fromJavaVersion()
-            .classpathFromResources(new InMemoryExecutionContext(), "spring-beans-5", "spring-context-5", "spring-boot-2", "spring-security", "spring-web-5", "spring-core-5"));
+            .classpathFromResources(new InMemoryExecutionContext(), "spring-beans-5", "spring-context-5", "spring-boot-2.7", "spring-security-config-5.8", "spring-security-core-5.8", "spring-security-web-5.8", "spring-web-5.3", "spring-core-5"));
     }
 
     @Test

--- a/src/test/java/org/openrewrite/java/spring/boot2/MaintainTrailingSlashURLMappingsTest.java
+++ b/src/test/java/org/openrewrite/java/spring/boot2/MaintainTrailingSlashURLMappingsTest.java
@@ -31,7 +31,7 @@ class MaintainTrailingSlashURLMappingsTest implements RewriteTest {
     public void defaults(RecipeSpec spec) {
         spec.recipe(new MaintainTrailingSlashURLMappings())
           .parser(JavaParser.fromJavaVersion()
-            .classpathFromResources(new InMemoryExecutionContext(), "spring-webmvc-5.+", "spring-webflux-5.+", "spring-web-5.+", "spring-context-5.+"));
+            .classpathFromResources(new InMemoryExecutionContext(), "spring-webmvc-5.+", "spring-webflux-5.+", "spring-web-5.3", "spring-context-5.+"));
     }
 
     @DocumentExample

--- a/src/test/java/org/openrewrite/java/spring/boot2/MaintainTrailingSlashURLMappingsTest.java
+++ b/src/test/java/org/openrewrite/java/spring/boot2/MaintainTrailingSlashURLMappingsTest.java
@@ -31,7 +31,11 @@ class MaintainTrailingSlashURLMappingsTest implements RewriteTest {
     public void defaults(RecipeSpec spec) {
         spec.recipe(new MaintainTrailingSlashURLMappings())
           .parser(JavaParser.fromJavaVersion()
-            .classpathFromResources(new InMemoryExecutionContext(), "spring-webmvc-5.+", "spring-webflux-5.+", "spring-web-5.3", "spring-context-5.+"));
+            .classpathFromResources(new InMemoryExecutionContext(),
+              "spring-webmvc-5.+",
+              "spring-webflux-5.+",
+              "spring-web-5.3",
+              "spring-context-5.+"));
     }
 
     @DocumentExample

--- a/src/test/java/org/openrewrite/java/spring/boot2/MigrateActuatorMediaTypeToApiVersionTest.java
+++ b/src/test/java/org/openrewrite/java/spring/boot2/MigrateActuatorMediaTypeToApiVersionTest.java
@@ -30,7 +30,9 @@ class MigrateActuatorMediaTypeToApiVersionTest implements RewriteTest {
     public void defaults(RecipeSpec spec) {
         spec.recipe(new MigrateActuatorMediaTypeToApiVersion())
           .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(),
-            "spring-boot-actuator-2.5", "spring-web-5.3", "spring-core-5"));
+            "spring-boot-actuator-2.5",
+            "spring-web-5.3",
+            "spring-core-5"));
     }
 
     @DocumentExample

--- a/src/test/java/org/openrewrite/java/spring/boot2/MigrateActuatorMediaTypeToApiVersionTest.java
+++ b/src/test/java/org/openrewrite/java/spring/boot2/MigrateActuatorMediaTypeToApiVersionTest.java
@@ -30,7 +30,7 @@ class MigrateActuatorMediaTypeToApiVersionTest implements RewriteTest {
     public void defaults(RecipeSpec spec) {
         spec.recipe(new MigrateActuatorMediaTypeToApiVersion())
           .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(),
-            "spring-boot-actuator-2.5", "spring-web-5", "spring-core-5"));
+            "spring-boot-actuator-2.5", "spring-web-5.3", "spring-core-5"));
     }
 
     @DocumentExample

--- a/src/test/java/org/openrewrite/java/spring/boot2/MigrateConfigurationPropertiesBindingPostProcessorValidatorBeanNameTest.java
+++ b/src/test/java/org/openrewrite/java/spring/boot2/MigrateConfigurationPropertiesBindingPostProcessorValidatorBeanNameTest.java
@@ -31,7 +31,7 @@ class MigrateConfigurationPropertiesBindingPostProcessorValidatorBeanNameTest im
     public void defaults(RecipeSpec spec) {
         spec.recipe(new MigrateConfigurationPropertiesBindingPostProcessorValidatorBeanName())
           .parser(JavaParser.fromJavaVersion()
-            .classpathFromResources(new InMemoryExecutionContext(), "spring-boot-2", "spring-beans-5", "spring-core-5", "spring-context-5"));
+            .classpathFromResources(new InMemoryExecutionContext(), "spring-boot-2.7", "spring-beans-5", "spring-core-5", "spring-context-5"));
     }
 
     @DocumentExample

--- a/src/test/java/org/openrewrite/java/spring/boot2/MigrateConfigurationPropertiesBindingPostProcessorValidatorBeanNameTest.java
+++ b/src/test/java/org/openrewrite/java/spring/boot2/MigrateConfigurationPropertiesBindingPostProcessorValidatorBeanNameTest.java
@@ -31,7 +31,11 @@ class MigrateConfigurationPropertiesBindingPostProcessorValidatorBeanNameTest im
     public void defaults(RecipeSpec spec) {
         spec.recipe(new MigrateConfigurationPropertiesBindingPostProcessorValidatorBeanName())
           .parser(JavaParser.fromJavaVersion()
-            .classpathFromResources(new InMemoryExecutionContext(), "spring-boot-2.7", "spring-beans-5", "spring-core-5", "spring-context-5"));
+            .classpathFromResources(new InMemoryExecutionContext(),
+              "spring-boot-2.7",
+              "spring-beans-5",
+              "spring-core-5",
+              "spring-context-5"));
     }
 
     @DocumentExample

--- a/src/test/java/org/openrewrite/java/spring/boot2/MigrateHsqlEmbeddedDatabaseConnectionTest.java
+++ b/src/test/java/org/openrewrite/java/spring/boot2/MigrateHsqlEmbeddedDatabaseConnectionTest.java
@@ -30,7 +30,7 @@ class MigrateHsqlEmbeddedDatabaseConnectionTest implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
         spec.recipe(new MigrateHsqlEmbeddedDatabaseConnection())
-          .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(), "spring-boot-2.+"));
+          .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(), "spring-boot-2.2"));
     }
 
     @DocumentExample

--- a/src/test/java/org/openrewrite/java/spring/boot2/MigrateRestTemplateBuilderTimeoutByIntTest.java
+++ b/src/test/java/org/openrewrite/java/spring/boot2/MigrateRestTemplateBuilderTimeoutByIntTest.java
@@ -29,7 +29,7 @@ class MigrateRestTemplateBuilderTimeoutByIntTest implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
         spec.recipe(new MigrateRestTemplateBuilderTimeoutByInt())
-          .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(), "spring-boot-2.1", "spring-web-5", "spring-core-5"));
+          .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(), "spring-boot-2.1", "spring-web-5.3", "spring-core-5"));
     }
 
     @DocumentExample

--- a/src/test/java/org/openrewrite/java/spring/boot2/MigrateRestTemplateBuilderTimeoutByIntTest.java
+++ b/src/test/java/org/openrewrite/java/spring/boot2/MigrateRestTemplateBuilderTimeoutByIntTest.java
@@ -29,7 +29,10 @@ class MigrateRestTemplateBuilderTimeoutByIntTest implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
         spec.recipe(new MigrateRestTemplateBuilderTimeoutByInt())
-          .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(), "spring-boot-2.1", "spring-web-5.3", "spring-core-5"));
+          .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(),
+            "spring-boot-2.1",
+            "spring-web-5.3",
+            "spring-core-5"));
     }
 
     @DocumentExample

--- a/src/test/java/org/openrewrite/java/spring/boot2/MigrateToWebServerFactoryCustomizerTest.java
+++ b/src/test/java/org/openrewrite/java/spring/boot2/MigrateToWebServerFactoryCustomizerTest.java
@@ -29,7 +29,10 @@ class MigrateToWebServerFactoryCustomizerTest implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
         spec.recipeFromResources("org.openrewrite.java.spring.boot2.MigrateToWebServerFactoryCustomizer")
-          .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(), "spring-boot-1.+", "spring-context-4.+", "spring-beans-4.+"));
+          .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(),
+            "spring-boot-1.+",
+            "spring-context-4.+",
+            "spring-beans-4.+"));
     }
 
     @DocumentExample

--- a/src/test/java/org/openrewrite/java/spring/boot2/MoveAutoConfigurationToImportsFileTest.java
+++ b/src/test/java/org/openrewrite/java/spring/boot2/MoveAutoConfigurationToImportsFileTest.java
@@ -254,7 +254,7 @@ class MoveAutoConfigurationToImportsFileTest implements RewriteTest {
     @Test
     void dontChangeAnnotationsOnAutoConfigurationClasses() {
         rewriteRun(
-          spec -> spec.parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(), "spring-boot-autoconfigure", "spring-context-5")),
+          spec -> spec.parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(), "spring-boot-autoconfigure-2.7", "spring-context-5")),
           text(
             """
               org.springframework.boot.autoconfigure.EnableAutoConfiguration=\\

--- a/src/test/java/org/openrewrite/java/spring/boot2/OutputCaptureExtensionTest.java
+++ b/src/test/java/org/openrewrite/java/spring/boot2/OutputCaptureExtensionTest.java
@@ -31,7 +31,10 @@ class OutputCaptureExtensionTest implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
         spec.recipe(new OutputCaptureExtension())
-          .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(), "spring-boot-test-1.+", "hamcrest-2.2", "junit-4.+"));
+          .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(),
+            "spring-boot-test-1.+",
+            "hamcrest-2.2",
+            "junit-4.+"));
     }
 
     @Issue("https://github.com/openrewrite/rewrite-spring/issues/46")

--- a/src/test/java/org/openrewrite/java/spring/boot2/ReplaceDeprecatedEnvironmentTestUtilsTest.java
+++ b/src/test/java/org/openrewrite/java/spring/boot2/ReplaceDeprecatedEnvironmentTestUtilsTest.java
@@ -30,7 +30,7 @@ class ReplaceDeprecatedEnvironmentTestUtilsTest implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
         spec.recipe(new ReplaceDeprecatedEnvironmentTestUtils())
-          .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(), "spring-beans-5", "spring-core-5", "spring-context-5", "spring-boot-test-1", "spring-web-5"));
+          .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(), "spring-beans-5", "spring-core-5", "spring-context-5", "spring-boot-test-1", "spring-web-5.3"));
     }
 
     @DocumentExample

--- a/src/test/java/org/openrewrite/java/spring/boot2/ReplaceDeprecatedEnvironmentTestUtilsTest.java
+++ b/src/test/java/org/openrewrite/java/spring/boot2/ReplaceDeprecatedEnvironmentTestUtilsTest.java
@@ -30,7 +30,12 @@ class ReplaceDeprecatedEnvironmentTestUtilsTest implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
         spec.recipe(new ReplaceDeprecatedEnvironmentTestUtils())
-          .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(), "spring-beans-5", "spring-core-5", "spring-context-5", "spring-boot-test-1", "spring-web-5.3"));
+          .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(),
+            "spring-beans-5",
+            "spring-core-5",
+            "spring-context-5",
+            "spring-boot-test-1",
+            "spring-web-5.3"));
     }
 
     @DocumentExample

--- a/src/test/java/org/openrewrite/java/spring/boot2/ReplaceExtendWithAndContextConfigurationTest.java
+++ b/src/test/java/org/openrewrite/java/spring/boot2/ReplaceExtendWithAndContextConfigurationTest.java
@@ -32,7 +32,7 @@ class ReplaceExtendWithAndContextConfigurationTest implements RewriteTest {
     public void defaults(RecipeSpec spec) {
         spec.recipe(new ReplaceExtendWithAndContextConfiguration())
           .parser(JavaParser.fromJavaVersion()
-            .classpathFromResources(new InMemoryExecutionContext(), "spring-boot-test-2.7", "spring-test-5", "junit-jupiter-api", "spring-context-5"));
+            .classpathFromResources(new InMemoryExecutionContext(), "spring-boot-test-2.4", "spring-test-5", "junit-jupiter-api", "spring-context-5"));
     }
 
     @DocumentExample

--- a/src/test/java/org/openrewrite/java/spring/boot2/ReplaceExtendWithAndContextConfigurationTest.java
+++ b/src/test/java/org/openrewrite/java/spring/boot2/ReplaceExtendWithAndContextConfigurationTest.java
@@ -32,7 +32,7 @@ class ReplaceExtendWithAndContextConfigurationTest implements RewriteTest {
     public void defaults(RecipeSpec spec) {
         spec.recipe(new ReplaceExtendWithAndContextConfiguration())
           .parser(JavaParser.fromJavaVersion()
-            .classpathFromResources(new InMemoryExecutionContext(), "spring-boot-test", "spring-test", "junit-jupiter-api", "spring-context-5"));
+            .classpathFromResources(new InMemoryExecutionContext(), "spring-boot-test-2.7", "spring-test-5", "junit-jupiter-api", "spring-context-5"));
     }
 
     @DocumentExample

--- a/src/test/java/org/openrewrite/java/spring/boot2/ReplaceExtendWithAndContextConfigurationTest.java
+++ b/src/test/java/org/openrewrite/java/spring/boot2/ReplaceExtendWithAndContextConfigurationTest.java
@@ -32,7 +32,11 @@ class ReplaceExtendWithAndContextConfigurationTest implements RewriteTest {
     public void defaults(RecipeSpec spec) {
         spec.recipe(new ReplaceExtendWithAndContextConfiguration())
           .parser(JavaParser.fromJavaVersion()
-            .classpathFromResources(new InMemoryExecutionContext(), "spring-boot-test-2.4", "spring-test-5", "junit-jupiter-api", "spring-context-5"));
+            .classpathFromResources(new InMemoryExecutionContext(),
+              "spring-boot-test-2.4",
+              "spring-test-5",
+              "junit-jupiter-api",
+              "spring-context-5"));
     }
 
     @DocumentExample

--- a/src/test/java/org/openrewrite/java/spring/boot2/RestTemplateBuilderRequestFactoryTest.java
+++ b/src/test/java/org/openrewrite/java/spring/boot2/RestTemplateBuilderRequestFactoryTest.java
@@ -30,7 +30,10 @@ class RestTemplateBuilderRequestFactoryTest implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
         spec.recipe(new RestTemplateBuilderRequestFactory())
-          .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(), "spring-boot-1.+", "spring-web-4.+", "spring-core-4.+"));
+          .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(),
+            "spring-boot-1.+",
+            "spring-web-4.+",
+            "spring-core-4.+"));
     }
 
     @DocumentExample

--- a/src/test/java/org/openrewrite/java/spring/boot2/ServerHttpSecurityLambdaDslTest.java
+++ b/src/test/java/org/openrewrite/java/spring/boot2/ServerHttpSecurityLambdaDslTest.java
@@ -30,8 +30,14 @@ class ServerHttpSecurityLambdaDslTest implements RewriteTest {
         spec.recipe(new ServerHttpSecurityLambdaDsl())
           .parser(JavaParser.fromJavaVersion()
             .classpathFromResources(new InMemoryExecutionContext(),
-              "spring-beans-5", "spring-context-5", "spring-boot-2.7", "spring-core-5", "spring-web-5.3",
-              "spring-security-core-5.8", "spring-security-config-5.8", "spring-security-web-5.8",
+              "spring-beans-5",
+              "spring-context-5",
+              "spring-boot-2.7",
+              "spring-core-5",
+              "spring-web-5.3",
+              "spring-security-core-5.8",
+              "spring-security-config-5.8",
+              "spring-security-web-5.8",
               "tomcat-embed"));
     }
 

--- a/src/test/java/org/openrewrite/java/spring/boot2/ServerHttpSecurityLambdaDslTest.java
+++ b/src/test/java/org/openrewrite/java/spring/boot2/ServerHttpSecurityLambdaDslTest.java
@@ -30,8 +30,8 @@ class ServerHttpSecurityLambdaDslTest implements RewriteTest {
         spec.recipe(new ServerHttpSecurityLambdaDsl())
           .parser(JavaParser.fromJavaVersion()
             .classpathFromResources(new InMemoryExecutionContext(),
-              "spring-beans-5", "spring-context-5", "spring-boot-2", "spring-core-5", "spring-web-5",
-              "spring-security-core-5", "spring-security-config-5", "spring-security-web-5",
+              "spring-beans-5", "spring-context-5", "spring-boot-2.7", "spring-core-5", "spring-web-5.3",
+              "spring-security-core-5.8", "spring-security-config-5.8", "spring-security-web-5.8",
               "tomcat-embed"));
     }
 

--- a/src/test/java/org/openrewrite/java/spring/boot2/SpringBoot2JUnit4to5MigrationTest.java
+++ b/src/test/java/org/openrewrite/java/spring/boot2/SpringBoot2JUnit4to5MigrationTest.java
@@ -32,7 +32,7 @@ class SpringBoot2JUnit4to5MigrationTest implements RewriteTest {
           .recipeFromResources("org.openrewrite.java.spring.boot2.SpringBoot2JUnit4to5Migration")
           .parser(JavaParser.fromJavaVersion()
             .classpathFromResources(new InMemoryExecutionContext(),
-              "spring-boot-test-2", "junit-4", "spring-test-5", "spring-context-5"));
+              "spring-boot-test-2.7", "junit-4", "spring-test-5", "spring-context-5"));
     }
 
     @Issue("https://github.com/openrewrite/rewrite-spring/issues/43")

--- a/src/test/java/org/openrewrite/java/spring/boot2/SpringBoot2JUnit4to5MigrationTest.java
+++ b/src/test/java/org/openrewrite/java/spring/boot2/SpringBoot2JUnit4to5MigrationTest.java
@@ -32,7 +32,10 @@ class SpringBoot2JUnit4to5MigrationTest implements RewriteTest {
           .recipeFromResources("org.openrewrite.java.spring.boot2.SpringBoot2JUnit4to5Migration")
           .parser(JavaParser.fromJavaVersion()
             .classpathFromResources(new InMemoryExecutionContext(),
-              "spring-boot-test-2.7", "junit-4", "spring-test-5", "spring-context-5"));
+              "spring-boot-test-2.7",
+              "junit-4",
+              "spring-test-5",
+              "spring-context-5"));
     }
 
     @Issue("https://github.com/openrewrite/rewrite-spring/issues/43")

--- a/src/test/java/org/openrewrite/java/spring/boot2/UnnecessarySpringExtensionTest.java
+++ b/src/test/java/org/openrewrite/java/spring/boot2/UnnecessarySpringExtensionTest.java
@@ -36,7 +36,7 @@ class UnnecessarySpringExtensionTest implements RewriteTest {
     public void defaults(RecipeSpec spec) {
         spec.recipe(new UnnecessarySpringExtension())
           .parser(JavaParser.fromJavaVersion()
-            .classpathFromResources(new InMemoryExecutionContext(), "spring-context-5", "spring-test", "spring-boot-test-2.*", "junit-jupiter-api", "spring-boot-test-autoconfigure-2.*", "spring-batch-test"));
+            .classpathFromResources(new InMemoryExecutionContext(), "spring-context-5", "spring-test-5", "spring-boot-test-2.*", "junit-jupiter-api", "spring-boot-test-autoconfigure-2.*", "spring-batch-test"));
     }
 
     @DocumentExample

--- a/src/test/java/org/openrewrite/java/spring/boot2/UnnecessarySpringExtensionTest.java
+++ b/src/test/java/org/openrewrite/java/spring/boot2/UnnecessarySpringExtensionTest.java
@@ -36,7 +36,13 @@ class UnnecessarySpringExtensionTest implements RewriteTest {
     public void defaults(RecipeSpec spec) {
         spec.recipe(new UnnecessarySpringExtension())
           .parser(JavaParser.fromJavaVersion()
-            .classpathFromResources(new InMemoryExecutionContext(), "spring-context-5", "spring-test-5", "spring-boot-test-2.4", "junit-jupiter-api", "spring-boot-test-autoconfigure-2.4", "spring-batch-test"));
+            .classpathFromResources(new InMemoryExecutionContext(),
+              "spring-context-5",
+              "spring-test-5",
+              "spring-boot-test-2.4",
+              "junit-jupiter-api",
+              "spring-boot-test-autoconfigure-2.4",
+              "spring-batch-test"));
     }
 
     @DocumentExample

--- a/src/test/java/org/openrewrite/java/spring/boot2/UnnecessarySpringExtensionTest.java
+++ b/src/test/java/org/openrewrite/java/spring/boot2/UnnecessarySpringExtensionTest.java
@@ -36,7 +36,7 @@ class UnnecessarySpringExtensionTest implements RewriteTest {
     public void defaults(RecipeSpec spec) {
         spec.recipe(new UnnecessarySpringExtension())
           .parser(JavaParser.fromJavaVersion()
-            .classpathFromResources(new InMemoryExecutionContext(), "spring-context-5", "spring-test-5", "spring-boot-test-2.*", "junit-jupiter-api", "spring-boot-test-autoconfigure-2.*", "spring-batch-test"));
+            .classpathFromResources(new InMemoryExecutionContext(), "spring-context-5", "spring-test-5", "spring-boot-test-2.4", "junit-jupiter-api", "spring-boot-test-autoconfigure-2.4", "spring-batch-test"));
     }
 
     @DocumentExample

--- a/src/test/java/org/openrewrite/java/spring/boot2/search/CustomizingJooqDefaultConfigurationTest.java
+++ b/src/test/java/org/openrewrite/java/spring/boot2/search/CustomizingJooqDefaultConfigurationTest.java
@@ -31,7 +31,12 @@ class CustomizingJooqDefaultConfigurationTest implements RewriteTest {
         spec.recipe(new CustomizingJooqDefaultConfiguration())
           .parser(JavaParser.fromJavaVersion()
             .classpathFromResources(new InMemoryExecutionContext(),
-              "spring-beans-5", "spring-context-5", "spring-boot-2.4", "spring-jdbc-4", "spring-orm-5", "jooq-3"));
+              "spring-beans-5",
+              "spring-context-5",
+              "spring-boot-2.4",
+              "spring-jdbc-4",
+              "spring-orm-5",
+              "jooq-3"));
     }
 
     @DocumentExample

--- a/src/test/java/org/openrewrite/java/spring/boot2/search/IntegrationSchedulerPoolRecipeTest.java
+++ b/src/test/java/org/openrewrite/java/spring/boot2/search/IntegrationSchedulerPoolRecipeTest.java
@@ -36,7 +36,7 @@ class IntegrationSchedulerPoolRecipeTest implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
         spec.recipe(new IntegrationSchedulerPoolRecipe())
-          .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(), "spring-boot-2", "spring-boot-autoconfigure"));
+          .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(), "spring-boot-2", "spring-boot-autoconfigure-2.7"));
     }
 
     @DocumentExample

--- a/src/test/java/org/openrewrite/java/spring/boot2/search/IntegrationSchedulerPoolRecipeTest.java
+++ b/src/test/java/org/openrewrite/java/spring/boot2/search/IntegrationSchedulerPoolRecipeTest.java
@@ -36,7 +36,7 @@ class IntegrationSchedulerPoolRecipeTest implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
         spec.recipe(new IntegrationSchedulerPoolRecipe())
-          .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(), "spring-boot-2", "spring-boot-autoconfigure-2.7"));
+          .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(), "spring-boot-2.4", "spring-boot-autoconfigure-2.3"));
     }
 
     @DocumentExample

--- a/src/test/java/org/openrewrite/java/spring/boot2/search/LoggingShutdownHooksTest.java
+++ b/src/test/java/org/openrewrite/java/spring/boot2/search/LoggingShutdownHooksTest.java
@@ -58,7 +58,7 @@ class LoggingShutdownHooksTest implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
         spec.recipe(new LoggingShutdownHooks())
-          .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(), "spring-boot-autoconfigure-2"));
+          .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(), "spring-boot-autoconfigure-2.7"));
     }
 
     @Test

--- a/src/test/java/org/openrewrite/java/spring/boot3/AddConfigurationAnnotationIfBeansPresentTest.java
+++ b/src/test/java/org/openrewrite/java/spring/boot3/AddConfigurationAnnotationIfBeansPresentTest.java
@@ -32,9 +32,14 @@ class AddConfigurationAnnotationIfBeansPresentTest implements RewriteTest {
         spec.recipe(new AddConfigurationAnnotationIfBeansPresent())
           .parser(JavaParser.fromJavaVersion()
             .classpathFromResources(new InMemoryExecutionContext(),
-              "spring-boot-autoconfigure-3", "spring-boot-3.5",
-              "spring-beans-6", "spring-context-6.2", "spring-web-6.2", "spring-core-6",
-              "spring-security-core-6", "spring-security-config-6.2",
+              "spring-boot-autoconfigure-3",
+              "spring-boot-3.5",
+              "spring-beans-6",
+              "spring-context-6.2",
+              "spring-web-6.2",
+              "spring-core-6",
+              "spring-security-core-6",
+              "spring-security-config-6.2",
               "spring-cloud-openfeign-core"));
     }
 

--- a/src/test/java/org/openrewrite/java/spring/boot3/AddConfigurationAnnotationIfBeansPresentTest.java
+++ b/src/test/java/org/openrewrite/java/spring/boot3/AddConfigurationAnnotationIfBeansPresentTest.java
@@ -32,9 +32,9 @@ class AddConfigurationAnnotationIfBeansPresentTest implements RewriteTest {
         spec.recipe(new AddConfigurationAnnotationIfBeansPresent())
           .parser(JavaParser.fromJavaVersion()
             .classpathFromResources(new InMemoryExecutionContext(),
-              "spring-boot-autoconfigure-3", "spring-boot-3",
-              "spring-beans-6", "spring-context-6", "spring-web-6", "spring-core-6",
-              "spring-security-core-6", "spring-security-config-6",
+              "spring-boot-autoconfigure-3", "spring-boot-3.5",
+              "spring-beans-6", "spring-context-6.2", "spring-web-6.2", "spring-core-6",
+              "spring-security-core-6", "spring-security-config-6.2",
               "spring-cloud-openfeign-core"));
     }
 

--- a/src/test/java/org/openrewrite/java/spring/boot3/AddValidToNestedConfigPropertiesTest.java
+++ b/src/test/java/org/openrewrite/java/spring/boot3/AddValidToNestedConfigPropertiesTest.java
@@ -30,7 +30,10 @@ class AddValidToNestedConfigPropertiesTest implements RewriteTest {
     public void defaults(RecipeSpec spec) {
         spec.recipe(new AddValidToNestedConfigProperties())
           .parser(JavaParser.fromJavaVersion()
-            .classpathFromResources(new InMemoryExecutionContext(), "spring-boot-3.5", "spring-context-5.+", "jakarta.validation-api-3.0.+")
+            .classpathFromResources(new InMemoryExecutionContext(),
+              "spring-boot-3.5",
+              "spring-context-5.+",
+              "jakarta.validation-api-3.0.+")
             .dependsOn(
               // language=java
               """
@@ -206,7 +209,11 @@ class AddValidToNestedConfigPropertiesTest implements RewriteTest {
     void doNotAddValidToStaticFields() {
         rewriteRun(
           spec -> spec.parser(JavaParser.fromJavaVersion()
-            .classpathFromResources(new InMemoryExecutionContext(), "spring-boot-3.5", "spring-context-5.+", "jakarta.validation-api-3.0.+", "slf4j-api-2.+")),
+            .classpathFromResources(new InMemoryExecutionContext(),
+              "spring-boot-3.5",
+              "spring-context-5.+",
+              "jakarta.validation-api-3.0.+",
+              "slf4j-api-2.+")),
           // language=java
           java(
             """

--- a/src/test/java/org/openrewrite/java/spring/boot3/AddValidToNestedConfigPropertiesTest.java
+++ b/src/test/java/org/openrewrite/java/spring/boot3/AddValidToNestedConfigPropertiesTest.java
@@ -30,7 +30,7 @@ class AddValidToNestedConfigPropertiesTest implements RewriteTest {
     public void defaults(RecipeSpec spec) {
         spec.recipe(new AddValidToNestedConfigProperties())
           .parser(JavaParser.fromJavaVersion()
-            .classpathFromResources(new InMemoryExecutionContext(), "spring-boot-3.+", "spring-context-5.+", "jakarta.validation-api-3.0.+")
+            .classpathFromResources(new InMemoryExecutionContext(), "spring-boot-3.5", "spring-context-5.+", "jakarta.validation-api-3.0.+")
             .dependsOn(
               // language=java
               """
@@ -206,7 +206,7 @@ class AddValidToNestedConfigPropertiesTest implements RewriteTest {
     void doNotAddValidToStaticFields() {
         rewriteRun(
           spec -> spec.parser(JavaParser.fromJavaVersion()
-            .classpathFromResources(new InMemoryExecutionContext(), "spring-boot-3.+", "spring-context-5.+", "jakarta.validation-api-3.0.+", "slf4j-api-2.+")),
+            .classpathFromResources(new InMemoryExecutionContext(), "spring-boot-3.5", "spring-context-5.+", "jakarta.validation-api-3.0.+", "slf4j-api-2.+")),
           // language=java
           java(
             """

--- a/src/test/java/org/openrewrite/java/spring/boot3/ConfigurationOverEnableSecurityTest.java
+++ b/src/test/java/org/openrewrite/java/spring/boot3/ConfigurationOverEnableSecurityTest.java
@@ -31,8 +31,8 @@ class ConfigurationOverEnableSecurityTest implements RewriteTest {
         spec.recipe(new ConfigurationOverEnableSecurity(false))
           .parser(JavaParser.fromJavaVersion()
             .classpathFromResources(new InMemoryExecutionContext(),
-              "spring-beans-6", "spring-context-6", "spring-boot-3", "spring-web-6", "spring-core-6",
-              "spring-security-core-6", "spring-security-config-6"));
+              "spring-beans-6", "spring-context-6.2", "spring-boot-3.5", "spring-web-6.2", "spring-core-6",
+              "spring-security-core-6", "spring-security-config-6.2"));
     }
 
     @DocumentExample

--- a/src/test/java/org/openrewrite/java/spring/boot3/ConfigurationOverEnableSecurityTest.java
+++ b/src/test/java/org/openrewrite/java/spring/boot3/ConfigurationOverEnableSecurityTest.java
@@ -31,8 +31,13 @@ class ConfigurationOverEnableSecurityTest implements RewriteTest {
         spec.recipe(new ConfigurationOverEnableSecurity(false))
           .parser(JavaParser.fromJavaVersion()
             .classpathFromResources(new InMemoryExecutionContext(),
-              "spring-beans-6", "spring-context-6.2", "spring-boot-3.5", "spring-web-6.2", "spring-core-6",
-              "spring-security-core-6", "spring-security-config-6.2"));
+              "spring-beans-6",
+              "spring-context-6.2",
+              "spring-boot-3.5",
+              "spring-web-6.2",
+              "spring-core-6",
+              "spring-security-core-6",
+              "spring-security-config-6.2"));
     }
 
     @DocumentExample

--- a/src/test/java/org/openrewrite/java/spring/boot3/MigrateDropWizardDependenciesTest.java
+++ b/src/test/java/org/openrewrite/java/spring/boot3/MigrateDropWizardDependenciesTest.java
@@ -28,7 +28,10 @@ class MigrateDropWizardDependenciesTest implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
         spec.recipeFromResources("org.openrewrite.java.spring.boot3.MigrateDropWizardDependencies")
-          .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(), "spring-boot-3.5", "spring-context-5.+", "spring-beans-5.+"));
+          .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(),
+            "spring-boot-3.5",
+            "spring-context-5.+",
+            "spring-beans-5.+"));
     }
 
     @Test

--- a/src/test/java/org/openrewrite/java/spring/boot3/MigrateDropWizardDependenciesTest.java
+++ b/src/test/java/org/openrewrite/java/spring/boot3/MigrateDropWizardDependenciesTest.java
@@ -28,7 +28,7 @@ class MigrateDropWizardDependenciesTest implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
         spec.recipeFromResources("org.openrewrite.java.spring.boot3.MigrateDropWizardDependencies")
-          .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(), "spring-boot-3.+", "spring-context-5.+", "spring-beans-5.+"));
+          .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(), "spring-boot-3.5", "spring-context-5.+", "spring-beans-5.+"));
     }
 
     @Test

--- a/src/test/java/org/openrewrite/java/spring/boot3/MigrateEndpointAccessValueSpring34Test.java
+++ b/src/test/java/org/openrewrite/java/spring/boot3/MigrateEndpointAccessValueSpring34Test.java
@@ -33,7 +33,7 @@ class MigrateEndpointAccessValueSpring34Test implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
         spec
-          .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(), "spring-boot-3"))
+          .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(), "spring-boot-3.5"))
           .recipeFromResource(
             "/META-INF/rewrite/spring-boot-34-properties.yml",
             "org.openrewrite.java.spring.boot3.SpringBootProperties_3_4");

--- a/src/test/java/org/openrewrite/java/spring/boot3/PreciseBeanTypeTest.java
+++ b/src/test/java/org/openrewrite/java/spring/boot3/PreciseBeanTypeTest.java
@@ -31,7 +31,7 @@ class PreciseBeanTypeTest implements RewriteTest {
     public void defaults(RecipeSpec spec) {
         spec.recipe(new PreciseBeanType())
           .parser(JavaParser.fromJavaVersion()
-            .classpathFromResources(new InMemoryExecutionContext(), "spring-context-5.+", "spring-boot-3.+"));
+            .classpathFromResources(new InMemoryExecutionContext(), "spring-context-5.+", "spring-boot-3.5"));
     }
 
     @DocumentExample

--- a/src/test/java/org/openrewrite/java/spring/boot3/RemoveConstructorBindingAnnotationTest.java
+++ b/src/test/java/org/openrewrite/java/spring/boot3/RemoveConstructorBindingAnnotationTest.java
@@ -33,7 +33,7 @@ class RemoveConstructorBindingAnnotationTest implements RewriteTest {
     public void defaults(RecipeSpec spec) {
         spec.recipe(new RemoveConstructorBindingAnnotation())
           .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(),
-            "spring-boot-2"));
+            "spring-boot-2.7"));
     }
 
     @DocumentExample

--- a/src/test/java/org/openrewrite/java/spring/boot3/RemoveEnableBatchProcessingTest.java
+++ b/src/test/java/org/openrewrite/java/spring/boot3/RemoveEnableBatchProcessingTest.java
@@ -29,7 +29,7 @@ class RemoveEnableBatchProcessingTest implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
         spec.recipe(new RemoveEnableBatchProcessing())
-          .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(), "spring-batch-core-4", "spring-boot-autoconfigure-2"));
+          .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(), "spring-batch-core-4", "spring-boot-autoconfigure-2.7"));
     }
 
     @DocumentExample

--- a/src/test/java/org/openrewrite/java/spring/boot3/ReplaceMockBeanAndSpyBeanTest.java
+++ b/src/test/java/org/openrewrite/java/spring/boot3/ReplaceMockBeanAndSpyBeanTest.java
@@ -30,7 +30,7 @@ class ReplaceMockBeanAndSpyBeanTest implements RewriteTest {
     public void defaults(RecipeSpec spec) {
         spec.recipeFromResources("org.openrewrite.java.spring.boot4.ReplaceMockBeanAndSpyBean")
           .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(),
-            "spring-boot-test-3", "mockito-core-5"));
+            "spring-boot-test-3.2", "mockito-core-5"));
     }
 
     @DocumentExample

--- a/src/test/java/org/openrewrite/java/spring/boot3/ReplaceRestTemplateBuilderMethodsTest.java
+++ b/src/test/java/org/openrewrite/java/spring/boot3/ReplaceRestTemplateBuilderMethodsTest.java
@@ -29,7 +29,7 @@ class ReplaceRestTemplateBuilderMethodsTest implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
         spec.recipeFromResources("org.openrewrite.java.spring.boot3.ReplaceRestTemplateBuilderMethods")
-          .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(), "spring-boot-3.+", "spring-web-5.+"));
+          .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(), "spring-boot-3.5", "spring-web-5.3"));
     }
 
     @DocumentExample

--- a/src/test/java/org/openrewrite/java/spring/boot4/AddAutoConfigureMockMvcTest.java
+++ b/src/test/java/org/openrewrite/java/spring/boot4/AddAutoConfigureMockMvcTest.java
@@ -31,7 +31,7 @@ class AddAutoConfigureMockMvcTest implements RewriteTest {
         spec.recipe(new AddAutoConfigureMockMvc())
           .parser(JavaParser.fromJavaVersion()
             .classpathFromResources(new InMemoryExecutionContext(),
-              "spring-boot-test-3",
+              "spring-boot-test-3.2",
               "spring-beans-6")
             .dependsOn(
               """

--- a/src/test/java/org/openrewrite/java/spring/boot4/AddAutoConfigureTestRestTemplateTest.java
+++ b/src/test/java/org/openrewrite/java/spring/boot4/AddAutoConfigureTestRestTemplateTest.java
@@ -33,12 +33,12 @@ class AddAutoConfigureTestRestTemplateTest implements RewriteTest {
             .classpathFromResources(new InMemoryExecutionContext(),
               "spring-boot-resttestclient-4",
               "spring-boot-autoconfigure-3",
-              "spring-boot-3",
-              "spring-boot-test-3",
+              "spring-boot-3.5",
+              "spring-boot-test-3.2",
               "spring-boot-test-autoconfigure-3",
               "spring-beans-6",
-              "spring-context-6",
-              "spring-web-6",
+              "spring-context-6.2",
+              "spring-web-6.2",
               "spring-core-6"));
     }
 
@@ -110,7 +110,7 @@ class AddAutoConfigureTestRestTemplateTest implements RewriteTest {
           spec -> spec.parser(JavaParser.fromJavaVersion()
             .classpathFromResources(new InMemoryExecutionContext(),
               "spring-boot-resttestclient-4",
-              "spring-boot-test-3",
+              "spring-boot-test-3.2",
               "spring-beans-6")
             .dependsOn(
               """

--- a/src/test/java/org/openrewrite/java/spring/boot4/AddAutoConfigureWebTestClientTest.java
+++ b/src/test/java/org/openrewrite/java/spring/boot4/AddAutoConfigureWebTestClientTest.java
@@ -31,7 +31,7 @@ class AddAutoConfigureWebTestClientTest implements RewriteTest {
         spec.recipe(new AddAutoConfigureWebTestClient())
           .parser(JavaParser.fromJavaVersion()
             .classpathFromResources(new InMemoryExecutionContext(),
-              "spring-boot-test-3",
+              "spring-boot-test-3.2",
               "spring-beans-6")
             .dependsOn(
               """

--- a/src/test/java/org/openrewrite/java/spring/boot4/MigrateMongoDbModularStartersTest.java
+++ b/src/test/java/org/openrewrite/java/spring/boot4/MigrateMongoDbModularStartersTest.java
@@ -40,12 +40,12 @@ class MigrateMongoDbModularStartersTest implements RewriteTest {
           .parser(JavaParser.fromJavaVersion()
             .classpathFromResources(new InMemoryExecutionContext(),
               "spring-boot-autoconfigure-3",
-              "spring-boot-3",
-              "spring-boot-test-3",
+              "spring-boot-3.5",
+              "spring-boot-test-3.2",
               "spring-boot-test-autoconfigure-3",
               "spring-beans-6",
-              "spring-context-6",
-              "spring-web-6",
+              "spring-context-6.2",
+              "spring-web-6.2",
               "spring-core-6")
             .dependsOn(
               """

--- a/src/test/java/org/openrewrite/java/spring/boot4/MigrateToModularStartersTest.java
+++ b/src/test/java/org/openrewrite/java/spring/boot4/MigrateToModularStartersTest.java
@@ -41,12 +41,12 @@ class MigrateToModularStartersTest implements RewriteTest {
         ).parser(JavaParser.fromJavaVersion()
           .classpathFromResources(new InMemoryExecutionContext(),
             "spring-boot-autoconfigure-3",
-            "spring-boot-3",
-            "spring-boot-test-3",
+            "spring-boot-3.5",
+            "spring-boot-test-3.2",
             "spring-boot-test-autoconfigure-3",
             "spring-beans-6",
-            "spring-context-6",
-            "spring-web-6",
+            "spring-context-6.2",
+            "spring-web-6.2",
             "spring-core-6"));
     }
 
@@ -342,7 +342,7 @@ class MigrateToModularStartersTest implements RewriteTest {
               "org.openrewrite.java.spring.boot4.MigrateToModularStarters"
             ).parser(JavaParser.fromJavaVersion()
               .classpathFromResources(new InMemoryExecutionContext(),
-                "spring-boot-actuator-3"));
+                "spring-boot-actuator-3.4"));
         }
 
         @Test

--- a/src/test/java/org/openrewrite/java/spring/boot4/RelocateWebServerClassesTest.java
+++ b/src/test/java/org/openrewrite/java/spring/boot4/RelocateWebServerClassesTest.java
@@ -32,7 +32,7 @@ class RelocateWebServerClassesTest implements RewriteTest {
           "/META-INF/rewrite/spring-boot-40-modular-starters.yml",
           "org.openrewrite.java.spring.boot4.RelocateWebServerClasses"
         ).parser(JavaParser.fromJavaVersion()
-          .classpathFromResources(new InMemoryExecutionContext(), "spring-boot-3"));
+          .classpathFromResources(new InMemoryExecutionContext(), "spring-boot-3.5"));
     }
 
     @DocumentExample

--- a/src/test/java/org/openrewrite/java/spring/boot4/UnwrapMockAndSpyBeanContainersTest.java
+++ b/src/test/java/org/openrewrite/java/spring/boot4/UnwrapMockAndSpyBeanContainersTest.java
@@ -32,9 +32,9 @@ class UnwrapMockAndSpyBeanContainersTest implements RewriteTest {
     public void defaults(RecipeSpec spec) {
         spec.recipe(new UnwrapMockAndSpyBeanContainers())
           .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(),
-            "spring-boot-test-3", "mockito-core-5"))
+            "spring-boot-test-3.2", "mockito-core-5"))
           .parser(KotlinParser.builder().classpathFromResources(new InMemoryExecutionContext(),
-            "spring-boot-test-3", "mockito-core-5"));
+            "spring-boot-test-3.2", "mockito-core-5"));
     }
 
     @DocumentExample

--- a/src/test/java/org/openrewrite/java/spring/cloud2022/MigrateRequestMappingOnFeignClientTest.java
+++ b/src/test/java/org/openrewrite/java/spring/cloud2022/MigrateRequestMappingOnFeignClientTest.java
@@ -31,7 +31,7 @@ class MigrateRequestMappingOnFeignClientTest implements RewriteTest {
         spec
           .recipe(new MigrateRequestMappingOnFeignClient())
           .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(),
-            "spring-web-6",
+            "spring-web-6.2",
             "spring-cloud-openfeign-core"));
     }
 

--- a/src/test/java/org/openrewrite/java/spring/data/MigrateJpaSortTest.java
+++ b/src/test/java/org/openrewrite/java/spring/data/MigrateJpaSortTest.java
@@ -29,7 +29,10 @@ class MigrateJpaSortTest implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
         spec.recipe(new MigrateJpaSort())
-          .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(), "javax.persistence-api-2.+", "spring-data-jpa-2.7", "spring-data-commons-2.7.+"));
+          .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(),
+            "javax.persistence-api-2.+",
+            "spring-data-jpa-2.7",
+            "spring-data-commons-2.7.+"));
     }
 
     @DocumentExample

--- a/src/test/java/org/openrewrite/java/spring/data/MigrateJpaSortTest.java
+++ b/src/test/java/org/openrewrite/java/spring/data/MigrateJpaSortTest.java
@@ -29,7 +29,7 @@ class MigrateJpaSortTest implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
         spec.recipe(new MigrateJpaSort())
-          .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(), "javax.persistence-api-2.+", "spring-data-jpa-2.+", "spring-data-commons-2.7.+"));
+          .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(), "javax.persistence-api-2.+", "spring-data-jpa-2.7", "spring-data-commons-2.7.+"));
     }
 
     @DocumentExample

--- a/src/test/java/org/openrewrite/java/spring/data/MigratePagingAndSortingRepositoryTest.java
+++ b/src/test/java/org/openrewrite/java/spring/data/MigratePagingAndSortingRepositoryTest.java
@@ -30,7 +30,7 @@ class MigratePagingAndSortingRepositoryTest implements RewriteTest {
     public void defaults(RecipeSpec spec) {
         spec.recipe(new MigratePagingAndSortingRepository())
           .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(),
-            "spring-data-commons-2.*", "spring-data-jpa-2.*"));
+            "spring-data-commons-2.*", "spring-data-jpa-2.7"));
     }
 
     @DocumentExample

--- a/src/test/java/org/openrewrite/java/spring/data/MigrateQuerydslJpaRepositoryTest.java
+++ b/src/test/java/org/openrewrite/java/spring/data/MigrateQuerydslJpaRepositoryTest.java
@@ -29,7 +29,7 @@ class MigrateQuerydslJpaRepositoryTest implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
         spec.recipe(new MigrateQuerydslJpaRepository())
-          .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(), "javax.persistence-api-2.+", "spring-data-jpa-2.+", "spring-data-commons-2.7.+"));
+          .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(), "javax.persistence-api-2.+", "spring-data-jpa-2.7", "spring-data-commons-2.7.+"));
     }
 
     @DocumentExample

--- a/src/test/java/org/openrewrite/java/spring/data/MigrateQuerydslJpaRepositoryTest.java
+++ b/src/test/java/org/openrewrite/java/spring/data/MigrateQuerydslJpaRepositoryTest.java
@@ -29,7 +29,10 @@ class MigrateQuerydslJpaRepositoryTest implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
         spec.recipe(new MigrateQuerydslJpaRepository())
-          .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(), "javax.persistence-api-2.+", "spring-data-jpa-2.7", "spring-data-commons-2.7.+"));
+          .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(),
+            "javax.persistence-api-2.+",
+            "spring-data-jpa-2.7",
+            "spring-data-commons-2.7.+"));
     }
 
     @DocumentExample

--- a/src/test/java/org/openrewrite/java/spring/data/MigrateRepositoryRestConfigurerAdapterTest.java
+++ b/src/test/java/org/openrewrite/java/spring/data/MigrateRepositoryRestConfigurerAdapterTest.java
@@ -29,7 +29,7 @@ class MigrateRepositoryRestConfigurerAdapterTest implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
         spec.parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(),
-            "spring-data-rest-webmvc", "spring-context-5", "spring-web-5"))
+            "spring-data-rest-webmvc", "spring-context-5", "spring-web-5.3"))
           .recipe(new MigrateRepositoryRestConfigurerAdapter());
     }
 

--- a/src/test/java/org/openrewrite/java/spring/data/MigrateRepositoryRestConfigurerAdapterTest.java
+++ b/src/test/java/org/openrewrite/java/spring/data/MigrateRepositoryRestConfigurerAdapterTest.java
@@ -29,7 +29,9 @@ class MigrateRepositoryRestConfigurerAdapterTest implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
         spec.parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(),
-            "spring-data-rest-webmvc", "spring-context-5", "spring-web-5.3"))
+            "spring-data-rest-webmvc",
+            "spring-context-5",
+            "spring-web-5.3"))
           .recipe(new MigrateRepositoryRestConfigurerAdapter());
     }
 

--- a/src/test/java/org/openrewrite/java/spring/doc/MigrateDocketBeanToGroupedOpenApiBeanTest.java
+++ b/src/test/java/org/openrewrite/java/spring/doc/MigrateDocketBeanToGroupedOpenApiBeanTest.java
@@ -32,9 +32,9 @@ class MigrateDocketBeanToGroupedOpenApiBeanTest implements RewriteTest {
     public void defaults(RecipeSpec spec) {
         spec.recipe(new MigrateDocketBeanToGroupedOpenApiBean())
           .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(),
-            "spring-core",
-            "spring-context",
-            "spring-beans",
+            "spring-core-5",
+            "spring-context-5",
+            "spring-beans-5",
             "spring-plugin-core",
             "springfox-core",
             "springfox-spring-web",

--- a/src/test/java/org/openrewrite/java/spring/framework/HttpComponentsClientHttpRequestFactoryConnectTimeoutTest.java
+++ b/src/test/java/org/openrewrite/java/spring/framework/HttpComponentsClientHttpRequestFactoryConnectTimeoutTest.java
@@ -89,7 +89,10 @@ class HttpComponentsClientHttpRequestFactoryConnectTimeoutTest implements Rewrit
     void commentsEvenWhenConnectionManagerIsPresent() {
         rewriteRun(
           spec -> spec.parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(),
-            "spring-beans-6", "spring-web-6.2", "httpclient5", "httpcore5")),
+            "spring-beans-6",
+            "spring-web-6.2",
+            "httpclient5",
+            "httpcore5")),
           //language=java
           java(
             """

--- a/src/test/java/org/openrewrite/java/spring/framework/HttpComponentsClientHttpRequestFactoryConnectTimeoutTest.java
+++ b/src/test/java/org/openrewrite/java/spring/framework/HttpComponentsClientHttpRequestFactoryConnectTimeoutTest.java
@@ -89,7 +89,7 @@ class HttpComponentsClientHttpRequestFactoryConnectTimeoutTest implements Rewrit
     void commentsEvenWhenConnectionManagerIsPresent() {
         rewriteRun(
           spec -> spec.parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(),
-            "spring-beans-6", "spring-web-6", "httpclient5", "httpcore5")),
+            "spring-beans-6", "spring-web-6.2", "httpclient5", "httpcore5")),
           //language=java
           java(
             """

--- a/src/test/java/org/openrewrite/java/spring/framework/HttpComponentsClientHttpRequestFactoryReadTimeoutTest.java
+++ b/src/test/java/org/openrewrite/java/spring/framework/HttpComponentsClientHttpRequestFactoryReadTimeoutTest.java
@@ -31,7 +31,7 @@ class HttpComponentsClientHttpRequestFactoryReadTimeoutTest implements RewriteTe
         spec.recipe(new HttpComponentsClientHttpRequestFactoryReadTimeout())
           .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(),
             "spring-beans-5.3",
-            "spring-boot-3",
+            "spring-boot-3.5",
             "spring-web-5.3",
             "httpclient5",
             "httpcore5"));

--- a/src/test/java/org/openrewrite/java/spring/framework/MigrateClientHttpResponseGetRawStatusCodeMethodTest.java
+++ b/src/test/java/org/openrewrite/java/spring/framework/MigrateClientHttpResponseGetRawStatusCodeMethodTest.java
@@ -28,7 +28,7 @@ class MigrateClientHttpResponseGetRawStatusCodeMethodTest implements RewriteTest
     @Override
     public void defaults(RecipeSpec spec) {
         spec.recipe(new MigrateClientHttpResponseGetRawStatusCodeMethod())
-          .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(), "spring-web-6"));
+          .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(), "spring-web-6.2"));
     }
 
     @DocumentExample

--- a/src/test/java/org/openrewrite/java/spring/framework/MigrateMethodArgumentNotValidExceptionErrorMethodTest.java
+++ b/src/test/java/org/openrewrite/java/spring/framework/MigrateMethodArgumentNotValidExceptionErrorMethodTest.java
@@ -31,7 +31,7 @@ class MigrateMethodArgumentNotValidExceptionErrorMethodTest implements RewriteTe
         spec
           .recipe(new MigrateMethodArgumentNotValidExceptionErrorMethod())
           .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(),
-            "spring-context-6.+", "spring-web-6.1.+"));
+            "spring-context-6.2", "spring-web-6.1.+"));
     }
 
     @DocumentExample

--- a/src/test/java/org/openrewrite/java/spring/framework/MigrateResponseEntityExceptionHandlerHttpStatusToHttpStatusCodeTest.java
+++ b/src/test/java/org/openrewrite/java/spring/framework/MigrateResponseEntityExceptionHandlerHttpStatusToHttpStatusCodeTest.java
@@ -30,7 +30,7 @@ class MigrateResponseEntityExceptionHandlerHttpStatusToHttpStatusCodeTest implem
     public void defaults(RecipeSpec spec) {
         spec.recipe(new MigrateResponseEntityExceptionHandlerHttpStatusToHttpStatusCode())
           .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(),
-            "spring-web-5", "spring-webmvc-5", "jspecify-1"));
+            "spring-web-5.3", "spring-webmvc-5", "jspecify-1"));
     }
 
     @DocumentExample

--- a/src/test/java/org/openrewrite/java/spring/framework/MigrateResponseEntityExceptionHandlerHttpStatusToHttpStatusCodeTest.java
+++ b/src/test/java/org/openrewrite/java/spring/framework/MigrateResponseEntityExceptionHandlerHttpStatusToHttpStatusCodeTest.java
@@ -30,7 +30,9 @@ class MigrateResponseEntityExceptionHandlerHttpStatusToHttpStatusCodeTest implem
     public void defaults(RecipeSpec spec) {
         spec.recipe(new MigrateResponseEntityExceptionHandlerHttpStatusToHttpStatusCode())
           .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(),
-            "spring-web-5.3", "spring-webmvc-5", "jspecify-1"));
+            "spring-web-5.3",
+            "spring-webmvc-5",
+            "jspecify-1"));
     }
 
     @DocumentExample

--- a/src/test/java/org/openrewrite/java/spring/framework/MigrateUriComponentsBuilderMethodsTest.java
+++ b/src/test/java/org/openrewrite/java/spring/framework/MigrateUriComponentsBuilderMethodsTest.java
@@ -35,7 +35,7 @@ class MigrateUriComponentsBuilderMethodsTest implements RewriteTest {
           .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(),
             "spring-web-6.1"))
           .parser(KotlinParser.builder().classpathFromResources(new InMemoryExecutionContext(),
-            "spring-web-6"));
+            "spring-web-6.2"));
     }
 
     @DocumentExample

--- a/src/test/java/org/openrewrite/java/spring/framework/MigrateUtf8MediaTypesTest.java
+++ b/src/test/java/org/openrewrite/java/spring/framework/MigrateUtf8MediaTypesTest.java
@@ -31,7 +31,7 @@ class MigrateUtf8MediaTypesTest implements RewriteTest {
     public void defaults(RecipeSpec spec) {
         spec.recipe(new MigrateUtf8MediaTypes())
           .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(),
-            "spring-core-5", "spring-web-5"));
+            "spring-core-5", "spring-web-5.3"));
     }
 
     @DocumentExample

--- a/src/test/java/org/openrewrite/java/spring/framework/MigrateWebExchangeBindExceptionResolveErrorMethodTest.java
+++ b/src/test/java/org/openrewrite/java/spring/framework/MigrateWebExchangeBindExceptionResolveErrorMethodTest.java
@@ -31,7 +31,7 @@ class MigrateWebExchangeBindExceptionResolveErrorMethodTest implements RewriteTe
         spec
           .recipe(new MigrateWebExchangeBindExceptionResolveErrorMethod())
           .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(),
-            "spring-context-6.+",
+            "spring-context-6.2",
             "spring-core-6.+",
             "spring-web-6.1.+"));
     }

--- a/src/test/java/org/openrewrite/java/spring/framework/MigrateWebMvcConfigurerAdapterTest.java
+++ b/src/test/java/org/openrewrite/java/spring/framework/MigrateWebMvcConfigurerAdapterTest.java
@@ -29,7 +29,9 @@ class MigrateWebMvcConfigurerAdapterTest implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
         spec.parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(),
-            "spring-webmvc-5", "spring-core-5", "spring-web-5.3"))
+            "spring-webmvc-5",
+            "spring-core-5",
+            "spring-web-5.3"))
           .recipe(new MigrateWebMvcConfigurerAdapter());
     }
 

--- a/src/test/java/org/openrewrite/java/spring/framework/MigrateWebMvcConfigurerAdapterTest.java
+++ b/src/test/java/org/openrewrite/java/spring/framework/MigrateWebMvcConfigurerAdapterTest.java
@@ -29,7 +29,7 @@ class MigrateWebMvcConfigurerAdapterTest implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
         spec.parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(),
-            "spring-webmvc-5", "spring-core-5", "spring-web-5"))
+            "spring-webmvc-5", "spring-core-5", "spring-web-5.3"))
           .recipe(new MigrateWebMvcConfigurerAdapter());
     }
 

--- a/src/test/java/org/openrewrite/java/spring/http/SimplifyMediaTypeParseCallsTest.java
+++ b/src/test/java/org/openrewrite/java/spring/http/SimplifyMediaTypeParseCallsTest.java
@@ -29,7 +29,7 @@ class SimplifyMediaTypeParseCallsTest implements RewriteTest {
     public void defaults(RecipeSpec spec) {
         spec
           .recipe(new SimplifyMediaTypeParseCalls())
-          .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(), "spring-web-6.+", "spring-core-6.+"));
+          .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(), "spring-web-6.2", "spring-core-6.+"));
     }
 
     @ParameterizedTest

--- a/src/test/java/org/openrewrite/java/spring/http/SimplifyWebTestClientCallsTest.java
+++ b/src/test/java/org/openrewrite/java/spring/http/SimplifyWebTestClientCallsTest.java
@@ -35,9 +35,9 @@ class SimplifyWebTestClientCallsTest implements RewriteTest {
         spec
           .recipe(new SimplifyWebTestClientCalls())
           .parser(JavaParser.fromJavaVersion()
-            .classpathFromResources(new InMemoryExecutionContext(), "spring-web-6.+", "spring-test-6.+"))
+            .classpathFromResources(new InMemoryExecutionContext(), "spring-web-6.2", "spring-test-6.+"))
           .parser(KotlinParser.builder()
-            .classpathFromResources(new InMemoryExecutionContext(), "spring-web-6", "spring-test-6"));
+            .classpathFromResources(new InMemoryExecutionContext(), "spring-web-6.2", "spring-test-6"));
     }
 
     @DocumentExample

--- a/src/test/java/org/openrewrite/java/spring/kafka/UpgradeSpringKafka40Test.java
+++ b/src/test/java/org/openrewrite/java/spring/kafka/UpgradeSpringKafka40Test.java
@@ -30,8 +30,8 @@ class UpgradeSpringKafka40Test implements RewriteTest {
     public void defaults(RecipeSpec spec) {
         spec.recipeFromResource("/META-INF/rewrite/spring-kafka-40.yml", "org.openrewrite.java.spring.kafka.UpgradeSpringKafka_4_0")
           .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(),
-            "spring-kafka-2",
-            "spring-context-6",
+            "spring-kafka-2.9",
+            "spring-context-6.2",
             "spring-core-6",
             "jackson-core-2.20"
           ));

--- a/src/test/java/org/openrewrite/java/spring/kafka/UpgradeSpringKafkaErrorHandlersTest.java
+++ b/src/test/java/org/openrewrite/java/spring/kafka/UpgradeSpringKafkaErrorHandlersTest.java
@@ -30,9 +30,9 @@ class UpgradeSpringKafkaErrorHandlersTest implements RewriteTest {
         spec
           .recipeFromResources("org.openrewrite.java.spring.kafka.UpgradeSpringKafka_2_8_ErrorHandlers")
           .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(),
-            "kafka-clients",
-            "spring-beans",
-            "spring-context",
+            "kafka-clients-3.2",
+            "spring-beans-5",
+            "spring-context-5",
             "spring-core-5",
             "spring-kafka-2.8"
           ));

--- a/src/test/java/org/openrewrite/java/spring/search/FindApiCallsTest.java
+++ b/src/test/java/org/openrewrite/java/spring/search/FindApiCallsTest.java
@@ -35,7 +35,10 @@ class FindApiCallsTest implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
         spec.recipe(new FindApiCalls())
-          .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(), "spring-webflux-5.+", "spring-web-5.3", "spring-boot-3.5"));
+          .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(),
+            "spring-webflux-5.+",
+            "spring-web-5.3",
+            "spring-boot-3.5"));
     }
 
     @DocumentExample

--- a/src/test/java/org/openrewrite/java/spring/search/FindApiCallsTest.java
+++ b/src/test/java/org/openrewrite/java/spring/search/FindApiCallsTest.java
@@ -35,7 +35,7 @@ class FindApiCallsTest implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
         spec.recipe(new FindApiCalls())
-          .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(), "spring-webflux-5.+", "spring-web-5.+", "spring-boot-3.+"));
+          .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(), "spring-webflux-5.+", "spring-web-5.3", "spring-boot-3.5"));
     }
 
     @DocumentExample

--- a/src/test/java/org/openrewrite/java/spring/search/FindApiEndpointsTest.java
+++ b/src/test/java/org/openrewrite/java/spring/search/FindApiEndpointsTest.java
@@ -31,7 +31,7 @@ class FindApiEndpointsTest implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
         spec.recipe(new FindApiEndpoints())
-          .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(), "spring-web-5.+", "spring-context-5.+"));
+          .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(), "spring-web-5.3", "spring-context-5.+"));
     }
 
     @DocumentExample

--- a/src/test/java/org/openrewrite/java/spring/search/FindConfigurationPropertiesTest.java
+++ b/src/test/java/org/openrewrite/java/spring/search/FindConfigurationPropertiesTest.java
@@ -33,7 +33,7 @@ class FindConfigurationPropertiesTest implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
         spec.recipe(new FindConfigurationProperties())
-          .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(), "spring-boot-2.+"));
+          .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(), "spring-boot-2.7"));
     }
 
     @DocumentExample

--- a/src/test/java/org/openrewrite/java/spring/security5/AuthorizeHttpRequestsTest.java
+++ b/src/test/java/org/openrewrite/java/spring/security5/AuthorizeHttpRequestsTest.java
@@ -32,8 +32,13 @@ class AuthorizeHttpRequestsTest implements RewriteTest {
           .parser(JavaParser.fromJavaVersion()
             .classpathFromResources(new InMemoryExecutionContext(),
               "spring-boot-2.7",
-              "spring-beans-4", "spring-context-4", "spring-web-4", "spring-core-4",
-              "spring-security-core-5.7", "spring-security-config-5.7", "spring-security-web-5.7",
+              "spring-beans-4",
+              "spring-context-4",
+              "spring-web-4",
+              "spring-core-4",
+              "spring-security-core-5.7",
+              "spring-security-config-5.7",
+              "spring-security-web-5.7",
               "tomcat-embed"));
     }
 

--- a/src/test/java/org/openrewrite/java/spring/security5/AuthorizeHttpRequestsTest.java
+++ b/src/test/java/org/openrewrite/java/spring/security5/AuthorizeHttpRequestsTest.java
@@ -31,7 +31,7 @@ class AuthorizeHttpRequestsTest implements RewriteTest {
         spec.recipe(new AuthorizeHttpRequests())
           .parser(JavaParser.fromJavaVersion()
             .classpathFromResources(new InMemoryExecutionContext(),
-              "spring-boot-2",
+              "spring-boot-2.7",
               "spring-beans-4", "spring-context-4", "spring-web-4", "spring-core-4",
               "spring-security-core-5.7", "spring-security-config-5.7", "spring-security-web-5.7",
               "tomcat-embed"));

--- a/src/test/java/org/openrewrite/java/spring/security5/ConvertSecurityMatchersToSecurityMatcherTest.java
+++ b/src/test/java/org/openrewrite/java/spring/security5/ConvertSecurityMatchersToSecurityMatcherTest.java
@@ -30,8 +30,11 @@ class ConvertSecurityMatchersToSecurityMatcherTest implements RewriteTest {
     public void defaults(RecipeSpec spec) {
         spec.recipe(new ConvertSecurityMatchersToSecurityMatcher())
           .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(),
-            "spring-context-5.3.+", "spring-beans-5.3.+", "spring-web-5.3.+",
-            "spring-security-web-5.8.+", "spring-security-config-5.8.+"));
+            "spring-context-5.3.+",
+            "spring-beans-5.3.+",
+            "spring-web-5.3.+",
+            "spring-security-web-5.8.+",
+            "spring-security-config-5.8.+"));
     }
 
     @DocumentExample

--- a/src/test/java/org/openrewrite/java/spring/security5/PropagateAuthenticationServiceExceptionsTest.java
+++ b/src/test/java/org/openrewrite/java/spring/security5/PropagateAuthenticationServiceExceptionsTest.java
@@ -31,7 +31,11 @@ class PropagateAuthenticationServiceExceptionsTest implements RewriteTest {
         spec
           .recipe(new PropagateAuthenticationServiceExceptions())
           .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(),
-            "spring-context-5.3.+", "spring-beans-5.3.+", "spring-web-5.3.+", "spring-security-web-5.8.+", "spring-security-config-5.8.+"));
+            "spring-context-5.3.+",
+            "spring-beans-5.3.+",
+            "spring-web-5.3.+",
+            "spring-security-web-5.8.+",
+            "spring-security-config-5.8.+"));
     }
 
     @DocumentExample

--- a/src/test/java/org/openrewrite/java/spring/security5/RemoveFilterSecurityInterceptorOncePerRequestTest.java
+++ b/src/test/java/org/openrewrite/java/spring/security5/RemoveFilterSecurityInterceptorOncePerRequestTest.java
@@ -31,7 +31,11 @@ class RemoveFilterSecurityInterceptorOncePerRequestTest implements RewriteTest {
     public void defaults(RecipeSpec spec) {
         spec.recipe(new RemoveFilterSecurityInterceptorOncePerRequest())
           .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(),
-            "spring-context-5.3.+", "spring-beans-5.3.+", "spring-web-5.3.+", "spring-security-web-5.8.+", "spring-security-config-5.8.+"));
+            "spring-context-5.3.+",
+            "spring-beans-5.3.+",
+            "spring-web-5.3.+",
+            "spring-security-web-5.8.+",
+            "spring-security-config-5.8.+"));
     }
 
     @DocumentExample

--- a/src/test/java/org/openrewrite/java/spring/security5/RemoveOauth2LoginConfigTest.java
+++ b/src/test/java/org/openrewrite/java/spring/security5/RemoveOauth2LoginConfigTest.java
@@ -30,7 +30,12 @@ class RemoveOauth2LoginConfigTest implements RewriteTest {
     public void defaults(RecipeSpec spec) {
         spec.recipe(new RemoveOauth2LoginConfig())
           .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(),
-            "spring-context-5.3.+", "spring-beans-5.3.+", "spring-web-5.3.+", "spring-security-web-5.8.+", "spring-security-config-5.8.+", "spring-security-oauth2-client-5.8.+"));
+            "spring-context-5.3.+",
+            "spring-beans-5.3.+",
+            "spring-web-5.3.+",
+            "spring-security-web-5.8.+",
+            "spring-security-config-5.8.+",
+            "spring-security-oauth2-client-5.8.+"));
     }
 
     @DocumentExample

--- a/src/test/java/org/openrewrite/java/spring/security5/ReplaceGlobalMethodSecurityWithMethodSecurityTest.java
+++ b/src/test/java/org/openrewrite/java/spring/security5/ReplaceGlobalMethodSecurityWithMethodSecurityTest.java
@@ -29,7 +29,7 @@ class ReplaceGlobalMethodSecurityWithMethodSecurityTest implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
         spec.recipe(new ReplaceGlobalMethodSecurityWithMethodSecurity())
-          .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(), "spring-security-config-5.+"));
+          .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(), "spring-security-config-5.8"));
     }
 
     @DocumentExample

--- a/src/test/java/org/openrewrite/java/spring/security5/UpdateEnableReactiveMethodSecurityTest.java
+++ b/src/test/java/org/openrewrite/java/spring/security5/UpdateEnableReactiveMethodSecurityTest.java
@@ -30,8 +30,10 @@ class UpdateEnableReactiveMethodSecurityTest implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
         spec.recipe(new UpdateEnableReactiveMethodSecurity())
-          .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(), "spring-security-web-5.8",
-            "spring-security-config-5.8", "spring-context-5.3"));
+          .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(),
+            "spring-security-web-5.8",
+            "spring-security-config-5.8",
+            "spring-context-5.3"));
     }
 
     @DocumentExample

--- a/src/test/java/org/openrewrite/java/spring/security5/UpdateRequestCacheTest.java
+++ b/src/test/java/org/openrewrite/java/spring/security5/UpdateRequestCacheTest.java
@@ -31,8 +31,11 @@ class UpdateRequestCacheTest implements RewriteTest {
     public void defaults(RecipeSpec spec) {
         spec.recipe(new UpdateRequestCache())
           .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(),
-            "spring-context-5.3.+", "spring-beans-5.3.+", "spring-web-5.3.+",
-            "spring-security-web-5.8.+", "spring-security-config-5.8.+"));
+            "spring-context-5.3.+",
+            "spring-beans-5.3.+",
+            "spring-web-5.3.+",
+            "spring-security-web-5.8.+",
+            "spring-security-config-5.8.+"));
     }
 
     @DocumentExample

--- a/src/test/java/org/openrewrite/java/spring/security5/UpgradeSpringSecurityTest.java
+++ b/src/test/java/org/openrewrite/java/spring/security5/UpgradeSpringSecurityTest.java
@@ -28,7 +28,14 @@ class UpgradeSpringSecurityTest implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
         spec.parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(),
-            "spring-core-5.3.+", "spring-context-5.3.+", "spring-beans-5.3.+", "spring-web-5.3.+", "spring-security-web-5.8.+", "spring-security-config-5.8.+", "spring-security-core-5.8.+", "tomcat-embed"))
+            "spring-core-5.3.+",
+            "spring-context-5.3.+",
+            "spring-beans-5.3.+",
+            "spring-web-5.3.+",
+            "spring-security-web-5.8.+",
+            "spring-security-config-5.8.+",
+            "spring-security-core-5.8.+",
+            "tomcat-embed"))
           .recipeFromResources("org.openrewrite.java.spring.security5.UpgradeSpringSecurity_5_8");
     }
 

--- a/src/test/java/org/openrewrite/java/spring/security5/UseNewRequestMatchersTest.java
+++ b/src/test/java/org/openrewrite/java/spring/security5/UseNewRequestMatchersTest.java
@@ -31,8 +31,11 @@ class UseNewRequestMatchersTest implements RewriteTest {
     public void defaults(RecipeSpec spec) {
         spec.recipe(new UseNewRequestMatchers())
           .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(),
-            "spring-context-5.3.+", "spring-beans-5.3.+", "spring-web-5.3.+",
-            "spring-security-web-5.8.+", "spring-security-config-5.8.+"));
+            "spring-context-5.3.+",
+            "spring-beans-5.3.+",
+            "spring-web-5.3.+",
+            "spring-security-web-5.8.+",
+            "spring-security-config-5.8.+"));
     }
 
     @DocumentExample

--- a/src/test/java/org/openrewrite/java/spring/security5/UseNewSecurityMatchersTest.java
+++ b/src/test/java/org/openrewrite/java/spring/security5/UseNewSecurityMatchersTest.java
@@ -36,7 +36,11 @@ class UseNewSecurityMatchersTest implements RewriteTest {
     public void defaults(RecipeSpec spec) {
         spec.recipe(new UseNewSecurityMatchers())
           .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(),
-            "spring-context-5.3.+", "spring-beans-5.3.+", "spring-web-5.3.+", "spring-security-web-5.7.+", "spring-security-config-5.7.+"));
+            "spring-context-5.3.+",
+            "spring-beans-5.3.+",
+            "spring-web-5.3.+",
+            "spring-security-web-5.7.+",
+            "spring-security-config-5.7.+"));
     }
 
     @DocumentExample

--- a/src/test/java/org/openrewrite/java/spring/security5/UseSha256InRememberMeTest.java
+++ b/src/test/java/org/openrewrite/java/spring/security5/UseSha256InRememberMeTest.java
@@ -32,10 +32,10 @@ class UseSha256InRememberMeTest implements RewriteTest {
         spec.recipe(new UseSha256InRememberMe())
           .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(),
             "spring-beans-6.+",
-            "spring-context-6.+",
+            "spring-context-6.2",
             "spring-security-core-6.+",
-            "spring-security-config-6.+",
-            "spring-security-web-6.+"));
+            "spring-security-config-6.2",
+            "spring-security-web-6.2"));
     }
 
     @DocumentExample

--- a/src/test/java/org/openrewrite/java/spring/security5/WebSecurityConfigurerAdapterTest.java
+++ b/src/test/java/org/openrewrite/java/spring/security5/WebSecurityConfigurerAdapterTest.java
@@ -33,7 +33,7 @@ class WebSecurityConfigurerAdapterTest implements RewriteTest {
         spec.recipe(new WebSecurityConfigurerAdapter())
           .parser(JavaParser.fromJavaVersion()
             .classpathFromResources(new InMemoryExecutionContext(),
-              "spring-boot-autoconfigure-2", "spring-boot-2",
+              "spring-boot-autoconfigure-2.7", "spring-boot-2.7",
               "spring-beans-4", "spring-context-4", "spring-web-4", "spring-core-4",
               "spring-security-core-5.7", "spring-security-config-5.7", "spring-security-web-5.7",
               "tomcat-embed"

--- a/src/test/java/org/openrewrite/java/spring/security5/WebSecurityConfigurerAdapterTest.java
+++ b/src/test/java/org/openrewrite/java/spring/security5/WebSecurityConfigurerAdapterTest.java
@@ -33,9 +33,15 @@ class WebSecurityConfigurerAdapterTest implements RewriteTest {
         spec.recipe(new WebSecurityConfigurerAdapter())
           .parser(JavaParser.fromJavaVersion()
             .classpathFromResources(new InMemoryExecutionContext(),
-              "spring-boot-autoconfigure-2.7", "spring-boot-2.7",
-              "spring-beans-4", "spring-context-4", "spring-web-4", "spring-core-4",
-              "spring-security-core-5.7", "spring-security-config-5.7", "spring-security-web-5.7",
+              "spring-boot-autoconfigure-2.7",
+              "spring-boot-2.7",
+              "spring-beans-4",
+              "spring-context-4",
+              "spring-web-4",
+              "spring-core-4",
+              "spring-security-core-5.7",
+              "spring-security-config-5.7",
+              "spring-security-web-5.7",
               "tomcat-embed"
             ));
     }

--- a/src/test/java/org/openrewrite/java/spring/security6/ApplyToWithLambdaDslTest.java
+++ b/src/test/java/org/openrewrite/java/spring/security6/ApplyToWithLambdaDslTest.java
@@ -31,7 +31,10 @@ class ApplyToWithLambdaDslTest implements RewriteTest {
     public void defaults(RecipeSpec spec) {
         spec.recipe(new ApplyToWithLambdaDsl())
           .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(),
-            "spring-security-config-6.2.+", "spring-security-web-6.2.+", "spring-context-5.+", "slf4j-api"));
+            "spring-security-config-6.2.+",
+            "spring-security-web-6.2.+",
+            "spring-context-5.+",
+            "slf4j-api"));
     }
 
     @DocumentExample

--- a/src/test/java/org/openrewrite/java/spring/security6/oauth2/client/OAuth2ClientLambdaDslTest.java
+++ b/src/test/java/org/openrewrite/java/spring/security6/oauth2/client/OAuth2ClientLambdaDslTest.java
@@ -34,8 +34,13 @@ class OAuth2ClientLambdaDslTest implements RewriteTest {
           .parser(JavaParser.fromJavaVersion()
             .classpathFromResources(new InMemoryExecutionContext(),
               "spring-boot-2.4",
-              "spring-beans-5.3", "spring-context-5.3", "spring-web-5.3", "spring-core-5.3",
-              "spring-security-core-5.5", "spring-security-config-5.5", "spring-security-web-5.5",
+              "spring-beans-5.3",
+              "spring-context-5.3",
+              "spring-web-5.3",
+              "spring-core-5.3",
+              "spring-security-core-5.5",
+              "spring-security-config-5.5",
+              "spring-security-web-5.5",
               "tomcat-embed"));
     }
 

--- a/src/test/java/org/openrewrite/java/spring/security6/oauth2/client/OAuth2LoginLambdaDslTest.java
+++ b/src/test/java/org/openrewrite/java/spring/security6/oauth2/client/OAuth2LoginLambdaDslTest.java
@@ -32,8 +32,14 @@ class OAuth2LoginLambdaDslTest implements RewriteTest {
           .parser(JavaParser.fromJavaVersion()
             .classpathFromResources(new InMemoryExecutionContext(),
               "spring-boot-2.4",
-              "spring-beans-5.3", "spring-context-5.3", "spring-web-5.3", "spring-webmvc-5.3", "spring-core-5.3",
-              "spring-security-core-5.5", "spring-security-config-5.5", "spring-security-web-5.5",
+              "spring-beans-5.3",
+              "spring-context-5.3",
+              "spring-web-5.3",
+              "spring-webmvc-5.3",
+              "spring-core-5.3",
+              "spring-security-core-5.5",
+              "spring-security-config-5.5",
+              "spring-security-web-5.5",
               "tomcat-embed"));
     }
 

--- a/src/test/java/org/openrewrite/java/spring/security6/oauth2/server/resource/OAuth2ResourceServerLambdaDslTest.java
+++ b/src/test/java/org/openrewrite/java/spring/security6/oauth2/server/resource/OAuth2ResourceServerLambdaDslTest.java
@@ -36,8 +36,14 @@ class OAuth2ResourceServerLambdaDslTest implements RewriteTest {
         spec.recipe(new OAuth2ResourceServerLambdaDsl())
           .parser(JavaParser.fromJavaVersion()
             .classpathFromResources(new InMemoryExecutionContext(),
-              "spring-beans-5", "spring-context-5", "spring-boot-2.7", "spring-web-5.3", "spring-core-5",
-              "spring-security-core-5.8", "spring-security-config-5.8", "spring-security-web-5.8",
+              "spring-beans-5",
+              "spring-context-5",
+              "spring-boot-2.7",
+              "spring-web-5.3",
+              "spring-core-5",
+              "spring-security-core-5.8",
+              "spring-security-config-5.8",
+              "spring-security-web-5.8",
               "tomcat-embed"))
           .parser(KotlinParser.builder()
             .classpathFromResources(new InMemoryExecutionContext(),

--- a/src/test/java/org/openrewrite/java/spring/security6/oauth2/server/resource/OAuth2ResourceServerLambdaDslTest.java
+++ b/src/test/java/org/openrewrite/java/spring/security6/oauth2/server/resource/OAuth2ResourceServerLambdaDslTest.java
@@ -36,13 +36,13 @@ class OAuth2ResourceServerLambdaDslTest implements RewriteTest {
         spec.recipe(new OAuth2ResourceServerLambdaDsl())
           .parser(JavaParser.fromJavaVersion()
             .classpathFromResources(new InMemoryExecutionContext(),
-              "spring-beans", "spring-context", "spring-boot", "spring-web", "spring-core",
-              "spring-security-core-5", "spring-security-config-5", "spring-security-web-5",
+              "spring-beans-5", "spring-context-5", "spring-boot-2.7", "spring-web-5.3", "spring-core-5",
+              "spring-security-core-5.8", "spring-security-config-5.8", "spring-security-web-5.8",
               "tomcat-embed"))
           .parser(KotlinParser.builder()
             .classpathFromResources(new InMemoryExecutionContext(),
-              "spring-beans", "spring-context", "spring-boot", "spring-web", "spring-core",
-              "spring-security-core-5", "spring-security-config-5", "spring-security-web-5",
+              "spring-beans-5", "spring-context-5", "spring-boot-2.7", "spring-web-5.3", "spring-core-5",
+              "spring-security-core-5.8", "spring-security-config-5.8", "spring-security-web-5.8",
               "tomcat-embed")
           );
     }

--- a/src/test/java/org/openrewrite/java/spring/util/concurrent/ListenableToCompletableFutureTest.java
+++ b/src/test/java/org/openrewrite/java/spring/util/concurrent/ListenableToCompletableFutureTest.java
@@ -30,7 +30,7 @@ class ListenableToCompletableFutureTest implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
         spec.recipe(new ListenableToCompletableFuture())
-          .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(), "spring-core-6", "spring-kafka-2"));
+          .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(), "spring-core-6", "spring-kafka-2.9"));
     }
 
     @DocumentExample


### PR DESCRIPTION
## What's changed?
Pin ambiguous `classpathFromResources()` artifact versions in tests.

## What's your motivation?
Few tests were failing randomly on my local machine on main branch.

## Anything in particular you'd like reviewers to focus on?
Are these pinned versions correct? Build is green but maybe I missed something.

## Anyone you would like to review specifically?
@timtebeek 

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
