### PR TITLE
chore(ci): only raise Dependabot PRs for major action bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,10 +7,18 @@ updates:
       interval: daily
     commit-message:
       prefix: "chore(ci)"
-    # Workflows reference floating major tags, which already track minor and
-    # patch releases; only major bumps need a pull request.
+    # These are referenced by floating major tag, which their authors move
+    # forward as minor and patch releases ship, so only major bumps need a
+    # pull request. Actions not listed here keep the default behaviour; add an
+    # entry only once a workflow references one by floating major tag.
     ignore:
-      - dependency-name: "*"
+      - dependency-name: actions/checkout
+        update-types: ["version-update:semver-minor", "version-update:semver-patch"]
+      - dependency-name: actions/setup-java
+        update-types: ["version-update:semver-minor", "version-update:semver-patch"]
+      - dependency-name: gradle/actions
+        update-types: ["version-update:semver-minor", "version-update:semver-patch"]
+      - dependency-name: peter-evans/create-pull-request
         update-types: ["version-update:semver-minor", "version-update:semver-patch"]
   - package-ecosystem: gradle
     directory: /

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,11 @@ updates:
       interval: daily
     commit-message:
       prefix: "chore(ci)"
+    # Workflows reference floating major tags, which already track minor and
+    # patch releases; only major bumps need a pull request.
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-minor", "version-update:semver-patch"]
   - package-ecosystem: gradle
     directory: /
     schedule:


### PR DESCRIPTION
## What's changed?

Ignore `semver-minor` and `semver-patch` updates for the four actions this repo references by floating major tag, so Dependabot only opens PRs for major bumps on those.

## What's your motivation?

Every versioned action reference in this repo is a floating major tag:

```
.github/workflows/properties.yml:16  actions/checkout@v7
.github/workflows/properties.yml:17  actions/setup-java@v5
.github/workflows/properties.yml:21  gradle/actions/setup-gradle@v6
.github/workflows/properties.yml:32  peter-evans/create-pull-request@v8
.github/workflows/ci.yml:23          openrewrite/gh-automation/...@main
```

Each author moves that tag forward as minor and patch releases ship, so CI already tracks them without any change here — all four currently resolve to the latest release:

| action | `@vN` resolves to | latest release |
|---|---|---|
| `actions/checkout@v7` | `3d3c42e5` | v7.0.1 — same commit |
| `actions/setup-java@v5` | `b6effb05` | v5.7.0 — same commit |
| `gradle/actions@v6` | `9c971963` | v6.3.0 — same commit |
| `peter-evans/create-pull-request@v8` | `5f6978fa` | v8.1.1 — same commit |

When Dependabot proposes `@v6` -> `@v6.2.0` it converts a self-updating ref into a pin, which is the opposite of what we want. #1114 is a concrete example: `v6` already resolves to v6.3.0, so merging it would have *downgraded* `setup-gradle` to v6.2.0 and frozen it there until the next nag. Closed in favour of this.

Major bumps (`v6` -> `v7`) are the one thing a floating tag cannot pick up on its own, so those keep raising PRs.

## Anything in particular you'd like reviewers to focus on?

The ignore list enumerates the four actions rather than using `dependency-name: "*"`. A blanket rule would also silence minor and patch updates for a future action that does *not* maintain a moving major tag, and that failure mode is silent. With an explicit list, forgetting to add an entry just means a noisy PR — visible and easy to fix.

Worth noting "official GitHub actions" would have been the wrong axis to split on: `gradle/actions` and `peter-evans/create-pull-request` are third-party and both float correctly, while an `actions/*` wildcard would have excluded the one that prompted this.

Also note this is not a supply-chain tradeoff: nothing here is SHA-pinned today, so the churn was not buying us pinning guarantees either.

## Checklist

- [x] Config-only change; no recipes or tests affected