### PR TITLE
Re-enable the two tests disabled on CI

### DIFF
--- a/src/test/java/org/openrewrite/java/spring/ImplicitWebAnnotationNamesTest.java
+++ b/src/test/java/org/openrewrite/java/spring/ImplicitWebAnnotationNamesTest.java
@@ -230,7 +230,7 @@ class ImplicitWebAnnotationNamesTest implements RewriteTest {
             );
         }
 
-        @ExpectedToFail("Whitespaces in Kotlin around a TypeExpression are problematic see https://github.com/openrewrite/rewrite-kotlin/issues/477. Use a formatter to prevent these situations.")
+        @ExpectedToFail("Whitespaces in Kotlin around a TypeExpression are problematic see https://github.com/openrewrite/rewrite/issues/6613. Use a formatter to prevent these situations.")
         @Test
         void annotationNoWhitespaceBetweenAnnotationAndVariable() {
             //language=kotlin

--- a/src/test/java/org/openrewrite/java/spring/batch/MigrateJobBuilderFactoryTest.java
+++ b/src/test/java/org/openrewrite/java/spring/batch/MigrateJobBuilderFactoryTest.java
@@ -16,7 +16,6 @@
 package org.openrewrite.java.spring.batch;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.InMemoryExecutionContext;
 import org.openrewrite.java.JavaParser;
@@ -25,7 +24,6 @@ import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.java.Assertions.java;
 
-@DisabledIfEnvironmentVariable(named = "CI", matches = "true")
 class MigrateJobBuilderFactoryTest implements RewriteTest {
 
     @Override

--- a/src/test/java/org/openrewrite/java/spring/security6/oauth2/server/resource/OAuth2ResourceServerLambdaDslTest.java
+++ b/src/test/java/org/openrewrite/java/spring/security6/oauth2/server/resource/OAuth2ResourceServerLambdaDslTest.java
@@ -17,7 +17,6 @@ package org.openrewrite.java.spring.security6.oauth2.server.resource;
 
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
 import org.junitpioneer.jupiter.Issue;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.InMemoryExecutionContext;
@@ -29,7 +28,6 @@ import org.openrewrite.test.RewriteTest;
 import static org.openrewrite.java.Assertions.java;
 import static org.openrewrite.kotlin.Assertions.kotlin;
 
-@DisabledIfEnvironmentVariable(named = "CI", matches = "true")
 class OAuth2ResourceServerLambdaDslTest implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {


### PR DESCRIPTION
## What's changed

Two test classes have been silently skipped on every CI run for months, both via a class-level `@DisabledIfEnvironmentVariable(named = "CI", matches = "true")`. This removes both annotations — 10 tests that never ran on CI now do.

| Test | Disabled in | Tests restored |
|---|---|---|
| `MigrateJobBuilderFactoryTest` | 6ab65337 (Oct 2025) | 7 |
| `OAuth2ResourceServerLambdaDslTest` | 6e687c61 (Oct 2025) | 3 |

## Why they were disabled

Both have the same signature: type-attribution / missing-type errors that reproduced **only on CI**, first worked around by loosening `TypeValidation`, then by disabling outright.

- `MigrateJobBuilderFactoryTest` — b79dd477 "Ignore further missing types only seen in CI" (added `methodDeclarations(false)`, `identifiers(false)`), then 6ab65337 "over unexplained issues there specifically".
- `OAuth2ResourceServerLambdaDslTest` — 6e687c61 "due to failures there" on `advanced()` only, alongside `TypeValidation.all().identifiers(false)`. #916 later removed that loosening to enable real type checking, and widened the disable to the whole class.

## Why it's safe now

- The root cause was very likely identified and fixed by #1113:

> `TypeTable.load()` matches artifact names as a regex prefix against a static, JVM-wide map and returns the first hit, so any prefix matching more than one GAV resolves by hash and test execution order.

- That explains the CI-only symptom precisely: CI runs the full suite in a single JVM, so an ambiguous prefix can bind to a different GAV than it does in a local single-class run. #1113 pinned both files' prefixes but left the annotations behind:

- `MigrateJobBuilderFactoryTest` — `spring-batch-core-5.+` / `-infrastructure-5.+` → `5.2`
- `OAuth2ResourceServerLambdaDslTest` — previously the most ambiguous in the repo, with `"spring-beans"`, `"spring-context"`, `"spring-boot"`, `"spring-web"`, `"spring-core"` carrying **no version component at all** → now `spring-beans-5`, `spring-boot-2.7`, `spring-web-5.3`, `spring-security-*-5.8`

The `TypeValidation` loosening both were paired with is also gone
 - #1036
 - #916

## Verification

Full suite run locally with `CI=true`, reproducing the shared-JVM, full-suite execution order the annotations were avoiding:

```
BUILD SUCCESSFUL
tests=1313  failures=0  errors=0  skipped=11   (was 14)

MigrateJobBuilderFactoryTest:            tests="7" skipped="0" failures="0"
OAuth2ResourceServerLambdaDslTest:       tests="1" skipped="0" failures="0"
OAuth2ResourceServerLambdaDslTest$Kotlin: tests="2" skipped="0" failures="0"
```

Single-class runs would prove nothing here — the original failure was execution-order dependent, so only the full suite is a meaningful check. CI on this PR is the real confirmation.

## Also included

Repoints the one `@ExpectedToFail` in the repo (`ImplicitWebAnnotationNamesTest$Kotlin.annotationNoWhitespaceBetweenAnnotationAndVariable`) from rewrite-kotlin#477 to openrewrite/rewrite#6613. The old link had been untouched since Dec 2023 and its title only loosely matched; #6613 names it as the original issue, lives in the active monorepo, and directly describes the `TypeReferencePrefix` spacing problem that makes `@PathVariable("id")id: Long` migrate to `@PathVariableid: Long`. That test stays skipped — it's a real open bug, not a stale workaround.

## Not addressed

`MigrateJobBuilderFactoryTest`'s class-level `defaults()` still uses unpinned prefixes (`spring-batch-core-4.+`, `spring-beans-5.+`, `spring-core-5.+`, `spring-context-5.+`) — the same ambiguity class #1113 pinned elsewhere. It passes today; pinning these is the obvious follow-up if it ever flakes again.