### PR TITLE
Record `@Bean` return types in the Spring components data table

### DIFF
--- a/src/main/java/org/openrewrite/java/spring/search/FindSpringComponents.java
+++ b/src/main/java/org/openrewrite/java/spring/search/FindSpringComponents.java
@@ -71,7 +71,14 @@ public class FindSpringComponents extends Recipe {
                         m.getReturnTypeExpression() != null) {
 
                     m = SearchResult.found(m, "bean");
-                    recordDependencies(TypeUtils.asFullyQualified(requireNonNull(m.getReturnTypeExpression()).getType()), m, ctx);
+                    JavaType.FullyQualified beanType = TypeUtils.asFullyQualified(requireNonNull(m.getReturnTypeExpression()).getType());
+                    if (beanType != null) {
+                        springComponents.insertRow(ctx, new SpringComponents.Row(
+                                getCursor().firstEnclosingOrThrow(SourceFile.class).getSourcePath().toString(),
+                                beanType.getFullyQualifiedName()
+                        ));
+                    }
+                    recordDependencies(beanType, m, ctx);
                 }
                 return m;
             }

--- a/src/test/java/org/openrewrite/java/spring/search/FindSpringComponentsTest.java
+++ b/src/test/java/org/openrewrite/java/spring/search/FindSpringComponentsTest.java
@@ -20,10 +20,12 @@ import org.openrewrite.DocumentExample;
 import org.openrewrite.InMemoryExecutionContext;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.java.spring.table.SpringComponentRelationships;
+import org.openrewrite.java.spring.table.SpringComponents;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
 import static org.openrewrite.PathUtils.separatorsToSystem;
 import static org.openrewrite.java.Assertions.java;
 
@@ -114,6 +116,126 @@ class FindSpringComponentsTest implements RewriteTest {
               /*~~(component)~~>*/@Component
               class C {
                   public C(B b) {}
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void beanReturnTypesAddedToComponentsTable() {
+        rewriteRun(
+          spec -> spec.dataTable(SpringComponents.Row.class, rows ->
+            assertThat(rows)
+              .extracting(SpringComponents.Row::getSourcePath, SpringComponents.Row::getComponentType)
+              .containsExactlyInAnyOrder(
+                tuple(separatorsToSystem("test/Config.java"), "test.A"),
+                tuple(separatorsToSystem("test/C.java"), "test.C"))),
+          //language=java
+          java("package test; class A {}"),
+          //language=java
+          java(
+            """
+              package test;
+              import org.springframework.context.annotation.Bean;
+              import org.springframework.context.annotation.Configuration;
+
+              @Configuration
+              class Config {
+                  @Bean
+                  A a() {
+                      return new A();
+                  }
+              }
+              """,
+            """
+              package test;
+              import org.springframework.context.annotation.Bean;
+              import org.springframework.context.annotation.Configuration;
+
+              @Configuration
+              class Config {
+                  /*~~(bean)~~>*/@Bean
+                  A a() {
+                      return new A();
+                  }
+              }
+              """
+          ),
+          //language=java
+          java(
+            """
+              package test;
+              import org.springframework.stereotype.Component;
+
+              @Component
+              class C {
+              }
+              """,
+            """
+              package test;
+              import org.springframework.stereotype.Component;
+
+              /*~~(component)~~>*/@Component
+              class C {
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void beanMethodWithoutFullyQualifiedReturnTypeNotAddedToComponentsTable() {
+        rewriteRun(
+          spec -> spec.dataTable(SpringComponents.Row.class, rows ->
+            assertThat(rows)
+              .extracting(SpringComponents.Row::getSourcePath, SpringComponents.Row::getComponentType)
+              .containsExactly(tuple(separatorsToSystem("test/C.java"), "test.C"))),
+          //language=java
+          java(
+            """
+              package test;
+              import org.springframework.stereotype.Component;
+
+              @Component
+              class C {
+              }
+              """,
+            """
+              package test;
+              import org.springframework.stereotype.Component;
+
+              /*~~(component)~~>*/@Component
+              class C {
+              }
+              """
+          ),
+          //language=java
+          java(
+            """
+              package test;
+              import org.springframework.context.annotation.Bean;
+              import org.springframework.context.annotation.Configuration;
+
+              @Configuration
+              class Config {
+                  @Bean
+                  int count() {
+                      return 1;
+                  }
+              }
+              """,
+            """
+              package test;
+              import org.springframework.context.annotation.Bean;
+              import org.springframework.context.annotation.Configuration;
+
+              @Configuration
+              class Config {
+                  /*~~(bean)~~>*/@Bean
+                  int count() {
+                      return 1;
+                  }
               }
               """
           )


### PR DESCRIPTION
- This PR proposes recording `@Bean` method return types in the `SpringComponents` data table, so `FindSpringComponents` reports the components its own description promises (fixes #594). We include this PR work along with a full history of your repo at https://eastagiletracker.com/projects/235. You can sign in with your GitHub ID to claim ownership of the project.

## What changed and why

- `FindSpringComponents` marks `@Bean` methods with a `bean` search result and records their parameters in `SpringComponentRelationships`, but it never inserts the bean's return type into `SpringComponents`. That table ships as "Classes defined with a form of a Spring `@Component` stereotype and types returned from `@Bean` annotated methods", so on a codebase whose beans are declared in `@Configuration` classes the table reports fewer components than the recipe actually found, and on one with no `@Component` classes at all the table comes back empty — which is the report in #594.

`visitMethodDeclaration` now resolves the return type once, inserts a `SpringComponents.Row` for it when that type resolves to a fully qualified type, and hands the same resolved type to `recordDependencies`. A `@Bean` method whose return type is not a class — a primitive, say — is still marked as a bean and simply contributes no row, so nothing that the recipe emits today changes: existing rows, markers and relationships are untouched, and the recipe's display name, description and `recipes.csv` entry are all unchanged.

Reproduction against `main` at c8c8585, using the new test as the probe:

```
$ ./gradlew test --tests "org.openrewrite.java.spring.search.FindSpringComponentsTest"

FindSpringComponentsTest > beanReturnTypesAddedToComponentsTable() FAILED
    java.lang.AssertionError:
    Expecting actual:
      [("test/C.java", "test.C")]
    to contain exactly in any order:
      [("test/Config.java", "test.A"), ("test/C.java", "test.C")]
```

`test.A` is the return type of the `@Bean` method the recipe has just marked, and it is absent from the table. Dropping the `@Component` class from that same scenario reproduces the other half of the report — the table is not emitted at all: `No data table found with row type: class org.openrewrite.java.spring.table.SpringComponents$Row`.

Verification: `./gradlew test --tests "org.openrewrite.java.spring.search.FindSpringComponentsTest"` passes with the change and fails without it, and `./gradlew test --tests "org.openrewrite.java.spring.search.*"` is green both before and on the changed tree, so the run adds no new failures. `./gradlew recipeCsvGenerate` leaves `recipes.csv` untouched by this change and `recipeCsvValidateContent` passes. Two tests come with it: `beanReturnTypesAddedToComponentsTable`, which asserts both the component row and the bean-return-type row, and `beanMethodWithoutFullyQualifiedReturnTypeNotAddedToComponentsTable`, the case that should be left alone, which pins that a non-class bean type adds nothing while the `@Component` row still lands. I scoped the local run to the `search` package and the recipe CSV check rather than the whole build, since `FindSpringComponents` is referenced by no other recipe in the repository; the full build is of course yours to run in CI.

## How this was managed

This work was tracked on a board imported from this repository's own issues, pull requests and milestones. The story it maps to is [Datatable not correct for find spring components?](https://eastagiletracker.com/projects/235/stories/101026), on the board at [eastagiletracker.com/projects/235](https://eastagiletracker.com/projects/235).

![board](https://raw.githubusercontent.com/eastagiletracker/rewrite-spring/agile-board-assets/board.png)

If you'd rather not receive contributions like this, reply `no-more-prs` on this pull request and we won't open any further ones on your repositories.

---

**Lawrence W. Sinclair**
CEO / East Agile
[linkedin.com/in/lwsinclair/](https://linkedin.com/in/lwsinclair/)
[eastagile.com](https://eastagile.com)
