### PR TITLE
Add `spring-boot-starter-webflux-test` and relocate the `@WebFluxTest` slice

### DIFF
--- a/src/main/resources/META-INF/rewrite/spring-boot-40-modular-starters.yml
+++ b/src/main/resources/META-INF/rewrite/spring-boot-40-modular-starters.yml
@@ -102,6 +102,21 @@ recipeList:
       version: 4.0.x
       scope: test
       onlyIfUsing: org.springframework.test.web.servlet.MockMvc
+  # @WebFluxTest slice; keyed on specific types rather than the package, since the SB3 package's WebTestClient types belong to spring-boot-webtestclient and also serve MockMvc-backed tests
+  - org.openrewrite.java.dependencies.AddDependency:
+      groupId: org.springframework.boot
+      artifactId: spring-boot-starter-webflux-test
+      acceptTransitive: true
+      version: 4.0.x
+      scope: test
+      onlyIfUsing: org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest
+  - org.openrewrite.java.dependencies.AddDependency:
+      groupId: org.springframework.boot
+      artifactId: spring-boot-starter-webflux-test
+      acceptTransitive: true
+      version: 4.0.x
+      scope: test
+      onlyIfUsing: org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebFlux
   - org.openrewrite.java.dependencies.AddDependency:
       groupId: org.springframework.boot
       artifactId: spring-boot-starter-restclient
@@ -405,6 +420,16 @@ recipeList:
       oldPackageName: org.springframework.boot.test.autoconfigure.web.servlet
       newPackageName: org.springframework.boot.webmvc.test.autoconfigure
       recursive: true
+  # spring-boot-webflux-test: the @WebFluxTest slice, type-by-type since the WebTestClient types below share the SB3 package but move to spring-boot-webtestclient instead
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest
+      newFullyQualifiedTypeName: org.springframework.boot.webflux.test.autoconfigure.WebFluxTest
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebFlux
+      newFullyQualifiedTypeName: org.springframework.boot.webflux.test.autoconfigure.AutoConfigureWebFlux
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTypeExcludeFilter
+      newFullyQualifiedTypeName: org.springframework.boot.webflux.test.autoconfigure.WebFluxTypeExcludeFilter
   # spring-boot-webtestclient (originating from spring-boot-test-autoconfigure and spring-boot-test)
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient

--- a/src/test/java/org/openrewrite/java/spring/boot4/MigrateToModularStartersTest.java
+++ b/src/test/java/org/openrewrite/java/spring/boot4/MigrateToModularStartersTest.java
@@ -333,161 +333,165 @@ class MigrateToModularStartersTest implements RewriteTest {
         );
     }
 
-    @Test
-    void addWebFluxTestStarterIfWebFluxTestIsUsedForTest() {
-        rewriteRun(
-          mavenProject("project",
-            //language=xml
-            pomXml(
-              """
-                <project>
-                    <modelVersion>4.0.0</modelVersion>
-                    <groupId>org.example</groupId>
-                    <artifactId>example</artifactId>
-                    <version>1.0-SNAPSHOT</version>
-                    <dependencies>
-                    </dependencies>
-                </project>
-                """,
-              spec -> spec.after(pom -> assertThat(pom)
-                .contains("<artifactId>spring-boot-starter-webflux-test</artifactId>")
-                .contains("<scope>test</scope>")
-                .containsPattern("<version>4\\.0\\.\\d+</version>")
-                .actual())
-            ),
-            srcTestJava(
-              //language=java
-              java(
-                """
-                  import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest;
+    @Nested
+    class WebFluxTestSlice {
 
-                  @WebFluxTest
-                  class GreetingControllerTest {
-                  }
-                  """,
-                """
-                  import org.springframework.boot.webflux.test.autoconfigure.WebFluxTest;
-
-                  @WebFluxTest
-                  class GreetingControllerTest {
-                  }
+        @Test
+        void addWebFluxTestStarterIfWebFluxTestIsUsedForTest() {
+            rewriteRun(
+              mavenProject("project",
+                //language=xml
+                pomXml(
                   """
-              )
-            )
-          )
-        );
-    }
+                    <project>
+                        <modelVersion>4.0.0</modelVersion>
+                        <groupId>org.example</groupId>
+                        <artifactId>example</artifactId>
+                        <version>1.0-SNAPSHOT</version>
+                        <dependencies>
+                        </dependencies>
+                    </project>
+                    """,
+                  spec -> spec.after(pom -> assertThat(pom)
+                    .contains("<artifactId>spring-boot-starter-webflux-test</artifactId>")
+                    .contains("<scope>test</scope>")
+                    .containsPattern("<version>4\\.0\\.\\d+</version>")
+                    .actual())
+                ),
+                srcTestJava(
+                  //language=java
+                  java(
+                    """
+                      import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest;
 
-    @Test
-    void addWebFluxTestStarterIfAutoConfigureWebFluxIsUsedForTest() {
-        rewriteRun(
-          mavenProject("project",
-            //language=xml
-            pomXml(
-              """
-                <project>
-                    <modelVersion>4.0.0</modelVersion>
-                    <groupId>org.example</groupId>
-                    <artifactId>example</artifactId>
-                    <version>1.0-SNAPSHOT</version>
-                    <dependencies>
-                    </dependencies>
-                </project>
-                """,
-              spec -> spec.after(pom -> assertThat(pom)
-                .contains("<artifactId>spring-boot-starter-webflux-test</artifactId>")
-                .contains("<scope>test</scope>")
-                .containsPattern("<version>4\\.0\\.\\d+</version>")
-                .actual())
-            ),
-            srcTestJava(
+                      @WebFluxTest
+                      class GreetingControllerTest {
+                      }
+                      """,
+                    """
+                      import org.springframework.boot.webflux.test.autoconfigure.WebFluxTest;
+
+                      @WebFluxTest
+                      class GreetingControllerTest {
+                      }
+                      """
+                  )
+                )
+              )
+            );
+        }
+
+        @Test
+        void addWebFluxTestStarterIfAutoConfigureWebFluxIsUsedForTest() {
+            rewriteRun(
+              mavenProject("project",
+                //language=xml
+                pomXml(
+                  """
+                    <project>
+                        <modelVersion>4.0.0</modelVersion>
+                        <groupId>org.example</groupId>
+                        <artifactId>example</artifactId>
+                        <version>1.0-SNAPSHOT</version>
+                        <dependencies>
+                        </dependencies>
+                    </project>
+                    """,
+                  spec -> spec.after(pom -> assertThat(pom)
+                    .contains("<artifactId>spring-boot-starter-webflux-test</artifactId>")
+                    .contains("<scope>test</scope>")
+                    .containsPattern("<version>4\\.0\\.\\d+</version>")
+                    .actual())
+                ),
+                srcTestJava(
+                  //language=java
+                  java(
+                    """
+                      import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebFlux;
+
+                      @AutoConfigureWebFlux
+                      class GreetingIntegrationTest {
+                      }
+                      """,
+                    """
+                      import org.springframework.boot.webflux.test.autoconfigure.AutoConfigureWebFlux;
+
+                      @AutoConfigureWebFlux
+                      class GreetingIntegrationTest {
+                      }
+                      """
+                  )
+                )
+              )
+            );
+        }
+
+        @Test
+        void doesNotAddWebFluxTestStarterForAutoConfigureWebTestClientUsage() {
+            rewriteRun(
+              mavenProject("project",
+                //language=xml
+                pomXml(
+                  """
+                    <project>
+                        <modelVersion>4.0.0</modelVersion>
+                        <groupId>org.example</groupId>
+                        <artifactId>example</artifactId>
+                        <version>1.0-SNAPSHOT</version>
+                        <dependencies>
+                        </dependencies>
+                    </project>
+                    """
+                ),
+                srcTestJava(
+                  //language=java
+                  java(
+                    """
+                      import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
+
+                      @AutoConfigureWebTestClient
+                      class ApiIntegrationTest {
+                      }
+                      """,
+                    """
+                      import org.springframework.boot.webtestclient.autoconfigure.AutoConfigureWebTestClient;
+
+                      @AutoConfigureWebTestClient
+                      class ApiIntegrationTest {
+                      }
+                      """
+                  )
+                )
+              )
+            );
+        }
+
+        @Test
+        void migrateWebFluxTestSliceTypes() {
+            rewriteRun(
               //language=java
               java(
                 """
                   import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebFlux;
+                  import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTypeExcludeFilter;
 
                   @AutoConfigureWebFlux
                   class GreetingIntegrationTest {
+                      WebFluxTypeExcludeFilter filter;
                   }
                   """,
                 """
                   import org.springframework.boot.webflux.test.autoconfigure.AutoConfigureWebFlux;
+                  import org.springframework.boot.webflux.test.autoconfigure.WebFluxTypeExcludeFilter;
 
                   @AutoConfigureWebFlux
                   class GreetingIntegrationTest {
+                      WebFluxTypeExcludeFilter filter;
                   }
                   """
               )
-            )
-          )
-        );
-    }
-
-    @Test
-    void doesNotAddWebFluxTestStarterForAutoConfigureWebTestClientUsage() {
-        rewriteRun(
-          mavenProject("project",
-            //language=xml
-            pomXml(
-              """
-                <project>
-                    <modelVersion>4.0.0</modelVersion>
-                    <groupId>org.example</groupId>
-                    <artifactId>example</artifactId>
-                    <version>1.0-SNAPSHOT</version>
-                    <dependencies>
-                    </dependencies>
-                </project>
-                """
-            ),
-            srcTestJava(
-              //language=java
-              java(
-                """
-                  import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
-
-                  @AutoConfigureWebTestClient
-                  class ApiIntegrationTest {
-                  }
-                  """,
-                """
-                  import org.springframework.boot.webtestclient.autoconfigure.AutoConfigureWebTestClient;
-
-                  @AutoConfigureWebTestClient
-                  class ApiIntegrationTest {
-                  }
-                  """
-              )
-            )
-          )
-        );
-    }
-
-    @Test
-    void migrateWebFluxTestSliceTypes() {
-        rewriteRun(
-          //language=java
-          java(
-            """
-              import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebFlux;
-              import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTypeExcludeFilter;
-
-              @AutoConfigureWebFlux
-              class GreetingIntegrationTest {
-                  WebFluxTypeExcludeFilter filter;
-              }
-              """,
-            """
-              import org.springframework.boot.webflux.test.autoconfigure.AutoConfigureWebFlux;
-              import org.springframework.boot.webflux.test.autoconfigure.WebFluxTypeExcludeFilter;
-
-              @AutoConfigureWebFlux
-              class GreetingIntegrationTest {
-                  WebFluxTypeExcludeFilter filter;
-              }
-              """
-          )
-        );
+            );
+        }
     }
 
     @Nested

--- a/src/test/java/org/openrewrite/java/spring/boot4/MigrateToModularStartersTest.java
+++ b/src/test/java/org/openrewrite/java/spring/boot4/MigrateToModularStartersTest.java
@@ -333,6 +333,163 @@ class MigrateToModularStartersTest implements RewriteTest {
         );
     }
 
+    @Test
+    void addWebFluxTestStarterIfWebFluxTestIsUsedForTest() {
+        rewriteRun(
+          mavenProject("project",
+            //language=xml
+            pomXml(
+              """
+                <project>
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>org.example</groupId>
+                    <artifactId>example</artifactId>
+                    <version>1.0-SNAPSHOT</version>
+                    <dependencies>
+                    </dependencies>
+                </project>
+                """,
+              spec -> spec.after(pom -> assertThat(pom)
+                .contains("<artifactId>spring-boot-starter-webflux-test</artifactId>")
+                .contains("<scope>test</scope>")
+                .containsPattern("<version>4\\.0\\.\\d+</version>")
+                .actual())
+            ),
+            srcTestJava(
+              //language=java
+              java(
+                """
+                  import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest;
+
+                  @WebFluxTest
+                  class GreetingControllerTest {
+                  }
+                  """,
+                """
+                  import org.springframework.boot.webflux.test.autoconfigure.WebFluxTest;
+
+                  @WebFluxTest
+                  class GreetingControllerTest {
+                  }
+                  """
+              )
+            )
+          )
+        );
+    }
+
+    @Test
+    void addWebFluxTestStarterIfAutoConfigureWebFluxIsUsedForTest() {
+        rewriteRun(
+          mavenProject("project",
+            //language=xml
+            pomXml(
+              """
+                <project>
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>org.example</groupId>
+                    <artifactId>example</artifactId>
+                    <version>1.0-SNAPSHOT</version>
+                    <dependencies>
+                    </dependencies>
+                </project>
+                """,
+              spec -> spec.after(pom -> assertThat(pom)
+                .contains("<artifactId>spring-boot-starter-webflux-test</artifactId>")
+                .contains("<scope>test</scope>")
+                .containsPattern("<version>4\\.0\\.\\d+</version>")
+                .actual())
+            ),
+            srcTestJava(
+              //language=java
+              java(
+                """
+                  import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebFlux;
+
+                  @AutoConfigureWebFlux
+                  class GreetingIntegrationTest {
+                  }
+                  """,
+                """
+                  import org.springframework.boot.webflux.test.autoconfigure.AutoConfigureWebFlux;
+
+                  @AutoConfigureWebFlux
+                  class GreetingIntegrationTest {
+                  }
+                  """
+              )
+            )
+          )
+        );
+    }
+
+    @Test
+    void doesNotAddWebFluxTestStarterForAutoConfigureWebTestClientUsage() {
+        rewriteRun(
+          mavenProject("project",
+            //language=xml
+            pomXml(
+              """
+                <project>
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>org.example</groupId>
+                    <artifactId>example</artifactId>
+                    <version>1.0-SNAPSHOT</version>
+                    <dependencies>
+                    </dependencies>
+                </project>
+                """
+            ),
+            srcTestJava(
+              //language=java
+              java(
+                """
+                  import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
+
+                  @AutoConfigureWebTestClient
+                  class ApiIntegrationTest {
+                  }
+                  """,
+                """
+                  import org.springframework.boot.webtestclient.autoconfigure.AutoConfigureWebTestClient;
+
+                  @AutoConfigureWebTestClient
+                  class ApiIntegrationTest {
+                  }
+                  """
+              )
+            )
+          )
+        );
+    }
+
+    @Test
+    void migrateWebFluxTestSliceTypes() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebFlux;
+              import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTypeExcludeFilter;
+
+              @AutoConfigureWebFlux
+              class GreetingIntegrationTest {
+                  WebFluxTypeExcludeFilter filter;
+              }
+              """,
+            """
+              import org.springframework.boot.webflux.test.autoconfigure.AutoConfigureWebFlux;
+              import org.springframework.boot.webflux.test.autoconfigure.WebFluxTypeExcludeFilter;
+
+              @AutoConfigureWebFlux
+              class GreetingIntegrationTest {
+                  WebFluxTypeExcludeFilter filter;
+              }
+              """
+          )
+        );
+    }
+
     @Nested
     class MigrateActuateHealthPackage implements RewriteTest {
         @Override


### PR DESCRIPTION
## What's changed?
`MigrateToModularStarters` adds `org.springframework.boot:spring-boot-starter-webflux-test` (test scope) when SB3 test sources use `@WebFluxTest` or `@AutoConfigureWebFlux`, and `MigrateAutoconfigurePackages` relocates the slice types (`WebFluxTest`, `AutoConfigureWebFlux`, `WebFluxTypeExcludeFilter`) from `org.springframework.boot.test.autoconfigure.web.reactive` to `org.springframework.boot.webflux.test.autoconfigure`.

## What's your motivation?
Customer-reported: after the Spring Boot 4 migration, modules whose tests use `@WebFluxTest` fail to compile — the annotation keeps its SB3 FQN and the dedicated SB4 starter is never added. The servlet twin has both halves (`spring-boot-starter-webmvc-test` entries + the `test.autoconfigure.web.servlet` ChangePackage); the reactive slice had neither.

## Anything in particular you'd like reviewers to focus on?
- Type-by-type rather than `ChangePackage`: the SB3 package splits — its WebTestClient types move to `spring-boot-webtestclient` (the existing block right below).
- The gates are the two annotation FQNs, not the package, so MockMvc-backed `@AutoConfigureWebTestClient` users don't get `spring-boot-starter-webflux-test` (which aggregates `spring-boot-starter-webflux`). `doesNotAddWebFluxTestStarterForAutoConfigureWebTestClientUsage` guards this.
- `WebFluxTestContextBootstrapper` is package-private in SB3 → no ChangeType.

## Checklist
- [x] I've added unit tests to cover both positive and negative cases