### PR TITLE
Upgrade Spring Cloud Stream for Boot 2.7

### DIFF
--- a/src/main/resources/META-INF/rewrite/spring-boot-27.yml
+++ b/src/main/resources/META-INF/rewrite/spring-boot-27.yml
@@ -57,6 +57,12 @@ recipeList:
       groupId: org.springdoc
       artifactId: "*"
       newVersion: 1.8.x
+  # Upgrade Spring Cloud Stream to the release line compatible with Spring Boot 2.7.
+  - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
+      groupId: org.springframework.cloud
+      artifactId: spring-cloud-stream-dependencies
+      newVersion: 3.2.x
+      overrideManagedVersion: false
   # Use recommended replacements for deprecated APIs
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: org.springframework.boot.web.server.LocalServerPort

--- a/src/test/java/org/openrewrite/java/spring/boot2/SpringCloudStreamVersionUpgradeTest.java
+++ b/src/test/java/org/openrewrite/java/spring/boot2/SpringCloudStreamVersionUpgradeTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.spring.boot2;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.Issue;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.openrewrite.maven.Assertions.pomXml;
+
+class SpringCloudStreamVersionUpgradeTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipeFromResources("org.openrewrite.java.spring.boot2.UpgradeSpringBoot_2_7");
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite-spring/issues/672")
+    @Test
+    void upgradesSpringCloudStreamBom() {
+        rewriteRun(
+          pomXml(
+            """
+              <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <parent>
+                      <groupId>org.springframework.boot</groupId>
+                      <artifactId>spring-boot-starter-parent</artifactId>
+                      <version>1.5.2.RELEASE</version>
+                      <relativePath/>
+                  </parent>
+                  <groupId>com.example</groupId>
+                  <artifactId>demo</artifactId>
+                  <version>0.0.1-SNAPSHOT</version>
+                  <properties>
+                      <spring-cloud-stream.version>Fishtown.SR4</spring-cloud-stream.version>
+                  </properties>
+                  <dependencyManagement>
+                      <dependencies>
+                          <dependency>
+                              <groupId>org.springframework.cloud</groupId>
+                              <artifactId>spring-cloud-stream-dependencies</artifactId>
+                              <version>${spring-cloud-stream.version}</version>
+                              <type>pom</type>
+                              <scope>import</scope>
+                          </dependency>
+                      </dependencies>
+                  </dependencyManagement>
+              </project>
+              """,
+            spec -> spec.after(actual ->
+              assertThat(actual)
+                .containsPattern("<spring-cloud-stream.version>3\\.2\\.\\d+</spring-cloud-stream.version>")
+                .actual()
+            )
+          )
+        );
+    }
+
+    @Test
+    void doesNotDowngradeNewerSpringCloudStreamBom() {
+        rewriteRun(
+          pomXml(
+            """
+              <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>demo</artifactId>
+                  <version>0.0.1-SNAPSHOT</version>
+                  <dependencyManagement>
+                      <dependencies>
+                          <dependency>
+                              <groupId>org.springframework.cloud</groupId>
+                              <artifactId>spring-cloud-stream-dependencies</artifactId>
+                              <version>4.0.0</version>
+                              <type>pom</type>
+                              <scope>import</scope>
+                          </dependency>
+                      </dependencies>
+                  </dependencyManagement>
+              </project>
+              """
+          )
+        );
+    }
+}


### PR DESCRIPTION
## What's changed?

- Upgrades `spring-cloud-stream-dependencies` to the Spring Boot 2.7-compatible `3.2.x` release line.
- Adds positive and no-downgrade regression coverage for the Boot 1.5-to-2.7 migration.

## What's your motivation?

- Fixes #672. Spring Cloud Stream’s BOM was left at its legacy version after upgrading Spring Boot, causing runtime incompatibilities.

## Anything in particular you'd like reviewers to focus on?

Please confirm that `3.2.x` is the intended Spring Cloud Stream target for the Boot 2.7 migration.

## Have you considered any alternatives or workarounds?

A standalone recipe was unnecessary because this is a narrowly scoped dependency-management upgrade specific to the existing Boot 2.7 composite recipe.

## Any additional context

`recipes.csv` does not require an update because the existing recipe’s metadata did not change.

### Checklist

- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've run `./gradlew build` locally, and committed any resulting changes to `recipes.csv`
- [x] I've [formatted the lines I changed](https://github.com/openrewrite/.github/blob/main/CONTRIBUTING.md#code-style-and-formatting), without reformatting code I didn't touch