### PR TITLE
Bump pinned Spring Boot parent to 4.0.8 in tests

### DIFF
--- a/src/test/java/org/openrewrite/java/spring/boot4/UpgradeSpringBoot_4_0Test.java
+++ b/src/test/java/org/openrewrite/java/spring/boot4/UpgradeSpringBoot_4_0Test.java
@@ -48,7 +48,7 @@ class UpgradeSpringBoot_4_0Test implements RewriteTest {
                     <parent>
                         <groupId>org.springframework.boot</groupId>
                         <artifactId>spring-boot-starter-parent</artifactId>
-                        <version>4.0.7</version>
+                        <version>4.0.8</version>
                         <relativePath/>
                     </parent>
                     <groupId>com.example</groupId>
@@ -72,7 +72,7 @@ class UpgradeSpringBoot_4_0Test implements RewriteTest {
                     <parent>
                         <groupId>org.springframework.boot</groupId>
                         <artifactId>spring-boot-starter-parent</artifactId>
-                        <version>4.0.7</version>
+                        <version>4.0.8</version>
                         <relativePath/>
                     </parent>
                     <groupId>com.example</groupId>

--- a/src/test/java/org/openrewrite/java/spring/data/UpgradeSpringDataMongoDb_5_0Test.java
+++ b/src/test/java/org/openrewrite/java/spring/data/UpgradeSpringDataMongoDb_5_0Test.java
@@ -203,7 +203,7 @@ class UpgradeSpringDataMongoDb_5_0Test implements RewriteTest {
                     <parent>
                         <groupId>org.springframework.boot</groupId>
                         <artifactId>spring-boot-starter-parent</artifactId>
-                        <version>4.0.7</version>
+                        <version>4.0.8</version>
                     </parent>
                     <groupId>com.example</groupId>
                     <artifactId>example</artifactId>
@@ -237,7 +237,7 @@ class UpgradeSpringDataMongoDb_5_0Test implements RewriteTest {
                     <parent>
                         <groupId>org.springframework.boot</groupId>
                         <artifactId>spring-boot-starter-parent</artifactId>
-                        <version>4.0.7</version>
+                        <version>4.0.8</version>
                     </parent>
                     <groupId>com.example</groupId>
                     <artifactId>example</artifactId>
@@ -262,7 +262,7 @@ class UpgradeSpringDataMongoDb_5_0Test implements RewriteTest {
                     <parent>
                         <groupId>org.springframework.boot</groupId>
                         <artifactId>spring-boot-starter-parent</artifactId>
-                        <version>4.0.7</version>
+                        <version>4.0.8</version>
                     </parent>
                     <groupId>com.example</groupId>
                     <artifactId>example</artifactId>
@@ -366,7 +366,7 @@ class UpgradeSpringDataMongoDb_5_0Test implements RewriteTest {
                     <parent>
                         <groupId>org.springframework.boot</groupId>
                         <artifactId>spring-boot-starter-parent</artifactId>
-                        <version>4.0.7</version>
+                        <version>4.0.8</version>
                     </parent>
                     <groupId>com.example</groupId>
                     <artifactId>example</artifactId>


### PR DESCRIPTION
`UpgradeSpringBoot_4_0Test.removeRedundantVersionAlreadyOnBoot4` and `UpgradeSpringDataMongoDb_5_0Test.removesOverridesThatBecomeRedundantWithBootManagement` started failing on every PR after Spring Boot 4.0.8 was published to Maven Central today at 12:51 GMT — the first now upgrades past the pinned 4.0.7, and the second no longer sees the `spring-data-mongodb` override as redundant against Boot's managed version.

This bumps the pinned parent from 4.0.7 to 4.0.8 across both test classes to get CI green again. It will rot at the next Boot patch release; making these assertions version-agnostic would be the durable fix, but that is a larger change than unblocking `main` warrants right now.