### PR TITLE
Add space after comma when inlining JdbcTemplate array initializer args

### DIFF
--- a/src/main/java/org/openrewrite/java/spring/framework/JdbcTemplateObjectArrayArgToVarArgs.java
+++ b/src/main/java/org/openrewrite/java/spring/framework/JdbcTemplateObjectArrayArgToVarArgs.java
@@ -21,12 +21,14 @@ import org.openrewrite.ExecutionContext;
 import org.openrewrite.Preconditions;
 import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
+import org.openrewrite.internal.ListUtils;
 import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.MethodMatcher;
 import org.openrewrite.java.search.UsesType;
 import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaType;
+import org.openrewrite.java.tree.Space;
 import org.openrewrite.java.tree.TypeUtils;
 
 import java.util.ArrayList;
@@ -63,17 +65,12 @@ public class JdbcTemplateObjectArrayArgToVarArgs extends Recipe {
                     newArgs.add(sql);
                     newArgs.add(rowMapper.withPrefix(arr.getPrefix()));
 
-                    if (arr instanceof J.NewArray) {
-                        J.NewArray newArray = (J.NewArray) arr;
-                        if (newArray.getInitializer() != null) {
-                            newArgs.addAll(newArray.getInitializer());
-                        } else {
-                            newArgs.add(arr);
-                        }
+                    if (arr instanceof J.NewArray && ((J.NewArray) arr).getInitializer() != null) {
+                        newArgs.addAll(ListUtils.mapFirst(((J.NewArray) arr).getInitializer(),
+                                first -> first.getPrefix().getWhitespace().isEmpty() ? first.withPrefix(Space.SINGLE_SPACE) : first));
                     } else {
                         newArgs.add(arr);
                     }
-
 
                     mi = mi.withArguments(newArgs);
                 }

--- a/src/test/java/org/openrewrite/java/spring/framework/JdbcTemplateObjectArrayArgToVarArgsTest.java
+++ b/src/test/java/org/openrewrite/java/spring/framework/JdbcTemplateObjectArrayArgToVarArgsTest.java
@@ -356,6 +356,10 @@ class JdbcTemplateObjectArrayArgToVarArgsTest implements RewriteTest {
                   User getUser(String first, String last) {
                       return jdbcTemplate.queryForObject("select NAME, AGE from USER where FIRST = ? && LAST = ?", new Object[]{ first, last }, User.class);
                   }
+
+                  User getUserWithoutSpaces(String first, String last) {
+                      return jdbcTemplate.queryForObject("select NAME, AGE from USER where FIRST = ? && LAST = ?", new Object[]{first, last}, User.class);
+                  }
               }
               """,
             """
@@ -366,6 +370,10 @@ class JdbcTemplateObjectArrayArgToVarArgsTest implements RewriteTest {
                   JdbcTemplate jdbcTemplate;
 
                   User getUser(String first, String last) {
+                      return jdbcTemplate.queryForObject("select NAME, AGE from USER where FIRST = ? && LAST = ?", User.class, first, last);
+                  }
+
+                  User getUserWithoutSpaces(String first, String last) {
                       return jdbcTemplate.queryForObject("select NAME, AGE from USER where FIRST = ? && LAST = ?", User.class, first, last);
                   }
               }


### PR DESCRIPTION
`JdbcTemplateObjectArrayArgToVarArgs` inlines `new Object[]{...}` initializers into varargs, but kept the first element's original prefix, so `new Object[]{first, last}` produced `..., User.class,first, last)` with no space after the comma.

The first inlined element now gets a single-space prefix when it has no leading whitespace; elements already prefixed with whitespace (including newlines in multi-line arrays) are untouched. The surrounding branch was also simplified to a single `ListUtils.mapFirst` call, and the existing `inlineArrayInitializerValues` test covers the no-space form.