### PR TITLE
Replace UNPROCESSABLE_ENTITY with UNPROCESSABLE_CONTENT in UpgradeSpr…

### DIFF
--- a/src/main/resources/META-INF/rewrite/spring-framework-70.yml
+++ b/src/main/resources/META-INF/rewrite/spring-framework-70.yml
@@ -27,6 +27,9 @@ recipeList:
       groupId: org.springframework
       artifactId: "*"
       newVersion: 7.0.x
+  - org.openrewrite.java.ReplaceConstantWithAnotherConstant:
+      existingFullyQualifiedConstantName: org.springframework.http.HttpStatus.UNPROCESSABLE_ENTITY
+      fullyQualifiedConstantName: org.springframework.http.HttpStatus.UNPROCESSABLE_CONTENT
   - org.openrewrite.java.testing.junit6.JUnit5to6Migration
   - org.openrewrite.java.jackson.UpgradeJackson_2_3
   - org.openrewrite.java.spring.kafka.UpgradeSpringKafka_4_0

--- a/src/test/java/org/openrewrite/java/spring/framework/UpgradeSpringFramework_7_0Test.java
+++ b/src/test/java/org/openrewrite/java/spring/framework/UpgradeSpringFramework_7_0Test.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.spring.framework;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.InMemoryExecutionContext;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+class UpgradeSpringFramework_7_0Test implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipeFromResources("org.openrewrite.java.spring.framework.UpgradeSpringFramework_7_0")
+          .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(), "spring-web-6.2"));
+    }
+
+    @Test
+    void replacesUnprocessableEntityStaticImport() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import static org.springframework.http.HttpStatus.UNPROCESSABLE_ENTITY;
+
+              class A {
+                  int status() {
+                      return UNPROCESSABLE_ENTITY.value();
+                  }
+              }
+              """,
+            """
+              import static org.springframework.http.HttpStatus.UNPROCESSABLE_CONTENT;
+
+              class A {
+                  int status() {
+                      return UNPROCESSABLE_CONTENT.value();
+                  }
+              }
+              """
+          )
+        );
+    }
+}


### PR DESCRIPTION
## What's changed?

Added a `ReplaceConstantWithAnotherConstant` migration to `UpgradeSpringFramework_7_0` that replaces:

`HttpStatus.UNPROCESSABLE_ENTITY` with `HttpStatus.UNPROCESSABLE_CONTENT`

Added regression coverage for static imports and their usages.

## What's your motivation?

Spring Framework 7.0 removes `UNPROCESSABLE_ENTITY`. Without this migration, projects upgraded by the recipe retain the old constant and fail to compile.

## Anything in particular you'd like reviewers to focus on?

Nope

## Anyone you would like to review specifically?

None.

## Have you considered any alternatives or workarounds?

## Any additional context