### PR TITLE
Fix non-varargs call warnings in AddRouteTrailingSlash

### DIFF
--- a/src/main/java/org/openrewrite/java/spring/boot3/AddRouteTrailingSlash.java
+++ b/src/main/java/org/openrewrite/java/spring/boot3/AddRouteTrailingSlash.java
@@ -101,10 +101,10 @@ public class AddRouteTrailingSlash extends Recipe {
         return !str.endsWith("/") && !str.endsWith("*");
     }
 
-    private J[] buildTwoStringsArray(J.Literal path) {
+    private Object[] buildTwoStringsArray(J.Literal path) {
         String oriPath = path.getValue().toString();
         String pathWithTrailingSlash = oriPath + '/';
-        return new J[]{
+        return new Object[]{
                 path.withId(Tree.randomId())
                         .withPrefix(EMPTY),
                 path.withId(Tree.randomId())


### PR DESCRIPTION
`buildTwoStringsArray` returned `J[]`, which is assignable to the `Object...` parameter of `JavaTemplate.apply` but not an exact match. That left javac unable to tell whether the array should be spread into two varargs slots or wrapped as a single element, so it warned at both call sites while silently picking the spread interpretation that was intended.

Changing the return type and array to `Object[]` makes the varargs match exact, silencing both warnings. No call sites changed and behavior is unchanged; `AddRouteTrailingSlashTest` passes.