### PR TITLE
Preserve whitespace when removing Kotlin annotation arguments

### DIFF
--- a/src/main/java/org/openrewrite/java/spring/ImplicitWebAnnotationNames.java
+++ b/src/main/java/org/openrewrite/java/spring/ImplicitWebAnnotationNames.java
@@ -77,13 +77,12 @@ public class ImplicitWebAnnotationNames extends Recipe {
                                         varDecls.getTypeExpression().getPrefix().withWhitespace(" ")));
                     }
                     // Kotlin case: variable name follows annotation directly (e.g., @PathVariable id: Long)
-                    // Only add space if BOTH typeExpression has no whitespace AND variable has no whitespace
-                    // This avoids adding space when there's already whitespace somewhere
-                    else if (varDecls.getTypeExpression() == null && !varDecls.getVariables().isEmpty()) {
+                    else if (!varDecls.getVariables().isEmpty()) {
                         J.VariableDeclarations.NamedVariable firstVar = varDecls.getVariables().get(0);
-                        if (firstVar.getPrefix().getWhitespace().isEmpty()) {
+                        if (firstVar.getPrefix().getWhitespace().isEmpty() &&
+                                firstVar.getName().getPrefix().getWhitespace().isEmpty()) {
                             varDecls = varDecls.withVariables(ListUtils.mapFirst(varDecls.getVariables(),
-                                    v -> v.withPrefix(v.getPrefix().withWhitespace(" "))));
+                                    v -> v.withName(v.getName().withPrefix(v.getName().getPrefix().withWhitespace(" ")))));
                         }
                     }
                 }

--- a/src/test/java/org/openrewrite/java/spring/ImplicitWebAnnotationNamesTest.java
+++ b/src/test/java/org/openrewrite/java/spring/ImplicitWebAnnotationNamesTest.java
@@ -17,7 +17,6 @@ package org.openrewrite.java.spring;
 
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.junitpioneer.jupiter.ExpectedToFail;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.InMemoryExecutionContext;
 import org.openrewrite.Issue;
@@ -25,7 +24,6 @@ import org.openrewrite.java.JavaParser;
 import org.openrewrite.kotlin.KotlinParser;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
-import org.openrewrite.test.TypeValidation;
 
 import static org.openrewrite.java.Assertions.java;
 import static org.openrewrite.kotlin.Assertions.kotlin;
@@ -230,12 +228,10 @@ class ImplicitWebAnnotationNamesTest implements RewriteTest {
             );
         }
 
-        @ExpectedToFail("Whitespaces in Kotlin around a TypeExpression are problematic see https://github.com/openrewrite/rewrite/issues/6613. Use a formatter to prevent these situations.")
         @Test
         void annotationNoWhitespaceBetweenAnnotationAndVariable() {
             //language=kotlin
             rewriteRun(
-              spec -> spec.typeValidationOptions(TypeValidation.none()),
               kotlin(
                 """
                   import org.springframework.http.ResponseEntity


### PR DESCRIPTION
`ImplicitWebAnnotationNames` turned `@PathVariable("id")id: Long` into `@PathVariableid: Long` in Kotlin, because the Kotlin branch of `visitVariableDeclarations` was gated on a null type expression — never true for `id: Long` — and wrote the space to the `NamedVariable` prefix rather than the name identifier prefix, which is where the Kotlin LST actually stores it.

- This was previously attributed to https://github.com/openrewrite/rewrite/issues/6613; that issue is now closed by openrewrite/rewrite#8558, which normalizes type parameter bound colons but deliberately leaves variable declarations alone, so the failure here was ours rather than the parser's.

The `annotationNoWhitespaceBetweenAnnotationAndVariable` test drops `@ExpectedToFail` along with the `TypeValidation.none()` override it no longer needs.