### PR TITLE
Assert Spring Boot 4 pom results with patterns instead of pinned versions

### DIFF
--- a/src/test/java/org/openrewrite/java/spring/boot4/UpgradeSpringBoot_4_0Test.java
+++ b/src/test/java/org/openrewrite/java/spring/boot4/UpgradeSpringBoot_4_0Test.java
@@ -66,26 +66,15 @@ class UpgradeSpringBoot_4_0Test implements RewriteTest {
                     </dependencies>
                 </project>
                 """,
-              """
-                <project>
-                    <modelVersion>4.0.0</modelVersion>
-                    <parent>
-                        <groupId>org.springframework.boot</groupId>
-                        <artifactId>spring-boot-starter-parent</artifactId>
-                        <version>4.0.8</version>
-                        <relativePath/>
-                    </parent>
-                    <groupId>com.example</groupId>
-                    <artifactId>redundant-version-app</artifactId>
-                    <version>1.0-SNAPSHOT</version>
-                    <dependencies>
-                        <dependency>
-                            <groupId>org.apache.commons</groupId>
-                            <artifactId>commons-lang3</artifactId>
-                        </dependency>
-                    </dependencies>
-                </project>
-                """
+              spec -> spec.after(actual -> assertThat(actual)
+                .describedAs("The Spring Boot parent should remain on the latest 4.0.x patch release")
+                .containsPattern("<artifactId>spring-boot-starter-parent</artifactId>\\s*<version>4\\.0\\.\\d+</version>")
+                .describedAs("A commons-lang3 override older than the Boot 4 managed version should be removed, " +
+                             "leaving the dependency versionless")
+                .containsPattern("<artifactId>commons-lang3</artifactId>\\s*</dependency>")
+                .describedAs("The now-unused version property should also be removed")
+                .doesNotContain("commons-lang3-override.version")
+                .actual())
             )
           )
         );

--- a/src/test/java/org/openrewrite/java/spring/data/UpgradeSpringDataMongoDb_5_0Test.java
+++ b/src/test/java/org/openrewrite/java/spring/data/UpgradeSpringDataMongoDb_5_0Test.java
@@ -256,29 +256,14 @@ class UpgradeSpringDataMongoDb_5_0Test implements RewriteTest {
                     </dependencies>
                 </project>
                 """,
-              """
-                <project>
-                    <modelVersion>4.0.0</modelVersion>
-                    <parent>
-                        <groupId>org.springframework.boot</groupId>
-                        <artifactId>spring-boot-starter-parent</artifactId>
-                        <version>4.0.8</version>
-                    </parent>
-                    <groupId>com.example</groupId>
-                    <artifactId>example</artifactId>
-                    <version>1.0.0</version>
-                    <dependencies>
-                        <dependency>
-                            <groupId>org.springframework.data</groupId>
-                            <artifactId>spring-data-mongodb</artifactId>
-                        </dependency>
-                        <dependency>
-                            <groupId>org.mongodb</groupId>
-                            <artifactId>mongodb-driver-sync</artifactId>
-                        </dependency>
-                    </dependencies>
-                </project>
-                """
+              spec -> spec.after(actual -> assertThat(actual)
+                .describedAs("The Spring Boot parent should be left alone")
+                .containsPattern("<artifactId>spring-boot-starter-parent</artifactId>\\s*<version>4\\.0\\.\\d+</version>")
+                .describedAs("Boot 3 era overrides should give way to Boot's management, or align with Spring Data MongoDB 5.0 " +
+                             "when Boot manages an older patch release than the recipe targets")
+                .containsPattern("<artifactId>spring-data-mongodb</artifactId>\\s*(<version>5\\.0\\.\\d+</version>\\s*)?</dependency>")
+                .containsPattern("<artifactId>mongodb-driver-sync</artifactId>\\s*(<version>5\\.\\d+\\.\\d+</version>\\s*)?</dependency>")
+                .actual())
             ),
             java("class Application {}")
           )


### PR DESCRIPTION
- Follow-up to #1136, which bumped a pinned parent to get CI green and noted that making the assertions version-agnostic would be the durable fix.

Both `UpgradeSpringBoot_4_0Test.removeRedundantVersionAlreadyOnBoot4` and `UpgradeSpringDataMongoDb_5_0Test.removesOverridesThatBecomeRedundantWithBootManagement` spelled out the resulting pom as a literal string, which pins whatever a dynamic version happened to resolve to; the Boot test therefore rots on every 4.0.x patch release. The Spring Data MongoDB test is worse: the recipe resolves `spring-data-mongodb` to the latest `5.0.x`, so whenever Spring Data publishes ahead of Boot the override is upgraded in place rather than removed as redundant, and no choice of pinned parent avoids that — hence its assertion deliberately accepts either a versionless dependency or a 5.x version, while still failing if a stale 4.x override survives.

Both tests now assert the resulting pom with AssertJ patterns, matching the style already used by the other tests in these classes; the `before` poms keep their pinned parents since those are inputs and never rot.

Note that `removeRedundantVersionAlreadyOnBoot4` is the `@DocumentExample` for `UpgradeSpringBoot_4_0`, and the examples extractor only records literal `after` strings, so the next `examples.yml` regeneration will drop the `after` from the published example (as is already the case for the Spring Data MongoDB recipe). Happy to add a version-stable example test and move `@DocumentExample` onto it if that tradeoff isn't worth it.