### PR TITLE
Automate recipes.csv generation instead of requiring a manual step

### DIFF
--- a/.github/workflows/recipes-csv.yml
+++ b/.github/workflows/recipes-csv.yml
@@ -1,0 +1,55 @@
+---
+name: Regenerate recipes.csv
+
+# What this does: after every merge to main, regenerates recipes.csv and commits
+# it straight back to main. Nobody has to run a command or open a PR for it.
+#
+# Why this can't just happen as part of the normal build: recipeCsvGenerate needs
+# the recipe jar to already be built (it scans the jar to find the recipes), but
+# the file it writes also gets packaged *into* that same jar. It can't be an
+# input and an output of the same build, so it has to be generated in a
+# follow-up step like this one, once main already has a jar to scan.
+#
+# Why a direct commit instead of a pull request: this workflow only ever runs
+# against main, never against someone else's branch, so there's no PR-review
+# safety concern. main also has no branch protection, and recipeCsvValidate
+# re-checks the regenerated file in this same job before anything is pushed, so
+# there's nothing left for a human to approve.
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+
+jobs:
+  update-recipes-csv:
+    runs-on: ubuntu-latest
+    # Don't react to the bot's own commit - it won't change anything, so the run
+    # would just be wasted, and it stops this workflow triggering itself forever.
+    if: github.repository_owner == 'openrewrite' && github.event.head_commit.author.name != 'github-actions[bot]'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+      - uses: gradle/actions/setup-gradle@v6
+
+      - name: Regenerate and validate recipes.csv
+        run: ./gradlew recipeCsvGenerate recipeCsvValidate
+
+      - name: Commit recipes.csv if it changed
+        run: |
+          if git diff --quiet -- src/main/resources/META-INF/rewrite/recipes.csv; then
+            echo "recipes.csv already up to date"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add src/main/resources/META-INF/rewrite/recipes.csv
+          git commit -m "[Auto] Regenerate recipes.csv"
+          git push

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -261,4 +261,11 @@ tasks {
     // against genuinely current content instead of whatever the contributor happened to commit.
     named("recipeCsvValidateCompleteness") { dependsOn("recipeCsvGenerate") }
     named("recipeCsvValidateContent") { dependsOn("recipeCsvGenerate") }
+
+    // recipeCsvGenerate rewrites recipes.csv, which both of these tasks also read as part of
+    // packaging/checking src/main/resources. Pulling recipeCsvGenerate into `check` (above) put
+    // it in the same build as these for the first time, and Gradle's task validation correctly
+    // flagged that nothing ordered them relative to it - so order them explicitly.
+    named("sourcesJar") { mustRunAfter("recipeCsvGenerate") }
+    named("licenseMain") { mustRunAfter("recipeCsvGenerate") }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -252,4 +252,13 @@ tasks {
         classpath = sourceSets.getByName("test").runtimeClasspath
         finalizedBy("licenseFormat")
     }
+
+    // recipeCsvValidate* only checks whatever recipes.csv already happens to be on disk, so a
+    // contributor who forgets to run `recipeCsvGenerate` locally only finds out from CI, and the
+    // fix lands as its own commit on their PR. Running generate first makes `check`/`build`
+    // self-healing: recipes.csv is always regenerated from the just-built jar before it's
+    // validated, so nobody has to remember the separate command, and validation always runs
+    // against genuinely current content instead of whatever the contributor happened to commit.
+    named("recipeCsvValidateCompleteness") { dependsOn("recipeCsvGenerate") }
+    named("recipeCsvValidateContent") { dependsOn("recipeCsvGenerate") }
 }


### PR DESCRIPTION
## Summary
- Contributors previously had to remember to run `recipeCsvGenerate` and commit the diff. Since every recipe change touched the same shared file, PRs regularly collided with each other on rebase.
- `recipeCsvValidateCompleteness`/`recipeCsvValidateContent` now depend on `recipeCsvGenerate`, so every `check`/`build` (locally and in CI) regenerates `recipes.csv` from the freshly built jar before validating it - no separate command, and validation always runs against genuinely current content rather than whatever a contributor happened to commit.
- `recipeCsvGenerate` needs the already-built jar to scan for recipes, so it can't run in the same pass that produces that jar - the committed file on `main` still lags by one merge. A new workflow (`.github/workflows/recipes-csv.yml`) closes that gap: on push to `main` it regenerates and re-validates, then commits the result straight to `main` - no PR, since `main` has no branch protection and the workflow never touches (untrusted) fork PR branches.
- Net effect: contributor branches no longer carry any diff against `recipes.csv`, so there's nothing left to conflict when rebasing onto a `main` whose copy has since moved.

## Test plan
- [ ] `./gradlew check --dry-run` confirms `recipeCsvGenerate` now runs ahead of `recipeCsvValidateCompleteness`/`recipeCsvValidateContent` in the task graph
- [ ] `recipes-csv.yml` YAML is well-formed
- [ ] First push to `main` after merge produces a `[Auto] Regenerate recipes.csv` bot commit if content changed